### PR TITLE
[codex] add explicit ports to remote SSH links

### DIFF
--- a/PingIsland/Services/Diagnostics/DiagnosticsExporter.swift
+++ b/PingIsland/Services/Diagnostics/DiagnosticsExporter.swift
@@ -65,33 +65,27 @@ enum DiagnosticsCommandRunner {
                 state.appendStderr(data)
             }
 
-            @Sendable
-            func finish(_ result: Result<DiagnosticsCommandResult, DiagnosticsCommandError>) {
-                guard state.markFinished() else { return }
+            func cleanupHandlers() {
                 stdoutPipe.fileHandleForReading.readabilityHandler = nil
                 stderrPipe.fileHandleForReading.readabilityHandler = nil
+                process.terminationHandler = nil
+            }
 
-                switch result {
-                case .success(let output):
-                    continuation.resume(returning: output)
-                case .failure(let error):
-                    continuation.resume(throwing: error)
-                }
+            func complete(_ result: Result<DiagnosticsCommandResult, DiagnosticsCommandError>) {
+                cleanupHandlers()
+                state.resume(continuation: continuation, with: result)
             }
 
             do {
                 process.terminationHandler = { process in
-                    stdoutPipe.fileHandleForReading.readabilityHandler = nil
-                    stderrPipe.fileHandleForReading.readabilityHandler = nil
-
                     state.appendStdout(stdoutPipe.fileHandleForReading.readDataToEndOfFile())
                     state.appendStderr(stderrPipe.fileHandleForReading.readDataToEndOfFile())
 
                     let result = state.makeResult(exitCode: process.terminationStatus)
                     if process.terminationStatus == 0 {
-                        finish(.success(result))
+                        complete(.success(result))
                     } else {
-                        finish(.failure(.executionFailed(
+                        complete(.failure(.executionFailed(
                             executable: executable,
                             exitCode: process.terminationStatus,
                             stderr: result.stderr
@@ -105,12 +99,16 @@ enum DiagnosticsCommandRunner {
                     let deadline = DispatchTime.now() + timeout
                     DispatchQueue.global(qos: .utility).asyncAfter(deadline: deadline) {
                         guard !state.isFinished else { return }
+                        cleanupHandlers()
                         terminateDiagnosticsProcess(process)
-                        finish(.failure(.timedOut(executable: executable, timeout: timeout)))
+                        state.resume(
+                            continuation: continuation,
+                            with: .failure(.timedOut(executable: executable, timeout: timeout))
+                        )
                     }
                 }
             } catch {
-                finish(.failure(.launchFailed(executable: executable, underlying: error)))
+                complete(.failure(.launchFailed(executable: executable, underlying: error)))
             }
         }
     }
@@ -148,6 +146,20 @@ private final class DiagnosticsCommandState: @unchecked Sendable {
         guard !finished else { return false }
         finished = true
         return true
+    }
+
+    func resume(
+        continuation: CheckedContinuation<DiagnosticsCommandResult, Error>,
+        with result: Result<DiagnosticsCommandResult, DiagnosticsCommandError>
+    ) {
+        guard markFinished() else { return }
+
+        switch result {
+        case .success(let output):
+            continuation.resume(returning: output)
+        case .failure(let error):
+            continuation.resume(throwing: error)
+        }
     }
 
     func makeResult(exitCode: Int32) -> DiagnosticsCommandResult {

--- a/PingIsland/Services/Remote/RemoteConnectorManager.swift
+++ b/PingIsland/Services/Remote/RemoteConnectorManager.swift
@@ -605,7 +605,7 @@ final class RemoteConnectorManager: ObservableObject {
         return Self.shouldBootstrapRemoteAgent(endpoint: endpoint, forceBootstrap: forceBootstrap)
     }
 
-    static func shouldBootstrapRemoteAgent(endpoint: RemoteEndpoint, forceBootstrap: Bool) -> Bool {
+    nonisolated static func shouldBootstrapRemoteAgent(endpoint: RemoteEndpoint, forceBootstrap: Bool) -> Bool {
         if forceBootstrap {
             return true
         }
@@ -739,7 +739,7 @@ final class RemoteConnectorManager: ObservableObject {
         }
     }
 
-    static func remoteBootstrapPrepareCommand(
+    nonisolated static func remoteBootstrapPrepareCommand(
         installRoot: String,
         controlSocketPath: String,
         hookSocketPath: String,
@@ -758,7 +758,7 @@ final class RemoteConnectorManager: ObservableObject {
         """
     }
 
-    static func remoteBootstrapInstallCommand(
+    nonisolated static func remoteBootstrapInstallCommand(
         installRoot: String,
         stagedBridgePath: String
     ) -> String {
@@ -768,7 +768,7 @@ final class RemoteConnectorManager: ObservableObject {
         """
     }
 
-    static func remoteManagedHookProfiles() -> [ManagedHookClientProfile] {
+    nonisolated static func remoteManagedHookProfiles() -> [ManagedHookClientProfile] {
         let supportedProfileIDs: Set<String> = [
             "claude-hooks",
             "codex-hooks",
@@ -780,7 +780,7 @@ final class RemoteConnectorManager: ObservableObject {
         }
     }
 
-    static func remoteManagedHookConfigDirectoryPaths(
+    nonisolated static func remoteManagedHookConfigDirectoryPaths(
         homeDirectory: String,
         profiles: [ManagedHookClientProfile]
     ) -> [String] {
@@ -791,7 +791,7 @@ final class RemoteConnectorManager: ObservableObject {
             .uniquedPreservingOrder()
     }
 
-    static func remoteConfigurationPath(relativePath: String, homeDirectory: String) -> String {
+    nonisolated static func remoteConfigurationPath(relativePath: String, homeDirectory: String) -> String {
         guard !relativePath.isEmpty else { return homeDirectory }
         return relativePath
             .split(separator: "/")
@@ -804,7 +804,7 @@ final class RemoteConnectorManager: ObservableObject {
         Self.shellQuote(value)
     }
 
-    private static func shellQuote(_ value: String) -> String {
+    nonisolated private static func shellQuote(_ value: String) -> String {
         "'" + value.replacingOccurrences(of: "'", with: "'\"'\"'") + "'"
     }
 }

--- a/PingIsland/Services/Remote/RemoteModels.swift
+++ b/PingIsland/Services/Remote/RemoteModels.swift
@@ -1,5 +1,72 @@
 import Foundation
 
+struct RemoteSSHLink: Equatable, Sendable {
+    let username: String?
+    let host: String
+    let port: Int
+
+    init?(sshTarget: String) {
+        let trimmedTarget = sshTarget.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedTarget.isEmpty else { return nil }
+
+        let userSplit = trimmedTarget.split(separator: "@", maxSplits: 1, omittingEmptySubsequences: false)
+        let username: String?
+        let hostPortSegment: String
+
+        if userSplit.count == 2 {
+            let rawUsername = String(userSplit[0]).trimmingCharacters(in: .whitespacesAndNewlines)
+            username = rawUsername.isEmpty ? nil : rawUsername
+            hostPortSegment = String(userSplit[1])
+        } else {
+            username = nil
+            hostPortSegment = trimmedTarget
+        }
+
+        let parsedHostPort = Self.parseHostAndPort(hostPortSegment)
+        guard let host = parsedHostPort.host else { return nil }
+
+        self.username = username
+        self.host = host
+        self.port = parsedHostPort.port ?? 22
+    }
+
+    var urlString: String {
+        let encodedUsername = username?
+            .addingPercentEncoding(withAllowedCharacters: .urlUserAllowed)
+        let hostComponent = host.contains(":") && !host.hasPrefix("[") ? "[\(host)]" : host
+        let userPrefix = encodedUsername.map { "\($0)@" } ?? ""
+        return "ssh://\(userPrefix)\(hostComponent):\(port)"
+    }
+
+    var url: URL? {
+        URL(string: urlString)
+    }
+
+    private static func parseHostAndPort(_ value: String) -> (host: String?, port: Int?) {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return (nil, nil) }
+
+        if trimmed.hasPrefix("["),
+           let closingBracketIndex = trimmed.firstIndex(of: "]") {
+            let hostStart = trimmed.index(after: trimmed.startIndex)
+            let host = String(trimmed[hostStart..<closingBracketIndex])
+            let remainder = trimmed[trimmed.index(after: closingBracketIndex)...]
+            let port = remainder.first == ":" ? Int(remainder.dropFirst()) : nil
+            return (host.isEmpty ? nil : host, port)
+        }
+
+        if let colonIndex = trimmed.lastIndex(of: ":"),
+           !trimmed[trimmed.index(after: colonIndex)...].isEmpty,
+           let port = Int(trimmed[trimmed.index(after: colonIndex)...]),
+           !trimmed[..<colonIndex].contains(":") {
+            let host = String(trimmed[..<colonIndex])
+            return (host.isEmpty ? nil : host, port)
+        }
+
+        return (trimmed, nil)
+    }
+}
+
 enum RemoteEndpointAuthMode: String, Codable, CaseIterable, Identifiable, Sendable {
     case unknown
     case publicKey
@@ -102,6 +169,14 @@ struct RemoteEndpoint: Identifiable, Codable, Equatable, Sendable {
             return trimmed
         }
         return sshTarget
+    }
+
+    var sshLink: RemoteSSHLink? {
+        RemoteSSHLink(sshTarget: sshTarget)
+    }
+
+    var sshURL: URL? {
+        sshLink?.url
     }
 }
 

--- a/PingIsland/UI/Views/SettingsWindowView.swift
+++ b/PingIsland/UI/Views/SettingsWindowView.swift
@@ -2082,11 +2082,27 @@ private struct RemoteHostManagementLine: View {
                             )
                     }
 
-                    Text(endpoint.sshTarget)
-                        .font(.system(size: 11, weight: .medium))
-                        .foregroundColor(.white.opacity(0.52))
-                        .lineLimit(1)
-                        .truncationMode(.middle)
+                    if let sshURL = endpoint.sshURL {
+                        Link(destination: sshURL) {
+                            HStack(spacing: 4) {
+                                Text(endpoint.sshURL?.absoluteString ?? endpoint.sshTarget)
+                                    .lineLimit(1)
+                                    .truncationMode(.middle)
+
+                                Image(systemName: "arrow.up.right.square")
+                                    .font(.system(size: 9, weight: .semibold))
+                            }
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundColor(.white.opacity(0.52))
+                        }
+                        .buttonStyle(.plain)
+                    } else {
+                        Text(endpoint.sshTarget)
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundColor(.white.opacity(0.52))
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
 
                     Text(detailText)
                         .font(.system(size: 11, weight: .medium))
@@ -2206,7 +2222,7 @@ private struct AddRemoteHostSheet: View {
 
                 VStack(alignment: .leading, spacing: 14) {
                 remoteField(title: "显示名称（可选）", placeholder: "例如 GPU Box", text: $displayName)
-                remoteField(title: "SSH 目标", placeholder: "例如 dev@10.0.0.8 或 my-server", text: $sshTarget)
+                remoteField(title: "SSH 目标", placeholder: "例如 dev@10.0.0.8:2222 或 my-server", text: $sshTarget)
 
                 VStack(alignment: .leading, spacing: 6) {
                     Text(appLocalized: "密码（可选）")
@@ -2328,9 +2344,25 @@ private struct RemotePasswordPromptSheet: View {
                 .font(.system(size: 16, weight: .bold))
                 .foregroundColor(.white)
 
-            Text(endpoint.sshTarget)
-                .font(.system(size: 12, weight: .medium, design: .monospaced))
-                .foregroundColor(.white.opacity(0.56))
+            if let sshURL = endpoint.sshURL {
+                Link(destination: sshURL) {
+                    HStack(spacing: 4) {
+                        Text(endpoint.sshURL?.absoluteString ?? endpoint.sshTarget)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+
+                        Image(systemName: "arrow.up.right.square")
+                            .font(.system(size: 9, weight: .semibold))
+                    }
+                    .font(.system(size: 12, weight: .medium, design: .monospaced))
+                    .foregroundColor(.white.opacity(0.56))
+                }
+                .buttonStyle(.plain)
+            } else {
+                Text(endpoint.sshTarget)
+                    .font(.system(size: 12, weight: .medium, design: .monospaced))
+                    .foregroundColor(.white.opacity(0.56))
+            }
 
             SecureField("", text: $password, prompt: Text(appLocalized: "输入 SSH 密码"))
                 .textFieldStyle(.plain)

--- a/PingIslandTests/RemoteSSHLinkTests.swift
+++ b/PingIslandTests/RemoteSSHLinkTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import Ping_Island
+
+final class RemoteSSHLinkTests: XCTestCase {
+    func testRemoteSSHLinkDefaultsToPort22() throws {
+        let endpoint = RemoteEndpoint(
+            displayName: "Server",
+            sshTarget: "dev@example.com"
+        )
+
+        let link = try XCTUnwrap(endpoint.sshLink)
+        XCTAssertEqual(link.username, "dev")
+        XCTAssertEqual(link.host, "example.com")
+        XCTAssertEqual(link.port, 22)
+        XCTAssertEqual(link.urlString, "ssh://dev@example.com:22")
+        XCTAssertEqual(endpoint.sshURL?.absoluteString, "ssh://dev@example.com:22")
+    }
+
+    func testRemoteSSHLinkKeepsExplicitPort() throws {
+        let endpoint = RemoteEndpoint(
+            displayName: "Server",
+            sshTarget: "dev@example.com:2201"
+        )
+
+        let link = try XCTUnwrap(endpoint.sshLink)
+        XCTAssertEqual(link.port, 2201)
+        XCTAssertEqual(link.urlString, "ssh://dev@example.com:2201")
+    }
+
+    func testRemoteSSHLinkParsesBracketedIPv6Host() throws {
+        let endpoint = RemoteEndpoint(
+            displayName: "IPv6",
+            sshTarget: "root@[2001:db8::10]:2202"
+        )
+
+        let link = try XCTUnwrap(endpoint.sshLink)
+        XCTAssertEqual(link.username, "root")
+        XCTAssertEqual(link.host, "2001:db8::10")
+        XCTAssertEqual(link.port, 2202)
+        XCTAssertEqual(link.urlString, "ssh://root@[2001:db8::10]:2202")
+    }
+}


### PR DESCRIPTION
## Summary
- add a small SSH target parser for remote endpoints
- generate clickable `ssh://` links with an explicit port, defaulting to `22`
- preserve user-specified ports and bracketed IPv6 hosts
- surface the generated SSH link in the remote host row and password prompt sheet
- add regression tests for default-port, explicit-port, and IPv6 parsing

## Why
The remote feature was only showing the raw SSH target text. Once that target is used as an SSH link, omitting the port makes the generated link incomplete for hosts that require a non-default port and ambiguous even for default-port hosts. This change makes the remote SSH link explicit and stable.

## Validation
- `xcodebuild -project PingIsland.xcodeproj -scheme PingIsland -configuration Debug CODE_SIGNING_ALLOWED=NO test -only-testing:PingIslandTests/RemoteSSHLinkTests -only-testing:PingIslandTests/RemoteHookConfigurationTests`
- `xcodebuild -project PingIsland.xcodeproj -scheme PingIsland -configuration Debug -destination 'platform=macOS' -derivedDataPath "$TMPDIR/ping-island-ci-deriveddata" -resultBundlePath "$TMPDIR/PingIslandTests.xcresult" CODE_SIGNING_ALLOWED=NO test -only-testing:PingIslandTests`

## Notes
- this branch is based on the shared CI-fix commit so the PR can validate cleanly while that fix is still unmerged on `main`
- manual click-through verification for `ssh://` links in Terminal was not run
