### PR TITLE
[codex] support bilingual online release notes

### DIFF
--- a/PingIsland/Services/Update/UpdateReleaseNotes.swift
+++ b/PingIsland/Services/Update/UpdateReleaseNotes.swift
@@ -10,6 +10,14 @@ struct UpdateReleaseNotes: Equatable, Sendable {
     var sections: [UpdateReleaseNotesSection] {
         UpdateReleaseNotesParser.sections(from: markdown)
     }
+
+    func sections(locale: Locale) -> [UpdateReleaseNotesSection] {
+        UpdateReleaseNotesParser.sections(from: markdown, locale: locale)
+    }
+
+    func localizedMarkdown(locale: Locale) -> String {
+        UpdateReleaseNotesParser.localizedMarkdown(from: markdown, locale: locale)
+    }
 }
 
 struct UpdateReleaseNotesSection: Equatable, Identifiable, Sendable {
@@ -19,8 +27,8 @@ struct UpdateReleaseNotesSection: Equatable, Identifiable, Sendable {
 }
 
 enum UpdateReleaseNotesParser {
-    static func sections(from markdown: String) -> [UpdateReleaseNotesSection] {
-        let normalized = markdown
+    static func sections(from markdown: String, locale: Locale? = nil) -> [UpdateReleaseNotesSection] {
+        let normalized = localizedMarkdown(from: markdown, locale: locale)
             .replacingOccurrences(of: "\r\n", with: "\n")
             .trimmingCharacters(in: .whitespacesAndNewlines)
 
@@ -66,6 +74,32 @@ enum UpdateReleaseNotesParser {
         return sections.filter { !$0.markdown.isEmpty }
     }
 
+    static func localizedMarkdown(from markdown: String, locale: Locale?) -> String {
+        let normalized = markdown
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !normalized.isEmpty else {
+            return ""
+        }
+
+        let blocks = localizedBlocks(from: normalized)
+        guard !blocks.isEmpty else {
+            return normalized
+        }
+
+        let preferredLanguage = preferredLanguageCode(for: locale)
+        if let preferredBlock = blocks[preferredLanguage] {
+            return preferredBlock
+        }
+
+        if preferredLanguage != "en", let englishBlock = blocks["en"] {
+            return englishBlock
+        }
+
+        return blocks.values.first ?? normalized
+    }
+
     private static func headingTitle(in line: String) -> String? {
         let trimmed = line.trimmingCharacters(in: .whitespaces)
         guard trimmed.hasPrefix("## ") else {
@@ -73,5 +107,54 @@ enum UpdateReleaseNotesParser {
         }
 
         return String(trimmed.dropFirst(3)).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func preferredLanguageCode(for locale: Locale?) -> String {
+        let languageCode = locale?.identifier.lowercased() ?? "en"
+        return languageCode.hasPrefix("zh") ? "zh-Hans" : "en"
+    }
+
+    private static func localizedBlocks(from markdown: String) -> [String: String] {
+        let lines = markdown.components(separatedBy: "\n")
+        var commonLines: [String] = []
+        var currentLanguage: String?
+        var blocks: [String: [String]] = [:]
+
+        for line in lines {
+            if let languageMarker = languageMarker(in: line) {
+                currentLanguage = languageMarker
+                if blocks[languageMarker] == nil {
+                    blocks[languageMarker] = []
+                }
+                continue
+            }
+
+            if let currentLanguage {
+                blocks[currentLanguage, default: []].append(line)
+            } else {
+                commonLines.append(line)
+            }
+        }
+
+        return blocks.reduce(into: [:]) { partialResult, entry in
+            let mergedLines = (commonLines + entry.value)
+                .joined(separator: "\n")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+
+            if !mergedLines.isEmpty {
+                partialResult[entry.key] = mergedLines
+            }
+        }
+    }
+
+    private static func languageMarker(in line: String) -> String? {
+        switch line.trimmingCharacters(in: .whitespacesAndNewlines) {
+        case "<!-- zh-Hans -->":
+            return "zh-Hans"
+        case "<!-- en -->":
+            return "en"
+        default:
+            return nil
+        }
     }
 }

--- a/PingIsland/UI/Views/ReleaseNotesWindowView.swift
+++ b/PingIsland/UI/Views/ReleaseNotesWindowView.swift
@@ -5,6 +5,7 @@ struct ReleaseNotesWindowView: View {
     let notes: UpdateReleaseNotes
     let onClose: () -> Void
 
+    @Environment(\.locale) private var locale
     @State private var expandedSectionIDs: Set<String> = []
 
     var body: some View {
@@ -43,12 +44,12 @@ struct ReleaseNotesWindowView: View {
             RoundedRectangle(cornerRadius: 30, style: .continuous)
                 .stroke(Color.white.opacity(0.08), lineWidth: 1)
         )
-        .preferredColorScheme(.dark)
-        .onAppear {
-            if expandedSectionIDs.isEmpty {
-                expandedSectionIDs = Set(notes.sections.map(\.id))
+            .preferredColorScheme(.dark)
+            .onAppear {
+                if expandedSectionIDs.isEmpty {
+                    expandedSectionIDs = Set(displayedSections.map(\.id))
+                }
             }
-        }
     }
 
     private var appIcon: some View {
@@ -87,7 +88,7 @@ struct ReleaseNotesWindowView: View {
     private var releaseNotesContent: some View {
         ScrollView {
             VStack(spacing: 14) {
-                ForEach(notes.sections.isEmpty ? [fallbackSection] : notes.sections) { section in
+                ForEach(displayedSections.isEmpty ? [fallbackSection] : displayedSections) { section in
                     ReleaseNotesSectionCard(
                         section: section,
                         isExpanded: expandedSectionIDs.contains(section.id),
@@ -100,11 +101,15 @@ struct ReleaseNotesWindowView: View {
         .frame(maxHeight: 430)
     }
 
+    private var displayedSections: [UpdateReleaseNotesSection] {
+        notes.sections(locale: locale)
+    }
+
     private var fallbackSection: UpdateReleaseNotesSection {
         UpdateReleaseNotesSection(
             id: "fallback",
             title: AppLocalization.string("更新内容"),
-            markdown: notes.markdown
+            markdown: notes.localizedMarkdown(locale: locale)
         )
     }
 

--- a/PingIslandTests/UpdateReleaseNotesParserTests.swift
+++ b/PingIslandTests/UpdateReleaseNotesParserTests.swift
@@ -30,4 +30,60 @@ final class UpdateReleaseNotesParserTests: XCTestCase {
         XCTAssertEqual(sections[0].title, "更新内容")
         XCTAssertTrue(sections[0].markdown.contains("第一条"))
     }
+
+    func testParserPrefersChineseLocalizedBlockForChineseLocale() {
+        let markdown = """
+        <!-- zh-Hans -->
+        ## 亮点
+        - 中文内容
+
+        <!-- en -->
+        ## Highlights
+        - English content
+        """
+
+        let sections = UpdateReleaseNotesParser.sections(
+            from: markdown,
+            locale: Locale(identifier: "zh-Hans")
+        )
+
+        XCTAssertEqual(sections.map(\.title), ["亮点"])
+        XCTAssertEqual(sections.first?.markdown, "- 中文内容")
+    }
+
+    func testParserPrefersEnglishLocalizedBlockForEnglishLocale() {
+        let markdown = """
+        <!-- zh-Hans -->
+        ## 亮点
+        - 中文内容
+
+        <!-- en -->
+        ## Highlights
+        - English content
+        """
+
+        let sections = UpdateReleaseNotesParser.sections(
+            from: markdown,
+            locale: Locale(identifier: "en")
+        )
+
+        XCTAssertEqual(sections.map(\.title), ["Highlights"])
+        XCTAssertEqual(sections.first?.markdown, "- English content")
+    }
+
+    func testParserFallsBackToEnglishBlockWhenChineseBlockIsMissing() {
+        let markdown = """
+        <!-- en -->
+        ## Highlights
+        - English only
+        """
+
+        let sections = UpdateReleaseNotesParser.sections(
+            from: markdown,
+            locale: Locale(identifier: "zh-Hans")
+        )
+
+        XCTAssertEqual(sections.map(\.title), ["Highlights"])
+        XCTAssertEqual(sections.first?.markdown, "- English only")
+    }
 }

--- a/releases/notes/0.0.6.md
+++ b/releases/notes/0.0.6.md
@@ -1,10 +1,19 @@
-## Ping Island 0.0.6
+<!-- zh-Hans -->
+## 亮点
+- 统一了设置页里各客户端的品牌图标展示，内置支持的集成现在会优先使用项目内维护的资源。
+- 修复了部分带刘海屏幕在特定分辨率下会露出过大半透明顶部遮罩的问题。
+- 远程主机的 SSH 链接现在会显式带上端口；未填写时默认补 `22`，自定义端口会被完整保留。
 
-### Highlights
-- Unifies settings-page client branding with bundled logos for supported integrations.
-- Fixes a notched-display rendering issue that could expose an oversized translucent overlay on some fullscreen/menu-bar layouts.
-- Adds explicit-port SSH links for remote hosts, defaulting to port 22 while preserving custom ports.
+## 说明
+- 远程主机列表和密码输入弹窗里的 SSH 目标现在都可以直接点击打开。
+- 本次也补了两处校验稳定性修复，让当前 Xcode 版本下的单测链路更稳定。
 
-### Notes
-- Remote host rows and password prompts now open `ssh://` links with an explicit port component.
-- This release also includes validation stability fixes so the macOS unit-test lane matches current Xcode behavior more reliably.
+<!-- en -->
+## Highlights
+- Unified settings-page client branding so supported integrations prefer bundled project-owned logo assets.
+- Fixed a notched-display rendering issue that could expose an oversized translucent overlay on some fullscreen and menu-bar layouts.
+- Remote host SSH links now include an explicit port; when none is provided, Ping Island defaults to `22` and preserves custom ports when present.
+
+## Notes
+- SSH targets in the remote host list and password prompt can now be opened directly.
+- This release also includes validation stability fixes to keep the unit-test lane aligned with the current Xcode toolchain.


### PR DESCRIPTION
## Summary
- add bilingual release-note parsing for a single Markdown asset
- support `<!-- zh-Hans -->` and `<!-- en -->` content blocks with locale-based selection
- fall back to English when the current language does not have a matching block
- update the `0.0.6` online release notes content to ship both Simplified Chinese and English

## Why
The current online release notes effectively only supported one language cleanly. If both Chinese and English were added to the same Markdown file, the app would render both together. This change keeps the release pipeline on a single asset per version while letting the UI present the right language for the current app locale.

## Validation
- `xcodebuild -project PingIsland.xcodeproj -scheme PingIsland -configuration Debug CODE_SIGNING_ALLOWED=NO test -only-testing:PingIslandTests/UpdateReleaseNotesParserTests`

## Notes
- manual release-notes window preview in both languages was not run
- this PR intentionally keeps the storage model to one Markdown file per version
