### PR TITLE
[codex] Enable signed GitHub Actions release packaging

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -30,7 +30,7 @@ concurrency:
 
 jobs:
   release:
-    name: Build and publish unsigned packages
+    name: Build and publish signed packages
     runs-on: macos-15
     timeout-minutes: 45
     env:
@@ -46,8 +46,97 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
 
-      - name: Build unsigned DMG and ZIP packages
-        run: ./scripts/package-unsigned.sh
+      - name: Validate release signing secrets
+        env:
+          BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          SPARKLE_APPCAST_URL: ${{ secrets.SPARKLE_APPCAST_URL }}
+          SPARKLE_PUBLIC_ED_KEY: ${{ secrets.SPARKLE_PUBLIC_ED_KEY }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          required=(
+            BUILD_CERTIFICATE_BASE64
+            P12_PASSWORD
+            KEYCHAIN_PASSWORD
+            APPLE_ID
+            APPLE_TEAM_ID
+            APPLE_APP_SPECIFIC_PASSWORD
+          )
+
+          for name in "${required[@]}"; do
+            if [ -z "${!name:-}" ]; then
+              echo "::error::Missing required repository secret: $name"
+              exit 1
+            fi
+          done
+
+          if [ -n "${SPARKLE_APPCAST_URL:-}" ] && [ -z "${SPARKLE_PUBLIC_ED_KEY:-}" ]; then
+            echo "::error::SPARKLE_PUBLIC_ED_KEY is required when SPARKLE_APPCAST_URL is set"
+            exit 1
+          fi
+
+          if [ -n "${SPARKLE_PUBLIC_ED_KEY:-}" ] && [ -z "${SPARKLE_APPCAST_URL:-}" ]; then
+            echo "::error::SPARKLE_APPCAST_URL is required when SPARKLE_PUBLIC_ED_KEY is set"
+            exit 1
+          fi
+
+      - name: Import Developer ID certificate
+        env:
+          BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          cert_path="$RUNNER_TEMP/build_certificate.p12"
+          keychain_path="$RUNNER_TEMP/ping-island-signing.keychain-db"
+
+          if ! echo "$BUILD_CERTIFICATE_BASE64" | base64 --decode > "$cert_path" 2>/dev/null; then
+            echo "$BUILD_CERTIFICATE_BASE64" | base64 -D > "$cert_path"
+          fi
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$keychain_path"
+          security set-keychain-settings -lut 21600 "$keychain_path"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$keychain_path"
+          security import "$cert_path" -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k "$keychain_path"
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$keychain_path"
+          security default-keychain -s "$keychain_path"
+
+          existing_keychains=$(security list-keychains -d user | tr -d '"' | xargs)
+          security list-keychains -d user -s "$keychain_path" $existing_keychains
+          security find-identity -v -p codesigning "$keychain_path"
+
+      - name: Inject Sparkle release config
+        if: ${{ secrets.SPARKLE_APPCAST_URL != '' && secrets.SPARKLE_PUBLIC_ED_KEY != '' }}
+        shell: bash
+        env:
+          SPARKLE_APPCAST_URL: ${{ secrets.SPARKLE_APPCAST_URL }}
+          SPARKLE_PUBLIC_ED_KEY: ${{ secrets.SPARKLE_PUBLIC_ED_KEY }}
+        run: |
+          set -euo pipefail
+
+          printf 'SPARKLE_APPCAST_URL = %s\nSPARKLE_PUBLIC_ED_KEY = %s\n' \
+            "$SPARKLE_APPCAST_URL" \
+            "$SPARKLE_PUBLIC_ED_KEY" \
+            > Config/LocalSecrets.xcconfig
+
+      - name: Build signed DMG and ZIP packages
+        env:
+          PING_ISLAND_BUILD_DIR: ${{ github.workspace }}/build/release
+          PING_ISLAND_RELEASE_DIR: ${{ github.workspace }}/releases/signed
+          PING_ISLAND_KEYCHAIN_PATH: ${{ runner.temp }}/ping-island-signing.keychain-db
+          PING_ISLAND_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          PING_ISLAND_NOTARY_APPLE_ID: ${{ secrets.APPLE_ID }}
+          PING_ISLAND_NOTARY_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          PING_ISLAND_NOTARY_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+        run: ./scripts/package-release.sh
 
       - name: Collect release metadata
         id: meta
@@ -56,20 +145,20 @@ jobs:
           set -euo pipefail
 
           shopt -s nullglob
-          dmg_assets=(releases/unsigned/*.dmg)
-          zip_assets=(releases/unsigned/*.zip)
+          dmg_assets=(releases/signed/*.dmg)
+          zip_assets=(releases/signed/*.zip)
 
           if [ "${#dmg_assets[@]}" -ne 1 ]; then
-            echo "::error::Expected exactly one DMG asset in releases/unsigned, found ${#dmg_assets[@]}"
+            echo "::error::Expected exactly one DMG asset in releases/signed, found ${#dmg_assets[@]}"
             exit 1
           fi
 
           if [ "${#zip_assets[@]}" -ne 1 ]; then
-            echo "::error::Expected exactly one ZIP asset in releases/unsigned, found ${#zip_assets[@]}"
+            echo "::error::Expected exactly one ZIP asset in releases/signed, found ${#zip_assets[@]}"
             exit 1
           fi
 
-          app_path="build/unsigned/DerivedData/Build/Products/Release/Ping Island.app"
+          app_path="build/release/export/Ping Island.app"
           if [ ! -d "$app_path" ]; then
             echo "::error::Expected built app bundle at $app_path"
             exit 1
@@ -117,17 +206,17 @@ jobs:
           set -euo pipefail
 
           notes_file="$RUNNER_TEMP/release-notes.md"
-          warning_block='> Warning: These GitHub Actions artifacts are unsigned local-test builds. Ping Island re-signs the app bundle with a consistent ad-hoc signature, but macOS may still require right-click Open or manual quarantine removal on first launch.'
+          release_block='> Built, signed with Developer ID, and notarized on GitHub Actions.'
 
           if [ "${{ steps.meta.outputs.has_notes }}" = "true" ]; then
             cp "${{ steps.meta.outputs.notes_path }}" "$notes_file"
-            printf '\n\n%s\n' "$warning_block" >> "$notes_file"
+            printf '\n\n%s\n' "$release_block" >> "$notes_file"
           else
             printf 'Release build for %s.\n\nIncluded assets:\n- %s\n- %s\n\n%s\n' \
               "$RELEASE_TAG" \
               "$(basename "${{ steps.meta.outputs.dmg_path }}")" \
               "$(basename "${{ steps.meta.outputs.zip_path }}")" \
-              "$warning_block" \
+              "$release_block" \
               > "$notes_file"
           fi
 
@@ -185,3 +274,13 @@ jobs:
             --prerelease="$RELEASE_PRERELEASE"
 
           gh release view "$RELEASE_TAG" --repo "$repo"
+
+      - name: Cleanup signing material
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          rm -f Config/LocalSecrets.xcconfig
+          rm -f "$RUNNER_TEMP/build_certificate.p12"
+          security delete-keychain "$RUNNER_TEMP/ping-island-signing.keychain-db" || true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,10 +103,11 @@ This file is a routing layer for coding agents working in this repo. Keep it sho
   - `./scripts/render-mascots.sh`
 - Release automation:
   - `./scripts/build.sh`
+  - `./scripts/package-release.sh`
   - `./scripts/package-unsigned.sh`
   - `./scripts/create-release.sh`
   - `./scripts/generate-keys.sh`
-  - GitHub Actions: `.github/workflows/release-packages.yml` publishes unsigned `dmg` / `zip` assets to the matching GitHub Release for a `v*` tag or manual dispatch
+  - GitHub Actions: `.github/workflows/release-packages.yml` imports a Developer ID certificate from repository secrets, notarizes the exported app, and publishes signed `dmg` / `zip` assets to the matching GitHub Release for a `v*` tag or manual dispatch
 - Release scripts assume local signing and notarization tooling. They may modify `build/`, `releases/`, and `.sparkle-keys/`.
 
 ## Working Rules

--- a/Config/LocalSecrets.example.xcconfig
+++ b/Config/LocalSecrets.example.xcconfig
@@ -1,4 +1,5 @@
 // Copy to Config/LocalSecrets.xcconfig and fill in your real values.
+// GitHub Actions release builds can inject the same values from repository secrets.
 
 SPARKLE_APPCAST_URL = https://example.com/appcast.xml
 SPARKLE_PUBLIC_ED_KEY = REPLACE_WITH_SPARKLE_PUBLIC_ED_KEY

--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ To create a locally shareable unsigned package for local testing:
 
 The script re-signs the built app bundle with a consistent ad-hoc signature before creating the `.dmg` and `.zip`, which helps embedded frameworks launch more reliably on another machine. The package is still unsigned for distribution and not notarized, so first launch may still require `Open` from Finder's context menu or manual quarantine removal.
 
+To create signed and notarized release packages in GitHub Actions, configure the release secrets described in [docs/sparkle-release.md](docs/sparkle-release.md) and run `.github/workflows/release-packages.yml` against a `v*` tag or the manual workflow dispatch input.
+
 For the full notarized release flow and Sparkle appcast setup, see [docs/sparkle-release.md](docs/sparkle-release.md).
 
 ## Testing

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -124,6 +124,8 @@ xcodebuild -project PingIsland.xcodeproj -scheme PingIsland -configuration Relea
 ./scripts/package-unsigned.sh
 ```
 
+如果你想通过 GitHub Actions 产出带 `Developer ID` 签名并完成 notarization 的发布包，请先按 [docs/sparkle-release.md](docs/sparkle-release.md) 配好仓库 secrets，再运行 `.github/workflows/release-packages.yml`。
+
 完整的 Sparkle / notarization 发布流程见 [docs/sparkle-release.md](docs/sparkle-release.md)。
 
 ## 测试

--- a/docs/sparkle-release.md
+++ b/docs/sparkle-release.md
@@ -1,41 +1,83 @@
 # Sparkle Release Setup
 
-## GitHub Release packages
+## Signed GitHub Actions releases
 
-The repo also ships `.github/workflows/release-packages.yml` for GitHub-hosted packaging.
+The repo ships `.github/workflows/release-packages.yml` for GitHub-hosted release packaging.
 
-- It builds the unsigned release app on `macos-15`.
-- It runs `./scripts/package-unsigned.sh` to generate both `.dmg` and `.zip`.
+- It runs on `macos-15`.
+- It imports your `Developer ID Application` certificate into a temporary keychain.
+- It archives and exports the app through `./scripts/package-release.sh`.
+- It notarizes the exported app bundle, staples it, then creates signed `.zip` and `.dmg` artifacts.
 - It publishes those assets to the matching GitHub Release for a `v*` tag.
 - It is safe to rerun after a partially failed publish; the workflow reuses the existing tag release, re-uploads assets with `--clobber`, and then updates the final draft / prerelease state.
-- It re-signs the built app bundle with a consistent ad-hoc signature before packaging so embedded frameworks and helpers keep a matching local-test signature.
-- It does not notarize, staple, or generate Sparkle appcast assets.
 
-Use that workflow when you want downloadable GitHub Release artifacts without the local signing / notarization toolchain. Those artifacts are still local-test-only unsigned builds, and macOS may require `Open` from Finder's context menu or manual quarantine removal on first launch. Use the flow below when you need the notarized Sparkle release path.
+If you have an individual Apple Developer account, that is fine: you do not need a company account for this flow. You do need a `Developer ID Application` certificate. A plain `Apple Development` certificate is not enough for signed, notarized downloads distributed outside the Mac App Store.
 
-## One-time setup
+### Required repository secrets
+
+Set these in `Settings -> Secrets and variables -> Actions`:
+
+| Secret | Purpose |
+| --- | --- |
+| `BUILD_CERTIFICATE_BASE64` | Base64-encoded `.p12` export of your `Developer ID Application` certificate |
+| `P12_PASSWORD` | Password used when exporting the `.p12` |
+| `KEYCHAIN_PASSWORD` | Password for the temporary CI keychain |
+| `APPLE_ID` | Apple ID email used for notarization |
+| `APPLE_TEAM_ID` | Your Apple Developer Team ID |
+| `APPLE_APP_SPECIFIC_PASSWORD` | App-specific password for `notarytool` |
+
+Optional secrets:
+
+| Secret | Purpose |
+| --- | --- |
+| `SPARKLE_APPCAST_URL` | Feed URL compiled into the app for Sparkle update checks |
+| `SPARKLE_PUBLIC_ED_KEY` | Public EdDSA key compiled into the app for Sparkle validation |
+
+### Export the signing certificate
+
+1. Open `Keychain Access`.
+2. Export the `Developer ID Application` identity as a `.p12`.
+3. Base64-encode it:
+
+```bash
+base64 -i developer-id-application.p12 | pbcopy
+```
+
+4. Paste the result into the `BUILD_CERTIFICATE_BASE64` secret.
+
+### Trigger the workflow
+
+1. Create release notes at `releases/notes/<version>.md`.
+   - Use `releases/notes/README.md` as the authoring template.
+2. Make sure the app version matches the release tag.
+3. Push a tag like `v0.0.1`, or open the workflow manually with the same tag name.
+
+The workflow will upload the signed `.dmg` and `.zip` to the matching GitHub Release and add a short note that the artifacts were signed and notarized in CI.
+
+## Local Sparkle release flow
+
+If you want the full local release path including Sparkle appcast generation and website update:
 
 1. Copy `Config/LocalSecrets.example.xcconfig` to `Config/LocalSecrets.xcconfig`.
 2. Fill in:
    - `SPARKLE_APPCAST_URL`
    - `SPARKLE_PUBLIC_ED_KEY`
-3. Generate signing keys if you have not already:
+3. Generate Sparkle signing keys if you have not already:
 
 ```bash
 ./scripts/generate-keys.sh
 ```
 
-## Per-release flow
-
-1. Create release notes at `releases/notes/<version>.md`.
-   - Use `releases/notes/README.md` as the authoring template.
-2. Build the app:
+4. Store notarization credentials locally:
 
 ```bash
-./scripts/build.sh
+xcrun notarytool store-credentials "PingIsland" \
+  --apple-id "your@email.com" \
+  --team-id "YOURTEAMID" \
+  --password "xxxx-xxxx-xxxx-xxxx"
 ```
 
-3. Create the notarized DMG, appcast, and release assets:
+5. Create the notarized DMG, appcast, and release assets:
 
 ```bash
 ./scripts/create-release.sh
@@ -43,8 +85,7 @@ Use that workflow when you want downloadable GitHub Release artifacts without th
 
 ## Notes
 
-- The GitHub Actions release-packaging workflow is intentionally separate from the Sparkle release flow above.
 - `Config/LocalSecrets.xcconfig` is intentionally gitignored.
-- `scripts/create-release.sh` will package `releases/notes/<version>.md` as `PingIsland-<version>.md`.
-- `scripts/create-release.sh` also uses `releases/notes/<version>.md` as the GitHub Release body when the file exists, and falls back to a short built-in message otherwise.
+- `scripts/package-release.sh` is the shared build + sign + notarize packaging entrypoint used by both local release tooling and GitHub Actions.
+- `scripts/create-release.sh` packages `releases/notes/<version>.md` as `PingIsland-<version>.md` and uses it as the GitHub Release body when present.
 - The app prefers Markdown release notes and falls back to Sparkle's explicit release notes links when Markdown is unavailable.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,12 +1,20 @@
 #!/bin/bash
 # Build Ping Island for release
-set -e
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
-BUILD_DIR="$PROJECT_DIR/build"
+BUILD_DIR="${PING_ISLAND_BUILD_DIR:-$PROJECT_DIR/build}"
+DERIVED_DATA_PATH="$BUILD_DIR/DerivedData"
 ARCHIVE_PATH="$BUILD_DIR/PingIsland.xcarchive"
 EXPORT_PATH="$BUILD_DIR/export"
+KEYCHAIN_PATH="${PING_ISLAND_KEYCHAIN_PATH:-}"
+TEAM_ID="${PING_ISLAND_TEAM_ID:-}"
+EXPORT_METHOD="${PING_ISLAND_EXPORT_METHOD:-developer-id}"
+SIGNING_CERTIFICATE="${PING_ISLAND_SIGNING_CERTIFICATE:-Developer ID Application}"
+ENABLE_HARDENED_RUNTIME="${PING_ISLAND_ENABLE_HARDENED_RUNTIME:-YES}"
+SCHEME="${PING_ISLAND_SCHEME:-PingIsland}"
+PROJECT_FILE="${PING_ISLAND_PROJECT_FILE:-PingIsland.xcodeproj}"
 
 echo "=== Building Ping Island ==="
 echo ""
@@ -17,53 +25,76 @@ mkdir -p "$BUILD_DIR"
 
 cd "$PROJECT_DIR"
 
+archive_args=(
+    xcodebuild archive
+    -project "$PROJECT_FILE"
+    -scheme "$SCHEME"
+    -configuration Release
+    -derivedDataPath "$DERIVED_DATA_PATH"
+    -archivePath "$ARCHIVE_PATH"
+    -destination "generic/platform=macOS"
+    ENABLE_HARDENED_RUNTIME="$ENABLE_HARDENED_RUNTIME"
+    CODE_SIGN_STYLE=Automatic
+)
+
+if [ -n "$TEAM_ID" ]; then
+    archive_args+=(DEVELOPMENT_TEAM="$TEAM_ID")
+fi
+
+if [ -n "$KEYCHAIN_PATH" ]; then
+    archive_args+=(OTHER_CODE_SIGN_FLAGS="--keychain $KEYCHAIN_PATH")
+fi
+
 # Build and archive
 echo "Archiving..."
-xcodebuild archive \
-    -project PingIsland.xcodeproj \
-    -scheme PingIsland \
-    -configuration Release \
-    -archivePath "$ARCHIVE_PATH" \
-    -destination "generic/platform=macOS" \
-    ENABLE_HARDENED_RUNTIME=YES \
-    CODE_SIGN_STYLE=Automatic \
-    | xcpretty || xcodebuild archive \
-    -project PingIsland.xcodeproj \
-    -scheme PingIsland \
-    -configuration Release \
-    -archivePath "$ARCHIVE_PATH" \
-    -destination "generic/platform=macOS" \
-    ENABLE_HARDENED_RUNTIME=YES \
-    CODE_SIGN_STYLE=Automatic
+if command -v xcpretty >/dev/null 2>&1; then
+    "${archive_args[@]}" | xcpretty
+else
+    "${archive_args[@]}"
+fi
 
 # Create ExportOptions.plist if it doesn't exist
 EXPORT_OPTIONS="$BUILD_DIR/ExportOptions.plist"
-cat > "$EXPORT_OPTIONS" << 'EOF'
+cat > "$EXPORT_OPTIONS" <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
     <key>method</key>
-    <string>developer-id</string>
+    <string>$EXPORT_METHOD</string>
     <key>destination</key>
     <string>export</string>
     <key>signingStyle</key>
     <string>automatic</string>
+    <key>signingCertificate</key>
+    <string>$SIGNING_CERTIFICATE</string>
 </dict>
 </plist>
 EOF
 
+if [ -n "$TEAM_ID" ]; then
+    /usr/libexec/PlistBuddy -c "Add :teamID string $TEAM_ID" "$EXPORT_OPTIONS"
+fi
+
+export_args=(
+    xcodebuild -exportArchive
+    -archivePath "$ARCHIVE_PATH"
+    -exportPath "$EXPORT_PATH"
+    -exportOptionsPlist "$EXPORT_OPTIONS"
+)
+
+if [ -n "$KEYCHAIN_PATH" ]; then
+    export_args+=(OTHER_CODE_SIGN_FLAGS="--keychain $KEYCHAIN_PATH")
+fi
+
 # Export the archive
 echo ""
 echo "Exporting..."
-xcodebuild -exportArchive \
-    -archivePath "$ARCHIVE_PATH" \
-    -exportPath "$EXPORT_PATH" \
-    -exportOptionsPlist "$EXPORT_OPTIONS" \
-    | xcpretty || xcodebuild -exportArchive \
-    -archivePath "$ARCHIVE_PATH" \
-    -exportPath "$EXPORT_PATH" \
-    -exportOptionsPlist "$EXPORT_OPTIONS"
+if command -v xcpretty >/dev/null 2>&1; then
+    "${export_args[@]}" | xcpretty
+else
+    "${export_args[@]}"
+fi
 
 echo ""
 echo "=== Build Complete ==="

--- a/scripts/create-release.sh
+++ b/scripts/create-release.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
-# Create a release: notarize, create DMG, sign for Sparkle, upload to GitHub, update website
-set -e
+# Create a release: build, notarize, create DMG, optionally sign for Sparkle, upload to GitHub, update website
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
-BUILD_DIR="$PROJECT_DIR/build"
+BUILD_DIR="${PING_ISLAND_BUILD_DIR:-$PROJECT_DIR/build/release}"
 EXPORT_PATH="$BUILD_DIR/export"
-RELEASE_DIR="$PROJECT_DIR/releases"
-KEYS_DIR="$PROJECT_DIR/.sparkle-keys"
+RELEASE_DIR="${PING_ISLAND_RELEASE_DIR:-$PROJECT_DIR/releases/signed}"
+NOTES_DIR="$PROJECT_DIR/releases/notes"
 
 # GitHub repository (owner/repo format)
 GITHUB_REPO="${PING_ISLAND_GITHUB_REPO:-farouqaldori/ping-island}"
@@ -18,22 +18,33 @@ WEBSITE_PUBLIC="$WEBSITE_DIR/public"
 
 APP_PATH="$EXPORT_PATH/Ping Island.app"
 APP_NAME="PingIsland"
-KEYCHAIN_PROFILE="PingIsland"
-NOTES_DIR="$PROJECT_DIR/releases/notes"
+NOTARY_PROFILE="${PING_ISLAND_NOTARY_KEYCHAIN_PROFILE:-PingIsland}"
 
 echo "=== Creating Release ==="
 echo ""
 
-# Check if app exists
+export PING_ISLAND_BUILD_DIR="$BUILD_DIR"
+export PING_ISLAND_RELEASE_DIR="$RELEASE_DIR"
+export PING_ISLAND_GENERATE_APPCAST=1
+export PING_ISLAND_NOTARY_KEYCHAIN_PROFILE="$NOTARY_PROFILE"
+
+"$SCRIPT_DIR/package-release.sh"
+
 if [ ! -d "$APP_PATH" ]; then
     echo "ERROR: App not found at $APP_PATH"
-    echo "Run ./scripts/build.sh first"
     exit 1
 fi
 
-# Get version from app
 VERSION=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$APP_PATH/Contents/Info.plist")
 BUILD=$(/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" "$APP_PATH/Contents/Info.plist")
+DMG_PATH="$RELEASE_DIR/$APP_NAME-$VERSION-$BUILD.dmg"
+NOTES_PATH="$NOTES_DIR/$VERSION.md"
+NOTES_ASSET_PATH="$RELEASE_DIR/$APP_NAME-$VERSION.md"
+
+if [ ! -f "$DMG_PATH" ]; then
+    echo "ERROR: DMG not found at $DMG_PATH"
+    exit 1
+fi
 
 echo "Version: $VERSION (build $BUILD)"
 echo ""
@@ -41,187 +52,17 @@ echo ""
 mkdir -p "$RELEASE_DIR" "$NOTES_DIR"
 
 # ============================================
-# Step 1: Notarize the app
+# Step 1: Create GitHub Release
 # ============================================
-echo "=== Step 1: Notarizing ==="
+echo "=== Step 1: Creating GitHub Release ==="
 
-# Check if keychain profile exists
-if ! xcrun notarytool history --keychain-profile "$KEYCHAIN_PROFILE" &>/dev/null; then
-    echo ""
-    echo "No keychain profile found. Set up credentials with:"
-    echo ""
-    echo "  xcrun notarytool store-credentials \"$KEYCHAIN_PROFILE\" \\"
-    echo "      --apple-id \"your@email.com\" \\"
-    echo "      --team-id \"2DKS5U9LV4\" \\"
-    echo "      --password \"xxxx-xxxx-xxxx-xxxx\""
-    echo ""
-    echo "Create an app-specific password at: https://appleid.apple.com"
-    echo ""
-    read -p "Skip notarization for now? (y/N) " -n 1 -r
-    echo
-    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-        exit 1
-    fi
-    SKIP_NOTARIZATION=true
-    echo "WARNING: Skipping notarization. Users will see Gatekeeper warnings!"
-else
-    # Create zip for notarization
-    ZIP_PATH="$BUILD_DIR/$APP_NAME-$VERSION.zip"
-    echo "Creating zip for notarization..."
-    ditto -c -k --keepParent "$APP_PATH" "$ZIP_PATH"
+GITHUB_DOWNLOAD_URL=""
 
-    echo "Submitting for notarization..."
-    xcrun notarytool submit "$ZIP_PATH" \
-        --keychain-profile "$KEYCHAIN_PROFILE" \
-        --wait
-
-    echo "Stapling notarization ticket..."
-    xcrun stapler staple "$APP_PATH"
-
-    rm "$ZIP_PATH"
-    echo "Notarization complete!"
-fi
-
-echo ""
-
-# ============================================
-# Step 2: Create DMG
-# ============================================
-echo "=== Step 2: Creating DMG ==="
-
-DMG_PATH="$RELEASE_DIR/$APP_NAME-$VERSION.dmg"
-NOTES_PATH="$NOTES_DIR/$VERSION.md"
-NOTES_ASSET_PATH="$RELEASE_DIR/$APP_NAME-$VERSION.md"
-
-# Remove existing DMG if present
-if [ -f "$DMG_PATH" ]; then
-    echo "Removing existing DMG..."
-    rm -f "$DMG_PATH"
-fi
-
-# Check if create-dmg is available (prettier DMG)
-if command -v create-dmg &> /dev/null; then
-    echo "Using create-dmg for prettier output..."
-    create-dmg \
-        --volname "Ping Island" \
-        --window-size 600 400 \
-        --icon-size 100 \
-        --icon "Ping Island.app" 150 200 \
-        --app-drop-link 450 200 \
-        --hide-extension "Ping Island.app" \
-        "$DMG_PATH" \
-        "$APP_PATH"
-else
-    echo "Using hdiutil (install create-dmg for prettier DMG: brew install create-dmg)"
-    hdiutil create -volname "Ping Island" \
-        -srcfolder "$APP_PATH" \
-        -ov -format UDZO \
-        "$DMG_PATH"
-fi
-
-echo "DMG created: $DMG_PATH"
-
-if [ -f "$NOTES_PATH" ]; then
-    cp "$NOTES_PATH" "$NOTES_ASSET_PATH"
-    echo "Release notes copied: $NOTES_ASSET_PATH"
-else
-    echo "WARNING: No markdown release notes found at $NOTES_PATH"
-fi
-echo ""
-
-# ============================================
-# Step 3: Notarize the DMG
-# ============================================
-if [ -z "$SKIP_NOTARIZATION" ]; then
-    echo "=== Step 3: Notarizing DMG ==="
-
-    xcrun notarytool submit "$DMG_PATH" \
-        --keychain-profile "$KEYCHAIN_PROFILE" \
-        --wait
-
-    xcrun stapler staple "$DMG_PATH"
-    echo "DMG notarized!"
-    echo ""
-fi
-
-# ============================================
-# Step 4: Sign for Sparkle and generate appcast
-# ============================================
-echo "=== Step 4: Signing for Sparkle ==="
-
-# Find Sparkle tools
-SPARKLE_SIGN=""
-GENERATE_APPCAST=""
-
-POSSIBLE_PATHS=(
-    "$HOME/Library/Developer/Xcode/DerivedData/PingIsland-*/SourcePackages/artifacts/sparkle/Sparkle/bin"
-)
-
-for path_pattern in "${POSSIBLE_PATHS[@]}"; do
-    for path in $path_pattern; do
-        if [ -x "$path/sign_update" ]; then
-            SPARKLE_SIGN="$path/sign_update"
-            GENERATE_APPCAST="$path/generate_appcast"
-            break 2
-        fi
-    done
-done
-
-if [ -z "$SPARKLE_SIGN" ]; then
-    echo "WARNING: Could not find Sparkle tools."
-    echo "Build the project in Xcode first to download Sparkle package."
-    echo ""
-    echo "Skipping Sparkle signing. You'll need to manually:"
-    echo "1. Sign the DMG with sign_update"
-    echo "2. Generate appcast with generate_appcast"
-else
-    # Check for private key
-    if [ ! -f "$KEYS_DIR/eddsa_private_key" ]; then
-        echo "WARNING: No private key found at $KEYS_DIR/eddsa_private_key"
-        echo "Run ./scripts/generate-keys.sh first"
-        echo ""
-        echo "Skipping Sparkle signing."
-    else
-        # Generate signature
-        echo "Signing DMG for Sparkle..."
-        SIGNATURE=$("$SPARKLE_SIGN" --ed-key-file "$KEYS_DIR/eddsa_private_key" "$DMG_PATH")
-
-        echo ""
-        echo "Sparkle signature:"
-        echo "$SIGNATURE"
-        echo ""
-
-        # Generate/update appcast
-        echo "Generating appcast..."
-        APPCAST_DIR="$RELEASE_DIR/appcast"
-        mkdir -p "$APPCAST_DIR"
-
-        # Copy DMG to appcast directory
-        cp "$DMG_PATH" "$APPCAST_DIR/"
-        if [ -f "$NOTES_ASSET_PATH" ]; then
-            cp "$NOTES_ASSET_PATH" "$APPCAST_DIR/"
-        fi
-
-        # Generate appcast.xml
-        "$GENERATE_APPCAST" --ed-key-file "$KEYS_DIR/eddsa_private_key" "$APPCAST_DIR"
-
-        echo "Appcast generated at: $APPCAST_DIR/appcast.xml"
-    fi
-fi
-
-echo ""
-
-# ============================================
-# Step 5: Create GitHub Release
-# ============================================
-echo "=== Step 5: Creating GitHub Release ==="
-
-if ! command -v gh &> /dev/null; then
+if ! command -v gh >/dev/null 2>&1; then
     echo "WARNING: gh CLI not found. Install with: brew install gh"
     echo "Skipping GitHub release."
 else
-    # Check if release already exists
-    if gh release view "v$VERSION" --repo "$GITHUB_REPO" &>/dev/null; then
+    if gh release view "v$VERSION" --repo "$GITHUB_REPO" >/dev/null 2>&1; then
         echo "Release v$VERSION already exists. Updating..."
         gh release upload "v$VERSION" "$DMG_PATH" --repo "$GITHUB_REPO" --clobber
         if [ -f "$NOTES_ASSET_PATH" ]; then
@@ -252,7 +93,7 @@ else
                 --notes "## Ping Island v$VERSION
 
 ### Installation
-1. Download \`$APP_NAME-$VERSION.dmg\`
+1. Download \`$(basename "$DMG_PATH")\`
 2. Open the DMG and drag Ping Island to Applications
 3. Launch Ping Island from Applications
 
@@ -261,7 +102,7 @@ After installation, Ping Island will automatically check for updates."
         fi
     fi
 
-    GITHUB_DOWNLOAD_URL="https://github.com/$GITHUB_REPO/releases/download/v$VERSION/$APP_NAME-$VERSION.dmg"
+    GITHUB_DOWNLOAD_URL="https://github.com/$GITHUB_REPO/releases/download/v$VERSION/$(basename "$DMG_PATH")"
     echo "GitHub release created: https://github.com/$GITHUB_REPO/releases/tag/v$VERSION"
     echo "Download URL: $GITHUB_DOWNLOAD_URL"
 fi
@@ -269,24 +110,21 @@ fi
 echo ""
 
 # ============================================
-# Step 6: Update website appcast and deploy
+# Step 2: Update website appcast and deploy
 # ============================================
-echo "=== Step 6: Updating Website ==="
+echo "=== Step 2: Updating Website ==="
 
 if [ -d "$WEBSITE_PUBLIC" ] && [ -f "$RELEASE_DIR/appcast/appcast.xml" ]; then
-    # Copy appcast to website
     cp "$RELEASE_DIR/appcast/appcast.xml" "$WEBSITE_PUBLIC/appcast.xml"
     if [ -f "$NOTES_ASSET_PATH" ]; then
         cp "$NOTES_ASSET_PATH" "$WEBSITE_PUBLIC/"
     fi
 
-    # Update the download URL in appcast to point to GitHub releases
     if [ -n "$GITHUB_DOWNLOAD_URL" ]; then
-        sed -i '' "s|url=\"[^\"]*$APP_NAME-$VERSION.dmg\"|url=\"$GITHUB_DOWNLOAD_URL\"|g" "$WEBSITE_PUBLIC/appcast.xml"
+        sed -i '' "s|url=\"[^\"]*$(basename "$DMG_PATH")\"|url=\"$GITHUB_DOWNLOAD_URL\"|g" "$WEBSITE_PUBLIC/appcast.xml"
         echo "Updated appcast.xml with GitHub download URL"
     fi
 
-    # Update src/config.ts with latest version and download URL
     CONFIG_FILE="$WEBSITE_DIR/src/config.ts"
     if [ -n "$GITHUB_DOWNLOAD_URL" ]; then
         cat > "$CONFIG_FILE" << EOF
@@ -297,7 +135,6 @@ EOF
         echo "Updated src/config.ts with version $VERSION"
     fi
 
-    # Commit and push website changes
     cd "$WEBSITE_DIR"
     if [ -d ".git" ]; then
         git add public/appcast.xml src/config.ts
@@ -330,7 +167,6 @@ else
 fi
 
 echo ""
-
 echo "=== Release Complete ==="
 echo ""
 echo "Files created:"

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -1,0 +1,215 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+BUILD_DIR="${PING_ISLAND_BUILD_DIR:-$PROJECT_DIR/build/release}"
+DERIVED_DATA_PATH="$BUILD_DIR/DerivedData"
+EXPORT_PATH="$BUILD_DIR/export"
+RELEASE_DIR="${PING_ISLAND_RELEASE_DIR:-$PROJECT_DIR/releases/signed}"
+NOTES_DIR="$PROJECT_DIR/releases/notes"
+KEYS_DIR="$PROJECT_DIR/.sparkle-keys"
+STAGING_DIR="$BUILD_DIR/dmg-staging"
+
+APP_BUNDLE_NAME="Ping Island.app"
+APP_PRODUCT_NAME="PingIsland"
+APP_PATH="$EXPORT_PATH/$APP_BUNDLE_NAME"
+
+NOTARY_APPLE_ID="${PING_ISLAND_NOTARY_APPLE_ID:-${APPLE_ID:-}}"
+NOTARY_TEAM_ID="${PING_ISLAND_NOTARY_TEAM_ID:-${APPLE_TEAM_ID:-}}"
+NOTARY_PASSWORD="${PING_ISLAND_NOTARY_PASSWORD:-${APPLE_APP_SPECIFIC_PASSWORD:-}}"
+NOTARY_KEYCHAIN_PROFILE="${PING_ISLAND_NOTARY_KEYCHAIN_PROFILE:-${NOTARY_KEYCHAIN_PROFILE:-PingIsland}}"
+SKIP_NOTARIZATION="${PING_ISLAND_SKIP_NOTARIZATION:-0}"
+
+SPARKLE_PRIVATE_KEY_PATH="${PING_ISLAND_SPARKLE_PRIVATE_KEY_PATH:-$KEYS_DIR/eddsa_private_key}"
+GENERATE_APPCAST="${PING_ISLAND_GENERATE_APPCAST:-0}"
+
+notary_args=()
+
+log_section() {
+    echo ""
+    echo "=== $1 ==="
+}
+
+require_command() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "ERROR: Missing required command: $1"
+        exit 1
+    fi
+}
+
+resolve_notary_credentials() {
+    if [ "$SKIP_NOTARIZATION" = "1" ]; then
+        return
+    fi
+
+    if [ -n "$NOTARY_APPLE_ID" ] && [ -n "$NOTARY_TEAM_ID" ] && [ -n "$NOTARY_PASSWORD" ]; then
+        notary_args=(
+            --apple-id "$NOTARY_APPLE_ID"
+            --team-id "$NOTARY_TEAM_ID"
+            --password "$NOTARY_PASSWORD"
+        )
+        return
+    fi
+
+    if xcrun notarytool history --keychain-profile "$NOTARY_KEYCHAIN_PROFILE" >/dev/null 2>&1; then
+        notary_args=(--keychain-profile "$NOTARY_KEYCHAIN_PROFILE")
+        return
+    fi
+
+    echo "ERROR: No usable notarization credentials were found."
+    echo "Provide one of:"
+    echo "  1. PING_ISLAND_NOTARY_APPLE_ID / PING_ISLAND_NOTARY_TEAM_ID / PING_ISLAND_NOTARY_PASSWORD"
+    echo "  2. A notarytool keychain profile named '$NOTARY_KEYCHAIN_PROFILE'"
+    echo ""
+    echo "You can skip notarization explicitly with PING_ISLAND_SKIP_NOTARIZATION=1."
+    exit 1
+}
+
+notarize_and_staple() {
+    local submit_path="$1"
+    local staple_path="$2"
+
+    if [ "$SKIP_NOTARIZATION" = "1" ]; then
+        echo "Skipping notarization for $submit_path"
+        return
+    fi
+
+    echo "Submitting $(basename "$submit_path") for notarization..."
+    xcrun notarytool submit "$submit_path" "${notary_args[@]}" --wait
+
+    echo "Stapling $(basename "$staple_path")..."
+    xcrun stapler staple "$staple_path"
+    xcrun stapler validate "$staple_path"
+}
+
+find_sparkle_bin_dir() {
+    shopt -s nullglob
+    local candidates=(
+        "$DERIVED_DATA_PATH/SourcePackages/artifacts/sparkle/Sparkle/bin"
+        "$HOME/Library/Developer/Xcode/DerivedData/PingIsland-*/SourcePackages/artifacts/sparkle/Sparkle/bin"
+        "$PROJECT_DIR/.build/artifacts/sparkle/Sparkle/bin"
+    )
+
+    for candidate in "${candidates[@]}"; do
+        if [ -x "$candidate/generate_appcast" ] && [ -x "$candidate/sign_update" ]; then
+            echo "$candidate"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+generate_sparkle_appcast() {
+    if [ "$GENERATE_APPCAST" != "1" ]; then
+        return
+    fi
+
+    log_section "Generating Sparkle Appcast"
+
+    if [ ! -f "$SPARKLE_PRIVATE_KEY_PATH" ]; then
+        echo "ERROR: Sparkle private key not found at $SPARKLE_PRIVATE_KEY_PATH"
+        exit 1
+    fi
+
+    local sparkle_bin_dir
+    if ! sparkle_bin_dir="$(find_sparkle_bin_dir)"; then
+        echo "ERROR: Could not find Sparkle tools in DerivedData or local artifacts."
+        exit 1
+    fi
+
+    local appcast_dir="$RELEASE_DIR/appcast"
+    mkdir -p "$appcast_dir"
+
+    cp "$DMG_PATH" "$appcast_dir/"
+    if [ -f "$NOTES_ASSET_PATH" ]; then
+        cp "$NOTES_ASSET_PATH" "$appcast_dir/"
+    fi
+
+    "$sparkle_bin_dir/generate_appcast" \
+        --ed-key-file "$SPARKLE_PRIVATE_KEY_PATH" \
+        "$appcast_dir"
+
+    echo "Appcast generated at: $appcast_dir/appcast.xml"
+}
+
+require_command xcodebuild
+require_command xcrun
+require_command ditto
+require_command hdiutil
+require_command codesign
+require_command spctl
+
+resolve_notary_credentials
+
+echo "=== Packaging Signed Ping Island ==="
+echo ""
+
+export PING_ISLAND_BUILD_DIR="$BUILD_DIR"
+"$SCRIPT_DIR/build.sh"
+
+if [ ! -d "$APP_PATH" ]; then
+    echo "ERROR: App bundle not found at $APP_PATH"
+    exit 1
+fi
+
+log_section "Verifying App Signature"
+codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+spctl --assess --type execute -vv "$APP_PATH"
+
+VERSION=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$APP_PATH/Contents/Info.plist")
+BUILD=$(/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" "$APP_PATH/Contents/Info.plist")
+
+mkdir -p "$RELEASE_DIR"
+
+ZIP_PATH="$RELEASE_DIR/$APP_PRODUCT_NAME-$VERSION-$BUILD.zip"
+DMG_PATH="$RELEASE_DIR/$APP_PRODUCT_NAME-$VERSION-$BUILD.dmg"
+NOTES_PATH="$NOTES_DIR/$VERSION.md"
+NOTES_ASSET_PATH="$RELEASE_DIR/$APP_PRODUCT_NAME-$VERSION.md"
+NOTARY_ZIP_PATH="$BUILD_DIR/$APP_PRODUCT_NAME-$VERSION-$BUILD-notarization.zip"
+
+rm -f "$ZIP_PATH" "$DMG_PATH" "$NOTARY_ZIP_PATH"
+rm -rf "$STAGING_DIR"
+
+log_section "Notarizing App Bundle"
+ditto -c -k --sequesterRsrc --keepParent "$APP_PATH" "$NOTARY_ZIP_PATH"
+notarize_and_staple "$NOTARY_ZIP_PATH" "$APP_PATH"
+rm -f "$NOTARY_ZIP_PATH"
+
+log_section "Creating ZIP"
+ditto -c -k --sequesterRsrc --keepParent "$APP_PATH" "$ZIP_PATH"
+
+log_section "Creating DMG"
+mkdir -p "$STAGING_DIR"
+cp -R "$APP_PATH" "$STAGING_DIR/"
+ln -s /Applications "$STAGING_DIR/Applications"
+
+hdiutil create \
+    -volname "Ping Island" \
+    -srcfolder "$STAGING_DIR" \
+    -ov \
+    -format UDZO \
+    "$DMG_PATH"
+
+rm -rf "$STAGING_DIR"
+
+notarize_and_staple "$DMG_PATH" "$DMG_PATH"
+if [ "$SKIP_NOTARIZATION" != "1" ]; then
+    spctl --assess --type open -vv "$DMG_PATH"
+fi
+
+if [ -f "$NOTES_PATH" ]; then
+    cp "$NOTES_PATH" "$NOTES_ASSET_PATH"
+    echo "Release notes copied: $NOTES_ASSET_PATH"
+fi
+
+generate_sparkle_appcast
+
+echo ""
+echo "=== Signed Package Ready ==="
+echo "Version: $VERSION ($BUILD)"
+echo "App: $APP_PATH"
+echo "ZIP: $ZIP_PATH"
+echo "DMG: $DMG_PATH"


### PR DESCRIPTION
## What changed

- changed the release workflow to import a Developer ID certificate from GitHub Actions secrets
- added a shared `scripts/package-release.sh` path for signed export, notarization, ZIP/DMG packaging, and optional Sparkle appcast generation
- updated the local release scripts and docs so the GitHub Actions path and local notarized release path stay aligned

## Why

The repository could only publish ad-hoc unsigned artifacts from GitHub Actions. This change makes the CI release path capable of producing signed and notarized macOS packages once the required Apple and certificate secrets are configured.

## Impact

- release maintainers can generate signed GitHub Release assets directly from CI
- the workflow now documents and validates the required secrets up front
- local and CI release packaging now share one implementation path, which should reduce drift over time

## Validation

- `bash -n scripts/build.sh scripts/package-release.sh scripts/create-release.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-packages.yml"); puts "YAML OK"'`

## Remaining gap

- not yet validated end-to-end with a real `Developer ID Application` certificate and notarization credentials in GitHub Actions
