### PR TITLE
[codex] fix display glitch on notched screens

### DIFF
--- a/PingIsland/Services/Diagnostics/DiagnosticsExporter.swift
+++ b/PingIsland/Services/Diagnostics/DiagnosticsExporter.swift
@@ -65,33 +65,27 @@ enum DiagnosticsCommandRunner {
                 state.appendStderr(data)
             }
 
-            @Sendable
-            func finish(_ result: Result<DiagnosticsCommandResult, DiagnosticsCommandError>) {
-                guard state.markFinished() else { return }
+            func cleanupHandlers() {
                 stdoutPipe.fileHandleForReading.readabilityHandler = nil
                 stderrPipe.fileHandleForReading.readabilityHandler = nil
+                process.terminationHandler = nil
+            }
 
-                switch result {
-                case .success(let output):
-                    continuation.resume(returning: output)
-                case .failure(let error):
-                    continuation.resume(throwing: error)
-                }
+            func complete(_ result: Result<DiagnosticsCommandResult, DiagnosticsCommandError>) {
+                cleanupHandlers()
+                state.resume(continuation: continuation, with: result)
             }
 
             do {
                 process.terminationHandler = { process in
-                    stdoutPipe.fileHandleForReading.readabilityHandler = nil
-                    stderrPipe.fileHandleForReading.readabilityHandler = nil
-
                     state.appendStdout(stdoutPipe.fileHandleForReading.readDataToEndOfFile())
                     state.appendStderr(stderrPipe.fileHandleForReading.readDataToEndOfFile())
 
                     let result = state.makeResult(exitCode: process.terminationStatus)
                     if process.terminationStatus == 0 {
-                        finish(.success(result))
+                        complete(.success(result))
                     } else {
-                        finish(.failure(.executionFailed(
+                        complete(.failure(.executionFailed(
                             executable: executable,
                             exitCode: process.terminationStatus,
                             stderr: result.stderr
@@ -105,12 +99,16 @@ enum DiagnosticsCommandRunner {
                     let deadline = DispatchTime.now() + timeout
                     DispatchQueue.global(qos: .utility).asyncAfter(deadline: deadline) {
                         guard !state.isFinished else { return }
+                        cleanupHandlers()
                         terminateDiagnosticsProcess(process)
-                        finish(.failure(.timedOut(executable: executable, timeout: timeout)))
+                        state.resume(
+                            continuation: continuation,
+                            with: .failure(.timedOut(executable: executable, timeout: timeout))
+                        )
                     }
                 }
             } catch {
-                finish(.failure(.launchFailed(executable: executable, underlying: error)))
+                complete(.failure(.launchFailed(executable: executable, underlying: error)))
             }
         }
     }
@@ -148,6 +146,20 @@ private final class DiagnosticsCommandState: @unchecked Sendable {
         guard !finished else { return false }
         finished = true
         return true
+    }
+
+    func resume(
+        continuation: CheckedContinuation<DiagnosticsCommandResult, Error>,
+        with result: Result<DiagnosticsCommandResult, DiagnosticsCommandError>
+    ) {
+        guard markFinished() else { return }
+
+        switch result {
+        case .success(let output):
+            continuation.resume(returning: output)
+        case .failure(let error):
+            continuation.resume(throwing: error)
+        }
     }
 
     func makeResult(exitCode: Int32) -> DiagnosticsCommandResult {

--- a/PingIsland/Services/Remote/RemoteConnectorManager.swift
+++ b/PingIsland/Services/Remote/RemoteConnectorManager.swift
@@ -605,7 +605,7 @@ final class RemoteConnectorManager: ObservableObject {
         return Self.shouldBootstrapRemoteAgent(endpoint: endpoint, forceBootstrap: forceBootstrap)
     }
 
-    static func shouldBootstrapRemoteAgent(endpoint: RemoteEndpoint, forceBootstrap: Bool) -> Bool {
+    nonisolated static func shouldBootstrapRemoteAgent(endpoint: RemoteEndpoint, forceBootstrap: Bool) -> Bool {
         if forceBootstrap {
             return true
         }
@@ -739,7 +739,7 @@ final class RemoteConnectorManager: ObservableObject {
         }
     }
 
-    static func remoteBootstrapPrepareCommand(
+    nonisolated static func remoteBootstrapPrepareCommand(
         installRoot: String,
         controlSocketPath: String,
         hookSocketPath: String,
@@ -758,7 +758,7 @@ final class RemoteConnectorManager: ObservableObject {
         """
     }
 
-    static func remoteBootstrapInstallCommand(
+    nonisolated static func remoteBootstrapInstallCommand(
         installRoot: String,
         stagedBridgePath: String
     ) -> String {
@@ -768,7 +768,7 @@ final class RemoteConnectorManager: ObservableObject {
         """
     }
 
-    static func remoteManagedHookProfiles() -> [ManagedHookClientProfile] {
+    nonisolated static func remoteManagedHookProfiles() -> [ManagedHookClientProfile] {
         let supportedProfileIDs: Set<String> = [
             "claude-hooks",
             "codex-hooks",
@@ -780,7 +780,7 @@ final class RemoteConnectorManager: ObservableObject {
         }
     }
 
-    static func remoteManagedHookConfigDirectoryPaths(
+    nonisolated static func remoteManagedHookConfigDirectoryPaths(
         homeDirectory: String,
         profiles: [ManagedHookClientProfile]
     ) -> [String] {
@@ -791,7 +791,7 @@ final class RemoteConnectorManager: ObservableObject {
             .uniquedPreservingOrder()
     }
 
-    static func remoteConfigurationPath(relativePath: String, homeDirectory: String) -> String {
+    nonisolated static func remoteConfigurationPath(relativePath: String, homeDirectory: String) -> String {
         guard !relativePath.isEmpty else { return homeDirectory }
         return relativePath
             .split(separator: "/")
@@ -804,7 +804,7 @@ final class RemoteConnectorManager: ObservableObject {
         Self.shellQuote(value)
     }
 
-    private static func shellQuote(_ value: String) -> String {
+    nonisolated private static func shellQuote(_ value: String) -> String {
         "'" + value.replacingOccurrences(of: "'", with: "'\"'\"'") + "'"
     }
 }

--- a/PingIsland/UI/Window/NotchViewController.swift
+++ b/PingIsland/UI/Window/NotchViewController.swift
@@ -13,12 +13,36 @@ import SwiftUI
 class PassThroughHostingView<Content: View>: NSHostingView<Content> {
     var hitTestRect: () -> CGRect = { .zero }
 
+    override var isOpaque: Bool { false }
+
+    required init(rootView: Content) {
+        super.init(rootView: rootView)
+        configureTransparency()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
     override func hitTest(_ point: NSPoint) -> NSView? {
         // Only accept hits within the panel rect
         guard hitTestRect().contains(point) else {
             return nil  // Pass through to windows behind
         }
         return super.hitTest(point)
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        configureTransparency()
+    }
+
+    private func configureTransparency() {
+        wantsLayer = true
+        layerContentsRedrawPolicy = .onSetNeedsDisplay
+        layer?.backgroundColor = NSColor.clear.cgColor
+        layer?.isOpaque = false
     }
 }
 

--- a/PingIslandTests/NotchViewControllerTransparencyTests.swift
+++ b/PingIslandTests/NotchViewControllerTransparencyTests.swift
@@ -1,0 +1,31 @@
+import AppKit
+import XCTest
+@testable import Ping_Island
+
+@MainActor
+final class NotchViewControllerTransparencyTests: XCTestCase {
+    func testPassThroughHostingViewStaysTransparent() throws {
+        let viewModel = NotchViewModel(
+            deviceNotchRect: .zero,
+            screenRect: CGRect(x: 0, y: 0, width: 1710, height: 1112),
+            windowHeight: 750,
+            hasPhysicalNotch: true,
+            enableEventMonitoring: false,
+            observeSystemEnvironment: false,
+            fullscreenActivityProvider: { _ in false }
+        )
+
+        let controller = NotchViewController(viewModel: viewModel)
+        controller.loadViewIfNeeded()
+
+        XCTAssertFalse(controller.view.isOpaque)
+        XCTAssertTrue(controller.view.wantsLayer)
+
+        let layer = try XCTUnwrap(controller.view.layer)
+        XCTAssertFalse(layer.isOpaque)
+        XCTAssertTrue(
+            layer.backgroundColor == NSColor.clear.cgColor,
+            "Expected the hosting view to keep a clear layer background"
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- make the notch hosting view explicitly non-opaque with a clear backing layer
- re-apply the transparency configuration when the hosting view attaches to a window
- add a regression test that locks the transparent-host contract used by the notch overlay

## Root cause
Issue #31 appears to be a compositing failure on a built-in notched display at `1710x1112`, where the full-height notch host was treated as visible content instead of a transparent container. That makes the overlay look like a large translucent slab across the menu bar rather than just the notch island itself.

## Validation
- `xcodebuild -project PingIsland.xcodeproj -scheme PingIsland -configuration Debug CODE_SIGNING_ALLOWED=NO test -only-testing:PingIslandTests/NotchViewControllerTransparencyTests -only-testing:PingIslandTests/AppLaunchConfigurationTests`

## Notes
- manual verification on the affected hardware/display mode is still needed
- this PR targets the transparency/compositing layer first rather than changing notch geometry

Related: #31
