### PR TITLE
[codex] Hide OpenCode child sessions from the primary list

### DIFF
--- a/PingIsland/Models/SessionState.swift
+++ b/PingIsland/Models/SessionState.swift
@@ -14,6 +14,7 @@ struct SessionState: Equatable, Identifiable, Sendable {
     private nonisolated static let minimalCompactDelay: TimeInterval = 10 * 60
     private nonisolated static let autoArchiveDelay: TimeInterval = 30 * 60
     private nonisolated static let codexContinuationPlaceholderHideWindow: TimeInterval = 10 * 60
+    private nonisolated static let openCodeChildSessionHideWindow: TimeInterval = 120
 
     // MARK: - Identity
 
@@ -233,6 +234,43 @@ struct SessionState: Equatable, Identifiable, Sendable {
             || (conversationInfo.lastMessage?.isEmpty == false)
     }
 
+    /// OpenCode subagents currently surface as extra shallow sessions on the same
+    /// terminal surface. Hide them once the richer parent session is visible.
+    nonisolated var isLikelyOpenCodeChildSessionPlaceholderForUI: Bool {
+        guard clientInfo.brand == .opencode else { return false }
+        guard chatItems.isEmpty else { return false }
+        guard intervention == nil else { return false }
+        guard sessionName?.isEmpty != false else { return false }
+        guard conversationInfo.summary?.isEmpty != false else { return false }
+        guard conversationInfo.firstUserMessage?.isEmpty != false else { return false }
+        guard conversationInfo.lastMessage?.isEmpty != false else { return false }
+
+        let visibleTexts = [
+            SessionTextSanitizer.sanitizedDisplayText(previewText),
+            compactHookMessage
+        ].compactMap { $0 }
+
+        guard !visibleTexts.isEmpty else { return false }
+        return visibleTexts.allSatisfy(Self.isLikelyGenericHookProgressText(_:))
+    }
+
+    nonisolated var hasDurableOpenCodeDisplayIdentity: Bool {
+        guard clientInfo.brand == .opencode else { return false }
+
+        let visibleTexts = [
+            SessionTextSanitizer.sanitizedDisplayText(previewText),
+            compactHookMessage,
+            SessionTextSanitizer.sanitizedDisplayText(conversationInfo.summary),
+            SessionTextSanitizer.sanitizedDisplayText(conversationInfo.firstUserMessage),
+            SessionTextSanitizer.sanitizedDisplayText(conversationInfo.lastMessage)
+        ].compactMap { $0 }
+
+        return !chatItems.isEmpty
+            || intervention != nil
+            || (sessionName?.isEmpty == false)
+            || visibleTexts.contains(where: { !Self.isLikelyGenericHookProgressText($0) })
+    }
+
     nonisolated func shouldRebindToExistingCodexThread(
         comparedTo other: SessionState,
         maximumRecencyGap: TimeInterval
@@ -267,6 +305,22 @@ struct SessionState: Equatable, Identifiable, Sendable {
 
         guard other.clientInfo.sessionFilePath?.isEmpty == false else { return false }
         return recencyGap <= 120
+    }
+
+    nonisolated func shouldHideAsDuplicateOpenCodeChildSession(comparedTo other: SessionState) -> Bool {
+        guard sessionId != other.sessionId else { return false }
+        guard isLikelyOpenCodeChildSessionPlaceholderForUI else { return false }
+        guard other.clientInfo.brand == .opencode else { return false }
+        guard other.hasDurableOpenCodeDisplayIdentity else { return false }
+        guard other.phase != .ended else { return false }
+        guard normalizedWorkspacePath == other.normalizedWorkspacePath else { return false }
+        guard createdAt >= other.createdAt else { return false }
+
+        let sharedIdentity = !hookSurfaceIdentityTokens.isDisjoint(with: other.hookSurfaceIdentityTokens)
+        guard sharedIdentity else { return false }
+
+        let recencyGap = abs(lastActivity.timeIntervalSince(other.lastActivity))
+        return recencyGap <= Self.openCodeChildSessionHideWindow
     }
 
     private nonisolated var hasOnlyTransientCodexProgressContent: Bool {
@@ -334,6 +388,56 @@ struct SessionState: Equatable, Identifiable, Sendable {
             "正在处理",
             "思考中",
             "压缩上下文"
+        ]
+        return containsMatches.contains { normalized.contains($0) }
+    }
+
+    private nonisolated static func isLikelyGenericHookProgressText(_ text: String) -> Bool {
+        let normalized = text
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: #"[….]+"#, with: "", options: .regularExpression)
+            .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+
+        guard !normalized.isEmpty else { return false }
+        guard normalized.count <= 32 else { return false }
+
+        let exactMatches: Set<String> = [
+            "working",
+            "working on it",
+            "processing",
+            "thinking",
+            "loading",
+            "starting",
+            "running",
+            "busy",
+            "work in progress",
+            "idle",
+            "ready",
+            "工作中",
+            "处理中",
+            "正在处理",
+            "思考中",
+            "加载中",
+            "准备中",
+            "运行中"
+        ]
+        if exactMatches.contains(normalized) {
+            return true
+        }
+
+        let containsMatches = [
+            "still working",
+            "working",
+            "processing",
+            "thinking",
+            "loading",
+            "running",
+            "waiting",
+            "工作中",
+            "处理中",
+            "正在处理",
+            "思考中"
         ]
         return containsMatches.contains { normalized.contains($0) }
     }
@@ -589,6 +693,26 @@ struct SessionState: Equatable, Identifiable, Sendable {
             normalized(clientInfo.tmuxSessionIdentifier).map { "tmuxSession:\($0)" },
             normalized(clientInfo.tmuxPaneIdentifier).map { "tmuxPane:\($0)" },
             normalized(clientInfo.processName).map { "process:\($0)" }
+        ].compactMap { $0 })
+    }
+
+    private nonisolated var hookSurfaceIdentityTokens: Set<String> {
+        func normalized(_ value: String?) -> String? {
+            let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let trimmed, !trimmed.isEmpty else { return nil }
+            return trimmed.lowercased()
+        }
+
+        return Set([
+            normalized(tty).map { "tty:\($0)" },
+            normalized(clientInfo.terminalBundleIdentifier).map { "terminalBundle:\($0)" },
+            normalized(clientInfo.terminalProgram).map { "terminalProgram:\($0)" },
+            normalized(clientInfo.transport).map { "transport:\($0)" },
+            normalized(clientInfo.remoteHost).map { "remoteHost:\($0)" },
+            normalized(clientInfo.terminalSessionIdentifier).map { "terminalSession:\($0)" },
+            normalized(clientInfo.iTermSessionIdentifier).map { "itermSession:\($0)" },
+            normalized(clientInfo.tmuxSessionIdentifier).map { "tmuxSession:\($0)" },
+            normalized(clientInfo.tmuxPaneIdentifier).map { "tmuxPane:\($0)" }
         ].compactMap { $0 })
     }
 }

