### PR TITLE
[codex] Support Claude Code session auto-approve from Ping Island

### DIFF
--- a/PingIsland/Models/SessionEvent.swift
+++ b/PingIsland/Models/SessionEvent.swift
@@ -21,6 +21,9 @@ enum SessionEvent: Sendable {
     /// User approved a permission request
     case permissionApproved(sessionId: String, toolUseId: String)
 
+    /// Session-level approval preference changed for the current session runtime.
+    case permissionAutoApprovalChanged(sessionId: String, isEnabled: Bool)
+
     /// User denied a permission request
     case permissionDenied(sessionId: String, toolUseId: String, reason: String?)
 
@@ -383,6 +386,8 @@ extension SessionEvent: CustomStringConvertible {
             return "hookReceived(\(event.event), session: \(event.sessionId.prefix(8)))"
         case .permissionApproved(let sessionId, let toolUseId):
             return "permissionApproved(session: \(sessionId.prefix(8)), tool: \(toolUseId.prefix(12)))"
+        case .permissionAutoApprovalChanged(let sessionId, let isEnabled):
+            return "permissionAutoApprovalChanged(session: \(sessionId.prefix(8)), enabled: \(isEnabled))"
         case .permissionDenied(let sessionId, let toolUseId, _):
             return "permissionDenied(session: \(sessionId.prefix(8)), tool: \(toolUseId.prefix(12)))"
         case .permissionSocketFailed(let sessionId, let toolUseId):

--- a/PingIsland/Models/SessionState.swift
+++ b/PingIsland/Models/SessionState.swift
@@ -8,6 +8,29 @@
 
 import Foundation
 
+enum SessionScopedApprovalAction: Equatable, Sendable {
+    case allowSession
+    case autoApprove
+
+    nonisolated var buttonTitle: String {
+        switch self {
+        case .allowSession:
+            return "Allow Session"
+        case .autoApprove:
+            return "Auto-Approve"
+        }
+    }
+
+    nonisolated var compactButtonTitle: String {
+        switch self {
+        case .allowSession:
+            return "Session"
+        case .autoApprove:
+            return "Auto"
+        }
+    }
+}
+
 /// Complete state for a single tracked session
 /// This is the single source of truth - all state reads and writes go through SessionStore
 struct SessionState: Equatable, Identifiable, Sendable {
@@ -33,6 +56,7 @@ struct SessionState: Equatable, Identifiable, Sendable {
     var pid: Int?
     var tty: String?
     var isInTmux: Bool
+    var autoApprovePermissions: Bool
 
     // MARK: - State Machine
 
@@ -93,6 +117,7 @@ struct SessionState: Equatable, Identifiable, Sendable {
         pid: Int? = nil,
         tty: String? = nil,
         isInTmux: Bool = false,
+        autoApprovePermissions: Bool = false,
         phase: SessionPhase = .idle,
         chatItems: [ChatHistoryItem] = [],
         toolTracker: ToolTracker = ToolTracker(),
@@ -119,6 +144,7 @@ struct SessionState: Equatable, Identifiable, Sendable {
         self.pid = pid
         self.tty = tty
         self.isInTmux = isInTmux
+        self.autoApprovePermissions = autoApprovePermissions
         self.phase = phase
         self.chatItems = chatItems
         self.toolTracker = toolTracker
@@ -470,6 +496,24 @@ struct SessionState: Equatable, Identifiable, Sendable {
     /// Whether the session is waiting on an approval-like decision.
     nonisolated var needsApprovalResponse: Bool {
         phase.isWaitingForApproval || intervention?.kind == .approval
+    }
+
+    nonisolated var scopedApprovalAction: SessionScopedApprovalAction? {
+        guard needsApprovalResponse else { return nil }
+
+        if ingress == .codexAppServer || intervention?.supportsSessionScope == true {
+            return .allowSession
+        }
+
+        if provider == .claude, clientInfo.kind == .claudeCode {
+            return .autoApprove
+        }
+
+        return nil
+    }
+
+    nonisolated var supportsSessionScopedApproval: Bool {
+        scopedApprovalAction != nil
     }
 
     /// Timestamp used when sorting sessions that need manual attention.

--- a/PingIsland/Services/Session/SessionMonitor.swift
+++ b/PingIsland/Services/Session/SessionMonitor.swift
@@ -50,13 +50,28 @@ class SessionMonitor: ObservableObject {
 
         HookSocketServer.shared.start(
             onEvent: { event in
-                // Play sound for the event
-                Task { @MainActor in
-                    SoundManager.shared.handleEvent(event.event)
-                }
-                
                 Task {
+                    let shouldAutoApprovePermission = await Self.shouldAutoApproveClaudePermission(for: event)
+
+                    if !shouldAutoApprovePermission {
+                        await MainActor.run {
+                            SoundManager.shared.handleEvent(event.event)
+                        }
+                    }
+
                     await SessionStore.shared.process(.hookReceived(event))
+
+                    if shouldAutoApprovePermission,
+                       let approvedToolUseId = await Self.resolvePendingApprovalToolUseId(for: event.sessionId, fallback: event.toolUseId) {
+                        HookSocketServer.shared.respondToPermission(
+                            toolUseId: approvedToolUseId,
+                            decision: "approveForSession"
+                        )
+                        await SessionStore.shared.process(
+                            .permissionApproved(sessionId: event.sessionId, toolUseId: approvedToolUseId)
+                        )
+                        return
+                    }
 
                     if let autoAnswer = await MainActor.run(body: { Self.defaultQoderAutoAnswer(for: event) }) {
                         await MainActor.run {
@@ -146,6 +161,20 @@ class SessionMonitor: ObservableObject {
             }
 
             guard let permission = session.activePermission else { return }
+
+            if forSession, session.scopedApprovalAction == .autoApprove {
+                await SessionStore.shared.process(
+                    .permissionAutoApprovalChanged(sessionId: sessionId, isEnabled: true)
+                )
+                HookSocketServer.shared.respondToPermission(
+                    toolUseId: permission.toolUseId,
+                    decision: "approveForSession"
+                )
+                await SessionStore.shared.process(
+                    .permissionApproved(sessionId: sessionId, toolUseId: permission.toolUseId)
+                )
+                return
+            }
 
             HookSocketServer.shared.respondToPermission(
                 toolUseId: permission.toolUseId,
@@ -422,6 +451,36 @@ class SessionMonitor: ObservableObject {
         }
 
         return (toolUseId, answers, updatedInput)
+    }
+
+    private nonisolated static func shouldAutoApproveClaudePermission(for event: HookEvent) async -> Bool {
+        guard event.provider == .claude,
+              event.event == "PermissionRequest",
+              event.status == "waiting_for_approval"
+        else {
+            return false
+        }
+
+        guard let session = await SessionStore.shared.session(for: event.sessionId) else {
+            return false
+        }
+
+        return session.autoApprovePermissions
+            && session.provider == .claude
+            && session.clientInfo.kind == .claudeCode
+    }
+
+    private nonisolated static func resolvePendingApprovalToolUseId(
+        for sessionId: String,
+        fallback: String?
+    ) async -> String? {
+        if let toolUseId = await SessionStore.shared.session(for: sessionId)?.activePermission?.toolUseId,
+           !toolUseId.isEmpty {
+            return toolUseId
+        }
+
+        guard let fallback, !fallback.isEmpty else { return nil }
+        return fallback
     }
 
     private func loadCodexRolloutFallback(

--- a/PingIsland/Services/State/SessionStore.swift
+++ b/PingIsland/Services/State/SessionStore.swift
@@ -91,6 +91,9 @@ actor SessionStore {
         case .permissionApproved(let sessionId, let toolUseId):
             await processPermissionApproved(sessionId: sessionId, toolUseId: toolUseId)
 
+        case .permissionAutoApprovalChanged(let sessionId, let isEnabled):
+            processPermissionAutoApprovalChanged(sessionId: sessionId, isEnabled: isEnabled)
+
         case .permissionDenied(let sessionId, let toolUseId, let reason):
             await processPermissionDenied(sessionId: sessionId, toolUseId: toolUseId, reason: reason)
 
@@ -476,6 +479,12 @@ actor SessionStore {
     }
 
     // MARK: - Permission Processing
+
+    private func processPermissionAutoApprovalChanged(sessionId: String, isEnabled: Bool) {
+        guard var session = sessions[sessionId] else { return }
+        session.autoApprovePermissions = isEnabled
+        sessions[sessionId] = session
+    }
 
     private func processPermissionApproved(sessionId: String, toolUseId: String) async {
         guard var session = sessions[sessionId] else { return }
@@ -1126,6 +1135,7 @@ actor SessionStore {
     private func markSessionEnded(_ session: inout SessionState) {
         session.phase = .ended
         session.intervention = nil
+        session.autoApprovePermissions = false
         session.lastActivity = Date()
     }
 

--- a/PingIsland/UI/Views/ChatView.swift
+++ b/PingIsland/UI/Views/ChatView.swift
@@ -445,7 +445,9 @@ struct ChatView: View {
         ChatApprovalBar(
             tool: tool,
             toolInput: session.pendingToolInput,
+            sessionAction: session.scopedApprovalAction,
             onApprove: { approvePermission() },
+            onApproveForSession: { approvePermissionForSession() },
             onDeny: { denyPermission() }
         )
     }
@@ -583,6 +585,10 @@ struct ChatView: View {
 
     private func approvePermission() {
         sessionMonitor.approvePermission(sessionId: sessionId)
+    }
+
+    private func approvePermissionForSession() {
+        sessionMonitor.approvePermission(sessionId: sessionId, forSession: true)
     }
 
     private func denyPermission() {
@@ -1201,12 +1207,15 @@ struct ChatInteractivePromptBar: View {
 struct ChatApprovalBar: View {
     let tool: String
     let toolInput: String?
+    let sessionAction: SessionScopedApprovalAction?
     let onApprove: () -> Void
+    let onApproveForSession: () -> Void
     let onDeny: () -> Void
 
     @State private var showContent = false
     @State private var showAllowButton = false
     @State private var showDenyButton = false
+    @State private var showSessionButton = false
 
     var body: some View {
         HStack(spacing: 12) {
@@ -1243,6 +1252,23 @@ struct ChatApprovalBar: View {
             .opacity(showDenyButton ? 1 : 0)
             .scaleEffect(showDenyButton ? 1 : 0.8)
 
+            if let sessionAction {
+                Button {
+                    onApproveForSession()
+                } label: {
+                    Text(sessionAction.buttonTitle)
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(.white.opacity(0.92))
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 8)
+                        .background(TerminalColors.blue.opacity(0.26))
+                        .clipShape(Capsule())
+                }
+                .buttonStyle(.plain)
+                .opacity(showSessionButton ? 1 : 0)
+                .scaleEffect(showSessionButton ? 1 : 0.8)
+            }
+
             // Allow button
             Button {
                 onApprove()
@@ -1271,6 +1297,9 @@ struct ChatApprovalBar: View {
                 showDenyButton = true
             }
             withAnimation(.spring(response: 0.35, dampingFraction: 0.7).delay(0.15)) {
+                showSessionButton = sessionAction != nil
+            }
+            withAnimation(.spring(response: 0.35, dampingFraction: 0.7).delay(0.2)) {
                 showAllowButton = true
             }
         }

--- a/PingIsland/UI/Views/SessionHoverPreviewView.swift
+++ b/PingIsland/UI/Views/SessionHoverPreviewView.swift
@@ -274,6 +274,18 @@ private struct HoverApprovalCard: View {
                 }
                 .buttonStyle(HoverApprovalButtonStyle(background: Color.white.opacity(0.1)))
 
+                if let sessionAction = session.scopedApprovalAction {
+                    Button(sessionAction.buttonTitle) {
+                        sessionMonitor.approvePermission(sessionId: session.sessionId, forSession: true)
+                    }
+                    .buttonStyle(
+                        HoverApprovalButtonStyle(
+                            background: TerminalColors.blue.opacity(0.26),
+                            foreground: .white.opacity(0.95)
+                        )
+                    )
+                }
+
                 Button("Allow") {
                     sessionMonitor.approvePermission(sessionId: session.sessionId)
                 }

--- a/PingIsland/UI/Views/SessionListView.swift
+++ b/PingIsland/UI/Views/SessionListView.swift
@@ -63,6 +63,7 @@ struct SessionListView: View {
                         onChat: { openChat(session) },
                         onArchive: { archiveSession(session) },
                         onApprove: { approveSession(session) },
+                        onApproveForSession: { approveSessionForScope(session) },
                         onReject: { rejectSession(session) }
                     )
                     .id(session.stableId)
@@ -111,6 +112,10 @@ struct SessionListView: View {
         sessionMonitor.approvePermission(sessionId: session.sessionId)
     }
 
+    private func approveSessionForScope(_ session: SessionState) {
+        sessionMonitor.approvePermission(sessionId: session.sessionId, forSession: true)
+    }
+
     private func rejectSession(_ session: SessionState) {
         sessionMonitor.denyPermission(sessionId: session.sessionId, reason: nil)
     }
@@ -131,6 +136,7 @@ struct InstanceRow: View {
     let onChat: () -> Void
     let onArchive: () -> Void
     let onApprove: () -> Void
+    let onApproveForSession: () -> Void
     let onReject: () -> Void
 
     @State private var isHovered = false
@@ -624,8 +630,10 @@ struct InstanceRow: View {
             }
         } else if isWaitingForApproval {
             InlineApprovalButtons(
+                sessionAction: session.scopedApprovalAction,
                 onChat: onChat,
                 onApprove: onApprove,
+                onApproveForSession: onApproveForSession,
                 onReject: onReject
             )
         } else {
@@ -710,13 +718,16 @@ private struct QueuePreviewLine: Identifiable {
 
 /// Compact inline approval buttons with staggered animation
 struct InlineApprovalButtons: View {
+    let sessionAction: SessionScopedApprovalAction?
     let onChat: () -> Void
     let onApprove: () -> Void
+    let onApproveForSession: () -> Void
     let onReject: () -> Void
 
     @State private var showChatButton = false
     @State private var showDenyButton = false
     @State private var showAllowButton = false
+    @State private var showSessionButton = false
 
     var body: some View {
         HStack(spacing: 5) {
@@ -742,6 +753,23 @@ struct InlineApprovalButtons: View {
             .opacity(showDenyButton ? 1 : 0)
             .scaleEffect(showDenyButton ? 1 : 0.8)
 
+            if let sessionAction {
+                Button {
+                    onApproveForSession()
+                } label: {
+                    Text(sessionAction.compactButtonTitle)
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundColor(.white.opacity(0.86))
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(TerminalColors.blue.opacity(0.24))
+                        .clipShape(Capsule())
+                }
+                .buttonStyle(.plain)
+                .opacity(showSessionButton ? 1 : 0)
+                .scaleEffect(showSessionButton ? 1 : 0.8)
+            }
+
             Button {
                 onApprove()
             } label: {
@@ -765,6 +793,9 @@ struct InlineApprovalButtons: View {
                 showDenyButton = true
             }
             withAnimation(.spring(response: 0.3, dampingFraction: 0.7).delay(0.1)) {
+                showSessionButton = sessionAction != nil
+            }
+            withAnimation(.spring(response: 0.3, dampingFraction: 0.7).delay(0.15)) {
                 showAllowButton = true
             }
         }

--- a/PingIslandTests/SessionStateTests.swift
+++ b/PingIslandTests/SessionStateTests.swift
@@ -108,6 +108,50 @@ final class SessionStateTests: XCTestCase {
         XCTAssertEqual(session.pendingToolInput, "command: swift test\ntimeout: 30")
     }
 
+    func testClaudeCodeWaitingForApprovalSupportsAutoApproveAction() {
+        let session = SessionState(
+            sessionId: "claude-auto-approve",
+            cwd: "/tmp/project",
+            provider: .claude,
+            clientInfo: SessionClientInfo(kind: .claudeCode, name: "Claude Code"),
+            phase: .waitingForApproval(
+                PermissionContext(toolUseId: "tool-1", toolName: "Bash", toolInput: nil, receivedAt: Date())
+            )
+        )
+
+        XCTAssertEqual(session.scopedApprovalAction, .autoApprove)
+        XCTAssertTrue(session.supportsSessionScopedApproval)
+    }
+
+    func testQoderWaitingForApprovalDoesNotExposeClaudeAutoApproveAction() {
+        let session = SessionState(
+            sessionId: "qoder-no-auto-approve",
+            cwd: "/tmp/project",
+            provider: .claude,
+            clientInfo: SessionClientInfo(kind: .qoder, profileID: "qoder", name: "Qoder"),
+            phase: .waitingForApproval(
+                PermissionContext(toolUseId: "tool-1", toolName: "Bash", toolInput: nil, receivedAt: Date())
+            )
+        )
+
+        XCTAssertNil(session.scopedApprovalAction)
+        XCTAssertFalse(session.supportsSessionScopedApproval)
+    }
+
+    func testCodexAppServerWaitingForApprovalUsesAllowSessionAction() {
+        let session = SessionState(
+            sessionId: "codex-session-scope",
+            cwd: "/tmp/project",
+            provider: .codex,
+            ingress: .codexAppServer,
+            phase: .waitingForApproval(
+                PermissionContext(toolUseId: "tool-1", toolName: "shell", toolInput: nil, receivedAt: Date())
+            )
+        )
+
+        XCTAssertEqual(session.scopedApprovalAction, .allowSession)
+    }
+
     func testIdleSessionAutoArchivesFromPrimaryUIAfterThirtyMinutes() {
         let session = SessionState(
             sessionId: "idle-auto-archive",

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Ping Island focuses on the moments that actually interrupt coding flow, then kee
 
 - **Attention-first UI** - Stay compact until a session needs approval, input, review, or intervention.
 - **Act from the notch** - Approve tools, deny requests, and answer follow-up prompts without hunting through tabs.
+- **Claude Code auto-approve** - Turn on per-session auto-approval when you want Claude Code to stop pausing on every permission request.
 - **One-click return** - Jump back to the right iTerm2, Ghostty, Terminal.app, tmux pane, or IDE window.
 - **Multi-agent coverage** - Track Claude Code, Codex, Gemini CLI, OpenCode, Cursor, Qoder, CodeBuddy, GitHub Copilot, and other compatible sessions in one place.
 - **Codex hook + app-server sync** - Support Codex CLI hooks, live app-server threads, and rollout parsing fallback when needed.


### PR DESCRIPTION
## Summary
- add a Claude Code `Auto-Approve` session action alongside the existing Codex session approval affordance
- wire Claude session auto-approval through session state, approval handling, and the list / hover / chat approval surfaces
- add regression coverage for the new approval-scoping behavior and document the capability in the README

## Why
Issue #10 asks for a way to stop Claude Code from pausing on every permission request. Ping Island already had a session-scoped approval concept for Codex, and Claude's tmux-backed approval flow can promote the current session to always allow, but the app did not expose that path in the UI or preserve the choice for follow-up prompts.

## User Impact
Claude Code sessions can now be switched into auto-approve mode from Ping Island with one click. The current request is approved immediately, and subsequent permission prompts in the same session are auto-accepted without repeated manual confirmation.

## Root Cause
The app only exposed per-request `allow` / `deny` handling for Claude hook sessions, even though the underlying approval flow could express a session-level approval decision.

## Validation
- `xcodebuild -project /Users/wudanwu/Island/PingIsland.xcodeproj -scheme PingIsland -configuration Debug CODE_SIGNING_ALLOWED=NO test -only-testing:PingIslandTests`

Closes #10
