### PR TITLE
feat(hooks): add GitHub Copilot hooks support

### DIFF
--- a/PingIsland/Models/ClientProfile.swift
+++ b/PingIsland/Models/ClientProfile.swift
@@ -11,6 +11,7 @@ enum SessionClientBrand: String, Codable, Equatable, Sendable {
     case codebuddy
     case codex
     case qoder
+    case copilot
     case neutral
 }
 
@@ -494,6 +495,31 @@ enum ClientProfileRegistry {
                 HookInstallEventDescriptor(name: "PermissionRequest", templates: [.matcher("*")], timeout: 86_400),
                 HookInstallEventDescriptor(name: "Notification", templates: [.matcher("*")]),
                 HookInstallEventDescriptor(name: "Stop", templates: [.plain]),
+            ]
+        ),
+        ManagedHookClientProfile(
+            id: "copilot-hooks",
+            title: "GitHub Copilot",
+            subtitle: "管理 ~/.github/hooks/island.json，支持 Copilot CLI 与 Agent hooks",
+            alwaysVisibleInSettings: true,
+            logoAssetName: nil,
+            localAppBundleIdentifiers: ["com.github.Copilot", "com.github.CopilotForXcode"],
+            iconSymbolName: "chevron.left.forwardslash.chevron.right",
+            configurationRelativePath: ".github/hooks/island.json",
+            bridgeSource: "copilot",
+            bridgeExtraArguments: [],
+            defaultEnabled: false,
+            installsClaudePythonScript: false,
+            brand: .copilot,
+            events: [
+                HookInstallEventDescriptor(name: "sessionStart", templates: [.matcher("*")]),
+                HookInstallEventDescriptor(name: "sessionEnd", templates: [.matcher("*")]),
+                HookInstallEventDescriptor(name: "userPromptSubmitted", templates: [.matcher("*")]),
+                HookInstallEventDescriptor(name: "preToolUse", templates: [.matcher("*")]),
+                HookInstallEventDescriptor(name: "postToolUse", templates: [.matcher("*")]),
+                HookInstallEventDescriptor(name: "agentStop", templates: [.matcher("*")]),
+                HookInstallEventDescriptor(name: "subagentStop", templates: [.matcher("*")]),
+                HookInstallEventDescriptor(name: "errorOccurred", templates: [.matcher("*")]),
             ]
         ),
     ]

--- a/PingIsland/Models/SessionEvent.swift
+++ b/PingIsland/Models/SessionEvent.swift
@@ -293,6 +293,10 @@ extension HookEvent {
            let json = String(data: data, encoding: .utf8) {
             metadata["toolInputJSON"] = json
         }
+        // 保存原始 toolUseId，用于后续响应
+        if let toolUseId = toolUseId {
+            metadata["originalToolUseId"] = toolUseId
+        }
         let message: String
         if isQoderWorkQuestionEvent {
             metadata["responseMode"] = "external_only"

--- a/PingIsland/Services/Hooks/HookInstaller.swift
+++ b/PingIsland/Services/Hooks/HookInstaller.swift
@@ -320,6 +320,13 @@ struct HookInstaller {
             json = existing
         }
 
+        // Add version field for GitHub Copilot hooks
+        if profile.brand == .copilot {
+            if json["version"] == nil {
+                json["version"] = 1
+            }
+        }
+
         let command: String
         if profile.installsClaudePythonScript {
             let python = detectPython()

--- a/PingIsland/Services/Session/SessionMonitor.swift
+++ b/PingIsland/Services/Session/SessionMonitor.swift
@@ -198,8 +198,10 @@ class SessionMonitor: ObservableObject {
                 return
             }
 
+            // 使用正确的 toolUseId：优先使用 metadata 中保存的原始值
+            let toolUseId = intervention.metadata["originalToolUseId"] ?? intervention.id
             HookSocketServer.shared.respondToIntervention(
-                toolUseId: intervention.id,
+                toolUseId: toolUseId,
                 decision: "answer",
                 updatedInput: updatedInput
             )

--- a/Prototype/Sources/IslandShared/HookPayloadMapper.swift
+++ b/Prototype/Sources/IslandShared/HookPayloadMapper.swift
@@ -105,6 +105,18 @@ public enum HookPayloadMapper {
             case .answer(let answers):
                 return String(data: (try? JSONSerialization.data(withJSONObject: ["answers": answers], options: [.sortedKeys])) ?? Data("{}".utf8), encoding: .utf8) ?? "{}"
             }
+        case .copilot:
+            // GitHub Copilot uses similar response format to Codex
+            switch decision {
+            case .approve, .approveForSession:
+                return #"{"decision":"accept"}"#
+            case .deny:
+                return #"{"decision":"decline"}"#
+            case .cancel:
+                return #"{"decision":"cancel"}"#
+            case .answer(let answers):
+                return String(data: (try? JSONSerialization.data(withJSONObject: ["answers": answers], options: [.sortedKeys])) ?? Data("{}".utf8), encoding: .utf8) ?? "{}"
+            }
         }
     }
 

--- a/Prototype/Sources/IslandShared/Models.swift
+++ b/Prototype/Sources/IslandShared/Models.swift
@@ -3,6 +3,7 @@ import Foundation
 public enum AgentProvider: String, Codable, CaseIterable, Sendable {
     case claude
     case codex
+    case copilot
 }
 
 public enum SessionStatusKind: String, Codable, CaseIterable, Sendable {


### PR DESCRIPTION
## Summary
Add GitHub Copilot hooks support to Island, allowing Copilot CLI and Agent sessions to be managed through Island's hook system.

## Changes
- Add  enum case
- Add Copilot hook profile to  with events:
  - sessionStart, sessionEnd, userPromptSubmitted
  - preToolUse, postToolUse, agentStop, subagentStop, errorOccurred
- Add  field support for Copilot hooks JSON format
- Add  to IslandShared models
- Add Copilot response format handling in HookPayloadMapper

## Configuration
- Hooks file: 
- Default: disabled (user must enable in Settings > Integration)

## Testing
Requires local code signing to run Xcode tests.