### PR TITLE
Allow archiving stale ended sessions after 10 minutes

### DIFF
--- a/PingIsland/Models/SessionState.swift
+++ b/PingIsland/Models/SessionState.swift
@@ -651,6 +651,9 @@ struct SessionState: Equatable, Identifiable, Sendable {
         if shouldAutoArchiveFromPrimaryUI {
             return false
         }
+        if phase == .ended, shouldShowArchiveActionInPrimaryUI {
+            return false
+        }
         if phase.isActive || needsManualAttention {
             return false
         }

--- a/PingIsland/Models/SessionState.swift
+++ b/PingIsland/Models/SessionState.swift
@@ -36,6 +36,7 @@ enum SessionScopedApprovalAction: Equatable, Sendable {
 struct SessionState: Equatable, Identifiable, Sendable {
     private nonisolated static let minimalCompactDelay: TimeInterval = 10 * 60
     private nonisolated static let autoArchiveDelay: TimeInterval = 30 * 60
+    private nonisolated static let endedArchiveActionDelay: TimeInterval = 10 * 60
     private nonisolated static let codexContinuationPlaceholderHideWindow: TimeInterval = 10 * 60
     private nonisolated static let openCodeChildSessionHideWindow: TimeInterval = 120
 
@@ -654,6 +655,20 @@ struct SessionState: Equatable, Identifiable, Sendable {
             return false
         }
         return Date().timeIntervalSince(lastActivity) >= Self.minimalCompactDelay
+    }
+
+    /// Whether the session list should offer a manual archive action for this row.
+    nonisolated var shouldShowArchiveActionInPrimaryUI: Bool {
+        switch phase {
+        case .idle:
+            return true
+        case .waitingForInput:
+            return intervention == nil
+        case .ended:
+            return Date().timeIntervalSince(lastActivity) >= Self.endedArchiveActionDelay
+        case .processing, .compacting, .waitingForApproval:
+            return false
+        }
     }
 
     nonisolated func shouldSortBeforeInQueue(_ other: SessionState) -> Bool {

--- a/PingIsland/UI/Views/SessionListView.swift
+++ b/PingIsland/UI/Views/SessionListView.swift
@@ -648,7 +648,7 @@ struct InstanceRow: View {
                     }
                 }
 
-                if session.phase == .idle || (session.phase == .waitingForInput && session.intervention == nil) {
+                if session.shouldShowArchiveActionInPrimaryUI {
                     IconButton(icon: "archivebox") {
                         onArchive()
                     }

--- a/PingIslandTests/SessionStateTests.swift
+++ b/PingIslandTests/SessionStateTests.swift
@@ -184,6 +184,41 @@ final class SessionStateTests: XCTestCase {
         XCTAssertFalse(session.shouldHideFromPrimaryUI)
     }
 
+    func testEndedSessionShowsArchiveActionAfterTenMinutes() {
+        let session = SessionState(
+            sessionId: "ended-archive-eligible",
+            cwd: "/tmp/project",
+            phase: .ended,
+            lastActivity: Date().addingTimeInterval(-(11 * 60))
+        )
+
+        XCTAssertTrue(session.shouldShowArchiveActionInPrimaryUI)
+        XCTAssertFalse(session.shouldHideFromPrimaryUI)
+    }
+
+    func testRecentlyEndedSessionDoesNotShowArchiveActionYet() {
+        let session = SessionState(
+            sessionId: "ended-archive-waiting",
+            cwd: "/tmp/project",
+            phase: .ended,
+            lastActivity: Date().addingTimeInterval(-(9 * 60))
+        )
+
+        XCTAssertFalse(session.shouldShowArchiveActionInPrimaryUI)
+        XCTAssertFalse(session.shouldHideFromPrimaryUI)
+    }
+
+    func testIdleSessionStillShowsArchiveActionImmediately() {
+        let session = SessionState(
+            sessionId: "idle-archive-immediate",
+            cwd: "/tmp/project",
+            phase: .idle,
+            lastActivity: Date().addingTimeInterval(-60)
+        )
+
+        XCTAssertTrue(session.shouldShowArchiveActionInPrimaryUI)
+    }
+
     func testCodexAppLaunchURLUsesThreadsRoute() {
         let threadID = "019d6163-2ee9-7ae2-8c45-5f7a16209149"
 

--- a/PingIslandTests/SessionStateTests.swift
+++ b/PingIslandTests/SessionStateTests.swift
@@ -194,6 +194,7 @@ final class SessionStateTests: XCTestCase {
 
         XCTAssertTrue(session.shouldShowArchiveActionInPrimaryUI)
         XCTAssertFalse(session.shouldHideFromPrimaryUI)
+        XCTAssertFalse(session.shouldUseMinimalCompactPresentation)
     }
 
     func testRecentlyEndedSessionDoesNotShowArchiveActionYet() {


### PR DESCRIPTION
## Summary
- centralize session-list archive eligibility in `SessionState`
- keep idle and non-intervention waiting-for-input sessions archivable immediately
- allow ended sessions to show the archive action after 10 minutes without changing the existing 30-minute auto-hide rule

## Testing
- `xcodebuild -project PingIsland.xcodeproj -scheme PingIsland -configuration Debug CODE_SIGNING_ALLOWED=NO test -only-testing:PingIslandTests/SessionStateTests`
- `xcodebuild -project PingIsland.xcodeproj -scheme PingIsland -configuration Debug CODE_SIGNING_ALLOWED=NO analyze`

Closes #25