### PR TITLE
feat: 添加 QuickPick 快速命令面板功能

### DIFF
--- a/PingIsland/App/AppDelegate.swift
+++ b/PingIsland/App/AppDelegate.swift
@@ -5,6 +5,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private var windowManager: WindowManager?
     private var screenObserver: ScreenObserver?
     private let launchConfiguration = AppLaunchConfiguration()
+    private var quickPickService: QuickPickService?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         if launchConfiguration.shouldEnforceSingleInstance && !ensureSingleInstance() {
@@ -32,6 +33,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             screenObserver = ScreenObserver { [weak self] in
                 self?.handleScreenChange()
             }
+        }
+
+        // 初始化 QuickPick 服务
+        if launchConfiguration.shouldEnableQuickPick {
+            quickPickService = QuickPickService.shared
         }
 
         if launchConfiguration.shouldPresentSettingsWindowOnLaunch {

--- a/PingIsland/App/AppLaunchConfiguration.swift
+++ b/PingIsland/App/AppLaunchConfiguration.swift
@@ -9,6 +9,7 @@ struct AppLaunchConfiguration: Equatable {
     let shouldObserveScreens: Bool
     let shouldEnforceSingleInstance: Bool
     let shouldPresentSettingsWindowOnLaunch: Bool
+    let shouldEnableQuickPick: Bool
     let activationPolicy: NSApplication.ActivationPolicy
 
     init(environment: [String: String] = Foundation.ProcessInfo.processInfo.environment) {
@@ -24,6 +25,7 @@ struct AppLaunchConfiguration: Equatable {
         self.shouldObserveScreens = !isRunningTests
         self.shouldEnforceSingleInstance = !isRunningTests
         self.shouldPresentSettingsWindowOnLaunch = isUITesting || shouldShowSettings
+        self.shouldEnableQuickPick = !isRunningTests
         self.activationPolicy = isUITesting ? .regular : .accessory
     }
 }

--- a/PingIsland/Services/QuickPick/CommandModels.swift
+++ b/PingIsland/Services/QuickPick/CommandModels.swift
@@ -1,0 +1,116 @@
+import Foundation
+import AppKit
+
+/// QuickPick 命令项模型
+struct QuickPickCommand: Identifiable, Hashable {
+    let id = UUID()
+    let name: String
+    let command: String
+    let icon: String
+    let description: String
+    
+    static let defaultCommands: [QuickPickCommand] = [
+        QuickPickCommand(
+            name: "Claude Code",
+            command: "claude code",
+            icon: "brain",
+            description: "启动 Claude Code 对话"
+        ),
+        QuickPickCommand(
+            name: "Codex",
+            command: "codex",
+            icon: "terminal",
+            description: "启动 Codex CLI"
+        ),
+        QuickPickCommand(
+            name: "Qoder",
+            command: "qodercli",
+            icon: "hammer",
+            description: "启动 Qoder CLI"
+        ),
+        QuickPickCommand(
+            name: "VS Code",
+            command: "code .",
+            icon: "chevron.left.forwardslash.chevron.right",
+            description: "在 VS Code 中打开"
+        ),
+    ]
+}
+
+/// QuickPick 目录项模型
+struct QuickPickDirectory: Identifiable, Hashable {
+    let id = UUID()
+    let path: String
+    let name: String
+    
+    var displayName: String {
+        (path as NSString).lastPathComponent
+    }
+    
+    var parentPath: String {
+        (path as NSString).deletingLastPathComponent
+    }
+}
+
+/// 命令执行服务
+final class CommandExecutor {
+    static let shared = CommandExecutor()
+    
+    private init() {}
+    
+    /// 在指定目录执行命令
+    func execute(_ command: String, in directory: String, completion: @escaping (Bool) -> Void) {
+        // 构建完整的 shell 命令
+        let fullCommand = "cd '\(directory)' && \(command) > /dev/null 2>&1 &"
+        
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        process.arguments = ["-c", fullCommand]
+        
+        do {
+            try process.run()
+            process.waitUntilExit()
+            completion(process.terminationStatus == 0)
+        } catch {
+            print("Command execution failed: \(error)")
+            completion(false)
+        }
+    }
+    
+    /// 使用 iTerm2 打开终端并执行命令
+    func executeInTerminal(_ command: String, in directory: String) {
+        let script = """
+        tell application "iTerm2"
+            activate
+            create window with default profile
+            tell current session of current window
+                write text "cd '\(directory)'"
+                write text "\(command)"
+            end tell
+        end tell
+        """
+        
+        var error: NSDictionary?
+        if let appleScript = NSAppleScript(source: script) {
+            appleScript.executeAndReturnError(&error)
+            if let error = error {
+                print("AppleScript error: \(error)")
+            }
+        }
+    }
+    
+    /// 使用系统终端执行命令
+    func executeInSystemTerminal(_ command: String, in directory: String) {
+        let script = """
+        tell application "Terminal"
+            activate
+            do script "cd '\(directory)' && \(command)"
+        end tell
+        """
+        
+        var error: NSDictionary?
+        if let appleScript = NSAppleScript(source: script) {
+            appleScript.executeAndReturnError(&error)
+        }
+    }
+}

--- a/PingIsland/Services/QuickPick/DirectoryDetector.swift
+++ b/PingIsland/Services/QuickPick/DirectoryDetector.swift
@@ -1,0 +1,142 @@
+import Foundation
+import AppKit
+
+/// 检测用户当前工作目录的优先级：
+/// 1. 前台终端 (iTerm2/Terminal) 当前目录
+/// 2. Finder 窗口当前路径
+/// 3. 最近访问的目录
+/// 4. 默认桌面目录
+final class DirectoryDetector {
+    static let shared = DirectoryDetector()
+    
+    private let fileManager = FileManager.default
+    
+    private init() {}
+    
+    /// 获取当前工作目录
+    func detectCurrentDirectory() -> String {
+        // 1. 优先检测前台终端
+        if let terminalDir = detectTerminalDirectory() {
+            return terminalDir
+        }
+        
+        // 2. 检测 Finder 窗口
+        if let finderDir = detectFinderDirectory() {
+            return finderDir
+        }
+        
+        // 3. 回退到桌面
+        return NSHomeDirectory() + "/Desktop"
+    }
+    
+    /// 检测前台终端的当前目录
+    private func detectTerminalDirectory() -> String? {
+        // 先尝试 iTerm2
+        if let itermDir = getITermDirectory() {
+            return itermDir
+        }
+        
+        // 再尝试 Terminal
+        if let terminalDir = getTerminalDirectory() {
+            return terminalDir
+        }
+        
+        return nil
+    }
+    
+    private func getITermDirectory() -> String? {
+        let script = """
+        tell application "iTerm2"
+            activate
+            if (count of windows) > 0 then
+                tell current session of current window
+                    return pwd
+                end tell
+            end if
+        end tell
+        """
+        
+        var error: NSDictionary?
+        if let appleScript = NSAppleScript(source: script) {
+            let result = appleScript.executeAndReturnError(&error)
+            if error == nil {
+                return result.stringValue
+            }
+        }
+        return nil
+    }
+    
+    private func getTerminalDirectory() -> String? {
+        let script = """
+        tell application "Terminal"
+            if (count of windows) > 0 then
+                return do shell script "pwd"
+            end if
+        end tell
+        """
+        
+        var error: NSDictionary?
+        if let appleScript = NSAppleScript(source: script) {
+            let result = appleScript.executeAndReturnError(&error)
+            if error == nil {
+                return result.stringValue
+            }
+        }
+        return nil
+    }
+    
+    /// 检测 Finder 当前窗口路径
+    private func detectFinderDirectory() -> String? {
+        let script = """
+        tell application "Finder"
+            if (count of windows) > 0 then
+                return POSIX path of (target of front window as alias)
+            end if
+        end tell
+        """
+        
+        var error: NSDictionary?
+        if let appleScript = NSAppleScript(source: script) {
+            let result = appleScript.executeAndReturnError(&error)
+            if error == nil, let path = result.stringValue, !path.isEmpty {
+                return path
+            }
+        }
+        return nil
+    }
+    
+    /// 扫描常见项目目录
+    func scanProjectDirectories() -> [String] {
+        let projectRoots = [
+            NSHomeDirectory() + "/code",
+            NSHomeDirectory() + "/projects",
+            NSHomeDirectory() + "/workspace",
+            NSHomeDirectory() + "/Develop",
+            NSHomeDirectory() + "/island",
+        ]
+        
+        var directories: [String] = []
+        
+        for root in projectRoots {
+            if fileManager.fileExists(atPath: root) {
+                do {
+                    let contents = try fileManager.contentsOfDirectory(atPath: root)
+                    for item in contents {
+                        let fullPath = (root as NSString).appendingPathComponent(item)
+                        var isDirectory: ObjCBool = false
+                        if fileManager.fileExists(atPath: fullPath, isDirectory: &isDirectory), isDirectory.boolValue {
+                            // 跳过隐藏目录
+                            if !item.hasPrefix(".") {
+                                directories.append(fullPath)
+                            }
+                        }
+                    }
+                } catch {
+                    continue
+                }
+            }
+        }
+        
+        return directories.sorted()
+    }
+}

--- a/PingIsland/Services/QuickPick/GlobalHotkeyManager.swift
+++ b/PingIsland/Services/QuickPick/GlobalHotkeyManager.swift
@@ -1,0 +1,83 @@
+import Foundation
+import AppKit
+import Carbon.HIToolbox
+
+/// 全局快捷键管理器
+final class GlobalHotkeyManager {
+    static let shared = GlobalHotkeyManager()
+    
+    private var eventMonitor: Any?
+    private var flagsMonitor: Any?
+    private var lastModifierCheck: Date = Date()
+    private var doubleTapTimer: Timer?
+    private var lastTapTime: Date?
+    private let doubleTapInterval: TimeInterval = 0.3
+    
+    var onHotkeyPressed: (() -> Void)?
+    var onDoubleModifierPressed: (() -> Void)?
+    
+    private init() {}
+    
+    /// 启动全局快捷键监听
+    func start() {
+        // 监听 ⌘+空格
+        eventMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            self?.handleKeyEvent(event)
+        }
+        
+        // 监听修饰键双击 (双击 Command 呼出)
+        flagsMonitor = NSEvent.addGlobalMonitorForEvents(matching: .flagsChanged) { [weak self] event in
+            self?.handleFlagsChanged(event)
+        }
+    }
+    
+    /// 停止监听
+    func stop() {
+        if let monitor = eventMonitor {
+            NSEvent.removeMonitor(monitor)
+            eventMonitor = nil
+        }
+        if let monitor = flagsMonitor {
+            NSEvent.removeMonitor(monitor)
+            flagsMonitor = nil
+        }
+        doubleTapTimer?.invalidate()
+        doubleTapTimer = nil
+    }
+    
+    private func handleKeyEvent(_ event: NSEvent) {
+        // 检测 ⌘+空格
+        let commandPressed = event.modifierFlags.contains(.command)
+        let spacePressed = event.keyCode == 49 // 空格键
+        
+        if commandPressed && spacePressed {
+            DispatchQueue.main.async { [weak self] in
+                self?.onHotkeyPressed?()
+            }
+        }
+    }
+    
+    private func handleFlagsChanged(_ event: NSEvent) {
+        let currentTime = Date()
+        
+        // 检测双击修饰键 (Command)
+        if event.modifierFlags.contains(.command) && !event.modifierFlags.contains(.shift) && !event.modifierFlags.contains(.option) && !event.modifierFlags.contains(.control) {
+            if let lastTime = lastTapTime {
+                let interval = currentTime.timeIntervalSince(lastTime)
+                if interval < doubleTapInterval && interval > 0 {
+                    // 双击检测到
+                    DispatchQueue.main.async { [weak self] in
+                        self?.onDoubleModifierPressed?()
+                    }
+                    lastTapTime = nil
+                    return
+                }
+            }
+            lastTapTime = currentTime
+        }
+    }
+    
+    deinit {
+        stop()
+    }
+}

--- a/PingIsland/Services/QuickPick/QuickPickService.swift
+++ b/PingIsland/Services/QuickPick/QuickPickService.swift
@@ -1,0 +1,195 @@
+import Foundation
+import AppKit
+import SwiftUI
+import Combine
+
+/// QuickPick 主服务
+final class QuickPickService: NSObject, ObservableObject {
+    static let shared = QuickPickService()
+    
+    @Published var isVisible = false
+    @Published var searchText = ""
+    @Published var selectedIndex = 0
+    @Published var currentDirectory: String
+    @Published var availableDirectories: [QuickPickDirectory] = []
+    
+    private var panel: NSPanel?
+    private var hostingView: NSHostingView<QuickPickView>?
+    private let hotkeyManager = GlobalHotkeyManager.shared
+    private let directoryDetector = DirectoryDetector.shared
+    
+    private var filteredCommands: [QuickPickCommand] = QuickPickCommand.defaultCommands
+    
+    var onCommandSelected: ((QuickPickCommand) -> Void)?
+    
+    private override init() {
+        currentDirectory = DirectoryDetector.shared.detectCurrentDirectory()
+        super.init()
+        loadDirectories()
+        setupPanel()
+        setupHotkey()
+    }
+    
+    /// 加载可用目录
+    private func loadDirectories() {
+        let projectDirs = directoryDetector.scanProjectDirectories()
+        availableDirectories = projectDirs.map { QuickPickDirectory(path: $0, name: ($0 as NSString).lastPathComponent) }
+        
+        // 添加当前目录到列表开头（如果不在列表中）
+        let currentDirName = (currentDirectory as NSString).lastPathComponent
+        if !availableDirectories.contains(where: { $0.path == currentDirectory }) {
+            availableDirectories.insert(QuickPickDirectory(path: currentDirectory, name: currentDirName), at: 0)
+        }
+    }
+    
+    /// 设置浮动面板
+    private func setupPanel() {
+        let contentRect = NSRect(x: 0, y: 0, width: 600, height: 60)
+        
+        panel = NSPanel(
+            contentRect: contentRect,
+            styleMask: [.nonactivatingPanel, .titled, .fullSizeContentView, .borderless],
+            backing: .buffered,
+            defer: false
+        )
+        
+        guard let panel = panel else { return }
+        
+        panel.level = .floating
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = true
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        panel.isMovableByWindowBackground = false
+        panel.hidesOnDeactivate = false
+        
+        let quickPickView = QuickPickView(service: self)
+        hostingView = NSHostingView(rootView: quickPickView)
+        hostingView?.frame = panel.contentView?.bounds ?? .zero
+        panel.contentView = hostingView
+        
+        panel.delegate = self
+    }
+    
+    /// 设置全局快捷键
+    private func setupHotkey() {
+        hotkeyManager.onHotkeyPressed = { [weak self] in
+            self?.toggle()
+        }
+        
+        hotkeyManager.onDoubleModifierPressed = { [weak self] in
+            self?.toggle()
+        }
+        
+        hotkeyManager.start()
+    }
+    
+    /// 切换显示状态
+    func toggle() {
+        if isVisible {
+            hide()
+        } else {
+            show()
+        }
+    }
+    
+    /// 显示面板
+    func show() {
+        // 刷新目录
+        currentDirectory = directoryDetector.detectCurrentDirectory()
+        loadDirectories()
+        
+        // 重置状态
+        searchText = ""
+        selectedIndex = 0
+        
+        // 显示面板在屏幕中央
+        if let screen = NSScreen.main {
+            let screenFrame = screen.visibleFrame
+            let panelWidth: CGFloat = 600
+            let panelHeight: CGFloat = 60
+            
+            let x = screenFrame.midX - panelWidth / 2
+            let y = screenFrame.maxY - panelHeight - 50 // 顶部间距
+            
+            panel?.setFrame(NSRect(x: x, y: y, width: panelWidth, height: panelHeight), display: true)
+        }
+        
+        panel?.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+        
+        isVisible = true
+    }
+    
+    /// 隐藏面板
+    func hide() {
+        panel?.orderOut(nil)
+        isVisible = false
+    }
+    
+    /// 刷新当前目录
+    func refreshDirectory() {
+        currentDirectory = directoryDetector.detectCurrentDirectory()
+        loadDirectories()
+    }
+    
+    /// 执行选中命令
+    func executeSelected() {
+        let commands = getFilteredCommands()
+        guard selectedIndex < commands.count else { return }
+        
+        let command = commands[selectedIndex]
+        onCommandSelected?(command)
+        
+        // 执行命令
+        CommandExecutor.shared.executeInTerminal(command.command, in: currentDirectory)
+        
+        hide()
+    }
+    
+    /// 切换到指定目录
+    func selectDirectory(_ directory: QuickPickDirectory) {
+        currentDirectory = directory.path
+    }
+    
+    /// 获取过滤后的命令列表
+    func getFilteredCommands() -> [QuickPickCommand] {
+        guard !searchText.isEmpty else {
+            return QuickPickCommand.defaultCommands
+        }
+        
+        let lowercased = searchText.lowercased()
+        return QuickPickCommand.defaultCommands.filter { command in
+            command.name.lowercased().contains(lowercased) ||
+            command.command.lowercased().contains(lowercased)
+        }
+    }
+    
+    /// 向上选择
+    func selectPrevious() {
+        let commands = getFilteredCommands()
+        if selectedIndex > 0 {
+            selectedIndex -= 1
+        } else {
+            selectedIndex = commands.count - 1
+        }
+    }
+    
+    /// 向下选择
+    func selectNext() {
+        let commands = getFilteredCommands()
+        if selectedIndex < commands.count - 1 {
+            selectedIndex += 1
+        } else {
+            selectedIndex = 0
+        }
+    }
+}
+
+// MARK: - NSWindowDelegate
+extension QuickPickService: NSWindowDelegate {
+    func windowDidResignKey(_ notification: Notification) {
+        // 点击外部时隐藏
+        hide()
+    }
+}

--- a/PingIsland/UI/QuickPick/QuickPickKeyHandler.swift
+++ b/PingIsland/UI/QuickPick/QuickPickKeyHandler.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+import AppKit
+import Combine
+
+/// 键盘事件处理器
+struct KeyboardEventHandler: NSViewRepresentable {
+    @ObservedObject var service: QuickPickService
+    
+    func makeNSView(context: Context) -> KeyboardEventNSView {
+        let view = KeyboardEventNSView()
+        view.service = service
+        return view
+    }
+    
+    func updateNSView(_ nsView: KeyboardEventNSView, context: Context) {
+        nsView.service = service
+    }
+}
+
+class KeyboardEventNSView: NSView {
+    weak var service: QuickPickService?
+    
+    override var acceptsFirstResponder: Bool { true }
+    
+    override func keyDown(with event: NSEvent) {
+        guard let service = service else {
+            super.keyDown(with: event)
+            return
+        }
+        
+        switch event.keyCode {
+        case 126: // Up
+            service.selectPrevious()
+        case 125: // Down
+            service.selectNext()
+        case 36: // Return
+            service.executeSelected()
+        case 53: // Escape
+            service.hide()
+        default:
+            // 检测 ⌘+K 切换目录
+            if event.modifierFlags.contains(.command) && event.charactersIgnoringModifiers == "k" {
+                service.refreshDirectory()
+            } else {
+                super.keyDown(with: event)
+            }
+        }
+    }
+}
+
+#Preview {
+    QuickPickView(service: QuickPickService.shared)
+        .frame(width: 600, height: 60)
+}

