### PR TITLE
feat: auto-install hooks on first launch with version metadata

### DIFF
--- a/PingIsland/Services/Hooks/HookInstaller.swift
+++ b/PingIsland/Services/Hooks/HookInstaller.swift
@@ -11,6 +11,9 @@ struct HookInstaller {
     private static let preferredTargetsDefaultsKey = "HookInstaller.preferredTargets.v1"
     private static let qoderMigrationDefaultsKey = "HookInstaller.preferredTargets.qoder-default.v1"
     private static let qoderWorkMigrationDefaultsKey = "HookInstaller.preferredTargets.qoderwork-default.v1"
+    private static let installedVersionDefaultsKey = "HookInstaller.installedVersion.v1"
+    private static let firstLaunchDefaultsKey = "HookInstaller.isFirstLaunch.v1"
+
     private static var defaultPreferredTargets: Set<String> {
         Set(
             ClientProfileRegistry.managedHookProfiles
@@ -21,17 +24,72 @@ struct HookInstaller {
 
     /// Install managed hooks for preferred clients on app launch.
     static func installIfNeeded() {
+        // Check if this is first launch and perform auto-integration
+        let isFirstLaunch = checkAndMarkFirstLaunch()
+
         let preferredTargets = preferredTargets()
         installBridgeLauncherIfNeeded()
         removeLegacyTraeHooks()
 
         for profile in ClientProfileRegistry.managedHookProfiles {
-            if preferredTargets.contains(profile.id) && canManage(profile) {
+            // For first launch, auto-install all defaultEnabled profiles
+            if isFirstLaunch && profile.defaultEnabled && canManage(profile) {
+                install(profile, persistPreference: true)
+            } else if preferredTargets.contains(profile.id) && canManage(profile) {
                 install(profile, persistPreference: false)
             } else {
                 uninstall(profile, persistPreference: false)
             }
         }
+
+        // Update version metadata after installation
+        updateVersionMetadata()
+    }
+
+    /// Check if this is the first launch and mark as installed
+    private static func checkAndMarkFirstLaunch() -> Bool {
+        let defaults = UserDefaults.standard
+
+        // Check if we've already recorded a version
+        if defaults.string(forKey: installedVersionDefaultsKey) != nil {
+            return false
+        }
+
+        // First launch - mark it
+        defaults.set(true, forKey: firstLaunchDefaultsKey)
+        return true
+    }
+
+    /// Update version metadata for tracking updates
+    private static func updateVersionMetadata() {
+        let defaults = UserDefaults.standard
+        let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0"
+        let currentBuild = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1"
+
+        let versionMetadata: [String: Any] = [
+            "version": currentVersion,
+            "build": currentBuild,
+            "installedAt": ISO8601DateFormatter().string(from: Date()),
+            "previousVersion": defaults.string(forKey: installedVersionDefaultsKey) ?? ""
+        ]
+
+        defaults.set(currentVersion, forKey: installedVersionDefaultsKey)
+        defaults.set(versionMetadata, forKey: "HookInstaller.versionMetadata.v1")
+    }
+
+    /// Get the installed version metadata
+    static func getVersionMetadata() -> [String: Any]? {
+        return UserDefaults.standard.dictionary(forKey: "HookInstaller.versionMetadata.v1")
+    }
+
+    /// Check if this is a fresh install (never installed before)
+    static func isFreshInstall() -> Bool {
+        return UserDefaults.standard.string(forKey: installedVersionDefaultsKey) == nil
+    }
+
+    /// Get the current installed version
+    static func getInstalledVersion() -> String? {
+        return UserDefaults.standard.string(forKey: installedVersionDefaultsKey)
     }
 
     static func install(_ profile: ManagedHookClientProfile) {

--- a/PingIsland/UI/Views/SettingsWindowView.swift
+++ b/PingIsland/UI/Views/SettingsWindowView.swift
@@ -917,6 +917,10 @@ private struct SettingsPanelContentView: View {
                 SettingsValueLine(title: "版本", value: appVersion)
                 SettingsLineDivider()
                 SettingsValueLine(title: "构建", value: appBuild)
+                SettingsLineDivider()
+                SettingsValueLine(title: "安装时间", value: versionMetadata)
+                SettingsLineDivider()
+                SettingsValueLine(title: "之前版本", value: previousVersion)
             }
 
             SettingsSectionCard(title: "更新") {
@@ -1089,6 +1093,33 @@ private struct SettingsPanelContentView: View {
 
     private var appBuild: String {
         Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1"
+    }
+
+    private var versionMetadata: String {
+        guard let metadata = HookInstaller.getVersionMetadata(),
+              let installedAt = metadata["installedAt"] as? String else {
+            return "首次安装"
+        }
+
+        // Format the date
+        let formatter = ISO8601DateFormatter()
+        if let date = formatter.date(from: installedAt) {
+            let displayFormatter = DateFormatter()
+            displayFormatter.dateStyle = .medium
+            displayFormatter.timeStyle = .short
+            return displayFormatter.string(from: date)
+        }
+
+        return installedAt
+    }
+
+    private var previousVersion: String {
+        guard let metadata = HookInstaller.getVersionMetadata(),
+              let previous = metadata["previousVersion"] as? String,
+              !previous.isEmpty else {
+            return "无"
+        }
+        return previous
     }
 
     private var updateTitle: String {


### PR DESCRIPTION
## Summary

- Add first launch detection and auto-integration for defaultEnabled hooks
- Add version metadata storage (version, build, installedAt, previousVersion)  
- Display version metadata in Settings > About page
- Add HookInstaller.getVersionMetadata(), isFreshInstall(), getInstalledVersion() APIs for version tracking

## Changes

### HookInstaller.swift
- Added version tracking keys and first launch detection
- Added updateVersionMetadata() to store version info after installation
- Added public APIs for version metadata access

### SettingsWindowView.swift  
- Added version metadata display in About page (installation time, previous version)