### PR TITLE
Fix precise Ghostty window focus for duplicate workspaces

### DIFF
--- a/PingIsland/Services/Window/TerminalSessionFocuser.swift
+++ b/PingIsland/Services/Window/TerminalSessionFocuser.swift
@@ -128,11 +128,13 @@ actor TerminalSessionFocuser {
             )
             return await focusITermSession(terminalPid: terminalPid, selector: selector)
         case "com.mitchellh.ghostty":
+            let ghosttyTerminalIdentifier = clientInfo?.terminalSessionIdentifier
             await FocusDiagnosticsStore.shared.record(
-                "TerminalFocus ghostty applescript terminalPid=\(terminalPid) workspacePath=\(workspacePath ?? "nil")"
+                "TerminalFocus ghostty applescript terminalPid=\(terminalPid) terminalIdentifier=\(ghosttyTerminalIdentifier ?? "nil") workspacePath=\(workspacePath ?? "nil")"
             )
             return await focusGhosttyTerminal(
                 terminalPid: terminalPid,
+                terminalSessionIdentifier: ghosttyTerminalIdentifier,
                 workspacePath: workspacePath
             )
         default:
@@ -323,8 +325,15 @@ actor TerminalSessionFocuser {
         return retryResult
     }
 
-    private func focusGhosttyTerminal(terminalPid: Int, workspacePath: String?) async -> Bool {
-        let result = await runAppleScript(lines: ghosttySelectionScriptLines(for: workspacePath))
+    private func focusGhosttyTerminal(
+        terminalPid: Int,
+        terminalSessionIdentifier: String?,
+        workspacePath: String?
+    ) async -> Bool {
+        let result = await runAppleScript(lines: Self.ghosttySelectionScriptLines(
+            terminalSessionIdentifier: terminalSessionIdentifier,
+            workspacePath: workspacePath
+        ))
         await FocusDiagnosticsStore.shared.record(
             "TerminalFocus ghostty select-result terminalPid=\(terminalPid) success=\(result)"
         )
@@ -443,10 +452,25 @@ actor TerminalSessionFocuser {
         }
     }
 
-    private func ghosttySelectionScriptLines(for workspacePath: String?) -> [String] {
+    static func ghosttySelectionScriptLines(
+        terminalSessionIdentifier: String?,
+        workspacePath: String?
+    ) -> [String] {
         var lines = [
             "tell application id \"com.mitchellh.ghostty\""
         ]
+
+        if let terminalSessionIdentifier = terminalSessionIdentifier?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !terminalSessionIdentifier.isEmpty {
+            lines.append(contentsOf: [
+                "set targetTerminalID to \(appleScriptStringLiteral(terminalSessionIdentifier))",
+                "try",
+                "set targetTerminal to first terminal whose id is targetTerminalID",
+                "focus targetTerminal",
+                "return \"ok\"",
+                "end try"
+            ])
+        }
 
         if let workspacePath = workspacePath?.trimmingCharacters(in: .whitespacesAndNewlines),
            !workspacePath.isEmpty {
@@ -498,7 +522,7 @@ actor TerminalSessionFocuser {
         return rawValue
     }
 
-    private func appleScriptStringLiteral(_ value: String) -> String {
+    private static func appleScriptStringLiteral(_ value: String) -> String {
         let escaped = value
             .replacingOccurrences(of: "\\", with: "\\\\")
             .replacingOccurrences(of: "\"", with: "\\\"")

--- a/PingIslandTests/SessionStateTests.swift
+++ b/PingIslandTests/SessionStateTests.swift
@@ -657,4 +657,32 @@ final class SessionStateTests: XCTestCase {
         XCTAssertEqual(messages.first?.textContent, "使用工具问我一个问题")
         XCTAssertEqual(messages.last?.textContent, "好的，我来问你。")
     }
+
+    func testGhosttySelectionScriptPrefersStableTerminalIdentifier() {
+        let lines = TerminalSessionFocuser.ghosttySelectionScriptLines(
+            terminalSessionIdentifier: "ghostty-terminal-1",
+            workspacePath: "/tmp/demo"
+        )
+        let script = lines.joined(separator: "\n")
+
+        XCTAssertTrue(script.contains("set targetTerminalID to \"ghostty-terminal-1\""))
+        XCTAssertTrue(script.contains("set targetTerminal to first terminal whose id is targetTerminalID"))
+        XCTAssertTrue(script.contains("focus targetTerminal"))
+
+        let identifierIndex = try! XCTUnwrap(lines.firstIndex(of: "set targetTerminalID to \"ghostty-terminal-1\""))
+        let workspaceIndex = try! XCTUnwrap(lines.firstIndex(of: "set targetPath to \"/tmp/demo\""))
+        XCTAssertLessThan(identifierIndex, workspaceIndex)
+    }
+
+    func testGhosttySelectionScriptFallsBackToWorkspaceMatchingWithoutIdentifier() {
+        let lines = TerminalSessionFocuser.ghosttySelectionScriptLines(
+            terminalSessionIdentifier: nil,
+            workspacePath: "/tmp/demo"
+        )
+        let script = lines.joined(separator: "\n")
+
+        XCTAssertFalse(script.contains("targetTerminalID"))
+        XCTAssertTrue(script.contains("set targetPath to \"/tmp/demo\""))
+        XCTAssertTrue(script.contains("focus (item 1 of exactMatches)"))
+    }
 }

--- a/Prototype/Tests/IslandTests/HookPayloadMapperTests.swift
+++ b/Prototype/Tests/IslandTests/HookPayloadMapperTests.swift
@@ -39,12 +39,17 @@ func mapsGhosttyTerminalContextFromEnvironment() throws {
     let envelope = HookPayloadMapper.makeEnvelope(
         source: .claude,
         arguments: ["island-bridge", "--source", "claude"],
-        environment: ["TERM_PROGRAM": "ghostty", "PWD": "/tmp/demo"],
+        environment: [
+            "TERM_PROGRAM": "ghostty",
+            "TERM_SESSION_ID": "ghostty-terminal-1",
+            "PWD": "/tmp/demo"
+        ],
         stdinData: payload
     )
 
     #expect(envelope.terminalContext.terminalProgram == "ghostty")
     #expect(envelope.terminalContext.terminalBundleID == "com.mitchellh.ghostty")
+    #expect(envelope.terminalContext.terminalSessionID == "ghostty-terminal-1")
 }
 
 @Test


### PR DESCRIPTION
## Summary
- prefer Ghostty's stable terminal session identifier before workspace/name fallback when focusing a session
- keep the existing workspace-based fallback for older sessions without a terminal identifier
- add regression coverage for Ghostty terminal session capture and selector generation

## Testing
- `swift test --package-path Prototype --filter mapsGhosttyTerminalContextFromEnvironment`
- `xcodebuild -project PingIsland.xcodeproj -scheme PingIsland -configuration Debug CODE_SIGNING_ALLOWED=NO test -only-testing:PingIslandTests/SessionStateTests`
- manual `osascript` focus by Ghostty terminal id

Closes #17.