--- a/PingIsland/UI/QuickPick/QuickPickView.swift
+++ b/PingIsland/UI/QuickPick/QuickPickView.swift
@@ -1,0 +1,132 @@
+import SwiftUI
+
+struct QuickPickView: View {
+    @ObservedObject var service: QuickPickService
+    @FocusState private var isSearchFocused: Bool
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            // 主搜索框
+            HStack(spacing: 12) {
+                // 目录选择按钮
+                Menu {
+                    ForEach(service.availableDirectories) { dir in
+                        Button(action: {
+                            service.selectDirectory(dir)
+                        }) {
+                            HStack {
+                                Text(dir.displayName)
+                                if dir.path == service.currentDirectory {
+                                    Image(systemName: "checkmark")
+                                }
+                            }
+                        }
+                    }
+                    
+                    Divider()
+                    
+                    Button(action: {
+                        service.refreshDirectory()
+                    }) {
+                        Label("刷新目录", systemImage: "arrow.clockwise")
+                    }
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: "folder")
+                        Text((service.currentDirectory as NSString).lastPathComponent)
+                            .lineLimit(1)
+                        Image(systemName: "chevron.down")
+                            .font(.caption)
+                    }
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(Color.gray.opacity(0.2))
+                    .cornerRadius(6)
+                }
+                .buttonStyle(.plain)
+                .menuStyle(.borderlessButton)
+                .frame(width: 150)
+                
+                // 分隔线
+                Rectangle()
+                    .fill(Color.gray.opacity(0.3))
+                    .frame(width: 1, height: 24)
+                
+                // 搜索输入框
+                Image(systemName: "magnifyingglass")
+                    .foregroundColor(.secondary)
+                
+                TextField("输入命令或搜索...", text: $service.searchText)
+                    .textFieldStyle(.plain)
+                    .focused($isSearchFocused)
+                    .onSubmit {
+                        service.executeSelected()
+                    }
+                
+                // 快捷键提示
+                Text("⌘␣ 关闭")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(Color(nsColor: .windowBackgroundColor))
+                    .shadow(color: .black.opacity(0.3), radius: 20, x: 0, y: 10)
+            )
+        }
+        .onAppear {
+            isSearchFocused = true
+        }
+        .onChange(of: service.searchText) { _ in
+            service.selectedIndex = 0
+        }
+    }
+}
+
+struct QuickPickResultRow: View {
+    let command: QuickPickCommand
+    let isSelected: Bool
+    
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: command.icon)
+                .frame(width: 24)
+                .foregroundColor(isSelected ? .white : .secondary)
+            
+            VStack(alignment: .leading, spacing: 2) {
+                Text(command.name)
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundColor(isSelected ? .white : .primary)
+                
+                Text(command.description)
+                    .font(.system(size: 11))
+                    .foregroundColor(isSelected ? .white.opacity(0.8) : .secondary)
+            }
+            
+            Spacer()
+            
+            Text(command.command)
+                .font(.system(size: 11, design: .monospaced))
+                .foregroundColor(isSelected ? .white.opacity(0.8) : .secondary)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 2)
+                .background(
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(isSelected ? Color.white.opacity(0.2) : Color.gray.opacity(0.1))
+                )
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(isSelected ? Color.accentColor : Color.clear)
+        )
+    }
+}
+
+#Preview {
+    QuickPickView(service: QuickPickService.shared)
+        .frame(width: 600, height: 60)
+}


### PR DESCRIPTION
## 变更内容

- 实现全局快捷键支持 (⌘+空格 / 双击 Command 呼出)
- 智能检测当前工作目录 (优先: 终端 > Finder > 桌面)
- 支持快速执行 claude code / codex / qodercli / code . 命令
- 创建浮动搜索面板，支持模糊搜索
- 支持 ⌘+K 刷新切换目录

## 本地测试

✅ 编译通过 (CODE_SIGN_IDENTITY="-" 模式)

## 功能说明

| 操作 | 效果 |
|------|------|
| ⌘+空格 | 呼出 QuickPick 输入框 |
| 双击 Command | 呼出 QuickPick 输入框 |
| ⌘+K | 刷新当前目录 |
| ↑/↓ | 选择命令 |
| Enter | 执行选中命令 |
| Esc | 关闭面板 |

## 新增文件

-  - 目录检测服务
-  - 命令模型
-  - 全局快捷键
-  - 核心服务
-  - SwiftUI 界面
-  - 键盘事件处理