### PR TITLE
Fix terminal jump authorization flow

### DIFF
--- a/PingIsland/Services/Window/TerminalAutomationPermissionCoordinator.swift
+++ b/PingIsland/Services/Window/TerminalAutomationPermissionCoordinator.swift
@@ -15,57 +15,47 @@ actor TerminalAutomationPermissionCoordinator {
         sessionId: String
     ) {
         guard provider == .claude || provider == .codex,
-              let bundleIdentifier = scriptableTerminalBundleIdentifier(for: clientInfo)
+              let bundleIdentifier = Self.scriptableTerminalBundleIdentifier(for: clientInfo)
         else {
             return
         }
 
-        guard attemptedBundleIdentifiers.insert(bundleIdentifier).inserted else {
-            return
-        }
-
         Task.detached(priority: .utility) {
-            await FocusDiagnosticsStore.shared.record(
-                "AutomationPermission preflight-start session=\(sessionId) bundle=\(bundleIdentifier)"
-            )
-
-            let runningApplication = await MainActor.run {
-                NSRunningApplication.runningApplications(withBundleIdentifier: bundleIdentifier)
-                    .first { !$0.isTerminated }
-            }
-
-            guard let runningApplication else {
-                await FocusDiagnosticsStore.shared.record(
-                    "AutomationPermission preflight-skip-no-running-app session=\(sessionId) bundle=\(bundleIdentifier)"
-                )
-                return
-            }
-
-            let targetDescriptor = NSAppleEventDescriptor(
-                processIdentifier: runningApplication.processIdentifier
-            )
-            guard let address = targetDescriptor.aeDesc else {
-                await FocusDiagnosticsStore.shared.record(
-                    "AutomationPermission preflight-skip-no-descriptor session=\(sessionId) bundle=\(bundleIdentifier) pid=\(runningApplication.processIdentifier)"
-                )
-                return
-            }
-
-            let status = AEDeterminePermissionToAutomateTarget(
-                address,
-                AEEventClass(typeWildCard),
-                AEEventID(typeWildCard),
-                true
-            )
-
-            await FocusDiagnosticsStore.shared.record(
-                "AutomationPermission preflight-result session=\(sessionId) bundle=\(bundleIdentifier) pid=\(runningApplication.processIdentifier) status=\(status)"
-            )
+            await self.preflightIfNeeded(bundleIdentifier: bundleIdentifier, sessionId: sessionId)
         }
     }
 