--- a/PingIsland/Services/Session/SessionMonitor.swift
+++ b/PingIsland/Services/Session/SessionMonitor.swift
@@ -289,6 +289,7 @@ class SessionMonitor: ObservableObject {
         return primaryVisibleSessions.filter { candidate in
             !primaryVisibleSessions.contains { other in
                 candidate.shouldHideAsDuplicateCodexPlaceholder(comparedTo: other)
+                    || candidate.shouldHideAsDuplicateOpenCodeChildSession(comparedTo: other)
             }
         }
     }

--- a/PingIslandTests/SessionStateTests.swift
+++ b/PingIslandTests/SessionStateTests.swift
@@ -233,6 +233,99 @@ final class SessionStateTests: XCTestCase {
         XCTAssertFalse(secondRealSession.shouldHideAsDuplicateCodexPlaceholder(comparedTo: firstRealSession))
     }
 
+    func testOpenCodeChildPlaceholderHidesWhenRicherParentMatchesSameSurface() {
+        let now = Date()
+        let parent = SessionState(
+            sessionId: "opencode-parent",
+            cwd: "/tmp/project",
+            clientInfo: SessionClientInfo(
+                kind: .custom,
+                profileID: "opencode",
+                name: "OpenCode",
+                origin: "cli",
+                originator: "OpenCode",
+                threadSource: "opencode-plugin",
+                terminalBundleIdentifier: "com.mitchellh.ghostty",
+                terminalProgram: "ghostty",
+                terminalSessionIdentifier: "ghostty-session-1"
+            ),
+            previewText: "Fix duplicate sessions in the menu bar",
+            phase: .processing,
+            lastActivity: now.addingTimeInterval(-15),
+            createdAt: now.addingTimeInterval(-60)
+        )
+        let child = SessionState(
+            sessionId: "opencode-child",
+            cwd: "/tmp/project",
+            clientInfo: SessionClientInfo(
+                kind: .custom,
+                profileID: "opencode",
+                name: "OpenCode",
+                origin: "cli",
+                originator: "OpenCode",
+                threadSource: "opencode-plugin",
+                terminalBundleIdentifier: "com.mitchellh.ghostty",
+                terminalProgram: "ghostty",
+                terminalSessionIdentifier: "ghostty-session-1"
+            ),
+            previewText: "Working...",
+            phase: .processing,
+            lastActivity: now,
+            createdAt: now.addingTimeInterval(-10)
+        )
+
+        XCTAssertTrue(child.isLikelyOpenCodeChildSessionPlaceholderForUI)
+        XCTAssertTrue(parent.hasDurableOpenCodeDisplayIdentity)
+        XCTAssertTrue(child.shouldHideAsDuplicateOpenCodeChildSession(comparedTo: parent))
+    }
+
+    func testOpenCodeRealSessionDoesNotHideAnotherRealSessionOnSameSurface() {
+        let now = Date()
+        let firstSession = SessionState(
+            sessionId: "opencode-real-1",
+            cwd: "/tmp/project",
+            clientInfo: SessionClientInfo(
+                kind: .custom,
+                profileID: "opencode",
+                name: "OpenCode",
+                origin: "cli",
+                originator: "OpenCode",
+                threadSource: "opencode-plugin",
+                terminalBundleIdentifier: "com.mitchellh.ghostty",
+                terminalProgram: "ghostty",
+                terminalSessionIdentifier: "ghostty-session-1"
+            ),
+            previewText: "Investigate working state detection",
+            phase: .processing,
+            lastActivity: now.addingTimeInterval(-20),
+            createdAt: now.addingTimeInterval(-120)
+        )
+        let secondSession = SessionState(
+            sessionId: "opencode-real-2",
+            cwd: "/tmp/project",
+            clientInfo: SessionClientInfo(
+                kind: .custom,
+                profileID: "opencode",
+                name: "OpenCode",
+                origin: "cli",
+                originator: "OpenCode",
+                threadSource: "opencode-plugin",
+                terminalBundleIdentifier: "com.mitchellh.ghostty",
+                terminalProgram: "ghostty",
+                terminalSessionIdentifier: "ghostty-session-1"
+            ),
+            previewText: "Write regression tests for child sessions",
+            phase: .processing,
+            lastActivity: now,
+            createdAt: now.addingTimeInterval(-30)
+        )
+
+        XCTAssertFalse(firstSession.isLikelyOpenCodeChildSessionPlaceholderForUI)
+        XCTAssertFalse(secondSession.isLikelyOpenCodeChildSessionPlaceholderForUI)
+        XCTAssertFalse(firstSession.shouldHideAsDuplicateOpenCodeChildSession(comparedTo: secondSession))
+        XCTAssertFalse(secondSession.shouldHideAsDuplicateOpenCodeChildSession(comparedTo: firstSession))
+    }
+
     func testGenericEmptyCodexPlaceholderHidesWhenNearbyThreadHasRolloutPath() {
         let now = Date()
         let placeholder = SessionState(


### PR DESCRIPTION
## What changed
- add an OpenCode-specific duplicate-session heuristic that hides shallow child-agent sessions when a richer parent session is already visible on the same workspace and terminal surface
- extend the primary session list filter to apply that OpenCode child-session suppression
- add regression tests covering both the hide case and the non-hide case for real parallel OpenCode sessions

## Why
Issue #14 reported that OpenCode subagents were being counted as a second window even though the user only had one real OpenCode window open.

Root cause: child-agent hook traffic was creating extra lightweight sessions with generic progress text, and the existing UI filtering only knew how to suppress duplicate Codex placeholders.

## Impact
- OpenCode subagents should no longer appear as duplicate rows in the primary list
- normal OpenCode sessions with real content should remain visible
- the fix stays narrowly scoped to OpenCode child-session placeholders and does not change the existing Codex placeholder rules

## Validation
- `xcodebuild -project PingIsland.xcodeproj -scheme PingIsland -configuration Debug CODE_SIGNING_ALLOWED=NO test -only-testing:PingIslandTests`

Closes #14