-    private func scriptableTerminalBundleIdentifier(for clientInfo: SessionClientInfo) -> String? {
+    func ensurePermissionIfNeeded(
+        terminalPid: Int,
+        bundleIdentifier: String,
+        sessionId: String?
+    ) async -> Bool {
+        guard Self.isAutomationPermissionRequired(bundleIdentifier: bundleIdentifier) else {
+            return true
+        }
+
+        guard let runningApplication = await MainActor.run(body: {
+            NSRunningApplication(processIdentifier: pid_t(terminalPid))
+        }), !runningApplication.isTerminated else {
+            await FocusDiagnosticsStore.shared.record(
+                "AutomationPermission focus-skip-no-running-app session=\(sessionId ?? "nil") bundle=\(bundleIdentifier) terminalPid=\(terminalPid)"
+            )
+            return false
+        }
+
+        let status = await determinePermissionStatus(
+            for: runningApplication,
+            askUserIfNeeded: true,
+            phase: "focus",
+            sessionId: sessionId
+        )
+        return status == noErr
+    }
+
+    static func scriptableTerminalBundleIdentifier(for clientInfo: SessionClientInfo) -> String? {
         switch clientInfo.terminalBundleIdentifier {
+        case "com.apple.Terminal":
+            return "com.apple.Terminal"
         case "com.googlecode.iterm2":
             if clientInfo.iTermSessionIdentifier?.isEmpty == false
                 || clientInfo.terminalSessionIdentifier?.isEmpty == false {
@@ -77,5 +67,77 @@ actor TerminalAutomationPermissionCoordinator {
         default:
             return nil
         }
+    }
+
+    static func isAutomationPermissionRequired(bundleIdentifier: String) -> Bool {
+        switch bundleIdentifier {
+        case "com.apple.Terminal", "com.googlecode.iterm2", "com.mitchellh.ghostty":
+            return true
+        default:
+            return false
+        }
+    }
+
+    private func preflightIfNeeded(bundleIdentifier: String, sessionId: String) async {
+        let runningApplication = await MainActor.run {
+            NSRunningApplication.runningApplications(withBundleIdentifier: bundleIdentifier)
+                .first { !$0.isTerminated }
+        }
+
+        guard let runningApplication else {
+            await FocusDiagnosticsStore.shared.record(
+                "AutomationPermission preflight-skip-no-running-app session=\(sessionId) bundle=\(bundleIdentifier)"
+            )
+            return
+        }
+
+        guard attemptedBundleIdentifiers.insert(bundleIdentifier).inserted else {
+            return
+        }
+
+        let status = await determinePermissionStatus(
+            for: runningApplication,
+            askUserIfNeeded: true,
+            phase: "preflight",
+            sessionId: sessionId
+        )
+
+        if status != noErr {
+            attemptedBundleIdentifiers.remove(bundleIdentifier)
+        }
+    }
+
+    private func determinePermissionStatus(
+        for runningApplication: NSRunningApplication,
+        askUserIfNeeded: Bool,
+        phase: String,
+        sessionId: String?
+    ) async -> OSStatus {
+        let bundleIdentifier = runningApplication.bundleIdentifier ?? "unknown"
+        await FocusDiagnosticsStore.shared.record(
+            "AutomationPermission \(phase)-start session=\(sessionId ?? "nil") bundle=\(bundleIdentifier) pid=\(runningApplication.processIdentifier) prompt=\(askUserIfNeeded)"
+        )
+
+        let targetDescriptor = NSAppleEventDescriptor(
+            processIdentifier: runningApplication.processIdentifier
+        )
+        guard let address = targetDescriptor.aeDesc else {
+            await FocusDiagnosticsStore.shared.record(
+                "AutomationPermission \(phase)-skip-no-descriptor session=\(sessionId ?? "nil") bundle=\(bundleIdentifier) pid=\(runningApplication.processIdentifier)"
+            )
+            return OSStatus(procNotFound)
+        }
+
+        let status = AEDeterminePermissionToAutomateTarget(
+            address,
+            AEEventClass(typeWildCard),
+            AEEventID(typeWildCard),
+            askUserIfNeeded
+        )
+
+        await FocusDiagnosticsStore.shared.record(
+            "AutomationPermission \(phase)-result session=\(sessionId ?? "nil") bundle=\(bundleIdentifier) pid=\(runningApplication.processIdentifier) status=\(status)"
+        )
+        return status
     }
 }

--- a/PingIsland/Services/Window/TerminalSessionFocuser.swift
+++ b/PingIsland/Services/Window/TerminalSessionFocuser.swift
@@ -109,6 +109,17 @@ actor TerminalSessionFocuser {
                 )
                 return false
             }
+            guard await TerminalAutomationPermissionCoordinator.shared.ensurePermissionIfNeeded(
+                terminalPid: terminalPid,
+                bundleIdentifier: bundleIdentifier,
+                sessionId: sessionId
+            ) else {
+                logger.debug("Automation permission unavailable for Terminal bundle \(bundleIdentifier, privacy: .public)")
+                await FocusDiagnosticsStore.shared.record(
+                    "TerminalFocus terminal skip-no-automation-permission terminalPid=\(terminalPid) sessionId=\(sessionId ?? "nil")"
+                )
+                return false
+            }
             return await runAppleScript(lines: terminalScriptLines(for: tty))
         case "com.googlecode.iterm2":
             let iTermSessionIdentifier = clientInfo?.iTermSessionIdentifier ?? clientInfo?.terminalSessionIdentifier
@@ -126,11 +137,33 @@ actor TerminalSessionFocuser {
             await FocusDiagnosticsStore.shared.record(
                 "TerminalFocus iterm applescript terminalPid=\(terminalPid) tty=\(tty ?? "nil") normalizedSessionIdentifier=\(normalizedITermSessionIdentifier(iTermSessionIdentifier) ?? "nil")"
             )
+            guard await TerminalAutomationPermissionCoordinator.shared.ensurePermissionIfNeeded(
+                terminalPid: terminalPid,
+                bundleIdentifier: bundleIdentifier,
+                sessionId: sessionId
+            ) else {
+                logger.debug("Automation permission unavailable for iTerm bundle \(bundleIdentifier, privacy: .public)")
+                await FocusDiagnosticsStore.shared.record(
+                    "TerminalFocus iterm skip-no-automation-permission terminalPid=\(terminalPid) sessionId=\(sessionId ?? "nil")"
+                )
+                return false
+            }
             return await focusITermSession(terminalPid: terminalPid, selector: selector)
         case "com.mitchellh.ghostty":
             await FocusDiagnosticsStore.shared.record(
                 "TerminalFocus ghostty applescript terminalPid=\(terminalPid) workspacePath=\(workspacePath ?? "nil")"
             )
+            guard await TerminalAutomationPermissionCoordinator.shared.ensurePermissionIfNeeded(
+                terminalPid: terminalPid,
+                bundleIdentifier: bundleIdentifier,
+                sessionId: sessionId
+            ) else {
+                logger.debug("Automation permission unavailable for Ghostty bundle \(bundleIdentifier, privacy: .public)")
+                await FocusDiagnosticsStore.shared.record(
+                    "TerminalFocus ghostty skip-no-automation-permission terminalPid=\(terminalPid) sessionId=\(sessionId ?? "nil")"
+                )
+                return false
+            }
             return await focusGhosttyTerminal(
                 terminalPid: terminalPid,
                 workspacePath: workspacePath

--- a/PingIslandTests/TerminalAutomationPermissionCoordinatorTests.swift
+++ b/PingIslandTests/TerminalAutomationPermissionCoordinatorTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import Ping_Island
+
+final class TerminalAutomationPermissionCoordinatorTests: XCTestCase {
+    func testScriptableTerminalBundleIdentifierIncludesTerminalApp() {
+        let clientInfo = SessionClientInfo(
+            kind: .claudeCode,
+            terminalBundleIdentifier: "com.apple.Terminal",
+            terminalProgram: "Apple_Terminal"
+        )
+
+        XCTAssertEqual(
+            TerminalAutomationPermissionCoordinator.scriptableTerminalBundleIdentifier(for: clientInfo),
+            "com.apple.Terminal"
+        )
+    }
+
+    func testScriptableTerminalBundleIdentifierRequiresTrackedITermSession() {
+        let missingIdentifiers = SessionClientInfo(
+            kind: .claudeCode,
+            terminalBundleIdentifier: "com.googlecode.iterm2",
+            terminalProgram: "iTerm.app"
+        )
+        let trackedSession = SessionClientInfo(
+            kind: .claudeCode,
+            terminalBundleIdentifier: "com.googlecode.iterm2",
+            terminalProgram: "iTerm.app",
+            terminalSessionIdentifier: "iterm-session-1"
+        )
+
+        XCTAssertNil(
+            TerminalAutomationPermissionCoordinator.scriptableTerminalBundleIdentifier(for: missingIdentifiers)
+        )
+        XCTAssertEqual(
+            TerminalAutomationPermissionCoordinator.scriptableTerminalBundleIdentifier(for: trackedSession),
+            "com.googlecode.iterm2"
+        )
+    }
+
+    func testAutomationPermissionRequirementMatchesScriptedTerminalBundles() {
+        XCTAssertTrue(
+            TerminalAutomationPermissionCoordinator.isAutomationPermissionRequired(
+                bundleIdentifier: "com.apple.Terminal"
+            )
+        )
+        XCTAssertTrue(
+            TerminalAutomationPermissionCoordinator.isAutomationPermissionRequired(
+                bundleIdentifier: "com.googlecode.iterm2"
+            )
+        )
+        XCTAssertTrue(
+            TerminalAutomationPermissionCoordinator.isAutomationPermissionRequired(
+                bundleIdentifier: "com.mitchellh.ghostty"
+            )
+        )
+        XCTAssertFalse(
+            TerminalAutomationPermissionCoordinator.isAutomationPermissionRequired(
+                bundleIdentifier: "com.todesktop.230313mzl4w4u92"
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- request terminal automation permission again from the live focus path so the first click can succeed after consent
- include Terminal.app in the scripted-terminal permission preflight, and keep preflight retryable when the target app was not ready yet
- add unit coverage for the automation-permission routing helpers

## Testing
- `xcodebuild -project PingIsland.xcodeproj -scheme PingIsland -configuration Debug CODE_SIGNING_ALLOWED=NO test -only-testing:PingIslandTests/TerminalAutomationPermissionCoordinatorTests`
- `xcodebuild -project PingIsland.xcodeproj -scheme PingIsland -configuration Debug CODE_SIGNING_ALLOWED=NO build`

Closes #16.