### PR TITLE
Add native Claude/Codex runtime preview path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ This file is a routing layer for coding agents working in this repo. Keep it sho
 - App entry: `PingIsland/App/PingIslandApp.swift`, `PingIsland/App/AppDelegate.swift`
 - Main state hub: `PingIsland/Services/State/SessionStore.swift`
 - Session association cache: `PingIsland/Services/State/SessionAssociationStore.swift`
+- Native runtime rollout scaffold: `PingIsland/Services/Runtime/`, `PingIsland/Core/FeatureFlags.swift`
 - Session bridge for UI: `PingIsland/Services/Session/SessionMonitor.swift`
 - Notch state and layout: `PingIsland/Core/NotchViewModel.swift`, `PingIsland/UI/Views/NotchView.swift`
 - Claude hook ingress: `Prototype/Sources/IslandBridge/`, `PingIsland/Services/Hooks/HookInstaller.swift`, `PingIsland/Services/Hooks/HookSocketServer.swift`
@@ -45,6 +46,7 @@ This file is a routing layer for coding agents working in this repo. Keep it sho
 - `PingIsland/Core`: notch geometry, shared state, app settings, selectors
 - `PingIsland/Models`: domain models for sessions, events, tools, phases
 - `PingIsland/Services`: ingestion, socket handling, state management, tmux, windows, updates
+- `PingIsland/Services/Runtime`: isolated native Claude/Codex runtime work. This path should coexist with the current implementation behind feature flags until parity is proven.
 - `PingIsland/Services/Remote`: remote endpoint persistence, SSH bootstrap / attach, and remote hook forwarding
 - `PingIsland/Services/Update`: Sparkle updater bridge, appcast/release-notes loading, update state publishing
 - `PingIsland/Services/Window/IDEExtensionInstaller.swift`: installs the VS Code-compatible terminal-focus extension used by Cursor / VS Code / CodeBuddy / Qoder style IDE hosts (`QoderWork` is hook-only, not an IDE extension host)
@@ -72,6 +74,7 @@ This file is a routing layer for coding agents working in this repo. Keep it sho
   - OpenCode is managed as a generated plugin file under `~/.config/opencode/plugins/ping-island.js`; treat it as a plugin-based integration, not a JSON hooks file.
   - `QoderWork` should not be added to `ideExtensionProfiles` unless it actually ships VS Code-compatible extension support in the future.
 - If you change how sessions are associated across relaunches or between hook/app-server ingress paths, inspect both `SessionStore` and `SessionAssociationStore` so cached client metadata stays compatible.
+- If you change the new native runtime rollout path, keep it isolated from the legacy hook/app-server flow. Reuse shared `SessionState`-driven views, but keep runtime orchestration, persistence, and feature gating under `PingIsland/Services/Runtime/` and `PingIsland/Core/FeatureFlags.swift`.
 - If you change session lifecycle or transitions, start in `SessionStore`. Avoid ad-hoc state mutation elsewhere.
   - Current rule: provider-originated end events should preserve the session in `.ended` so it stays visible in the list; only explicit user archive/removal should delete it from `SessionStore`.
   - Primary list rule: sessions with no new activity for 30 minutes should auto-hide from the primary list until fresh hook/file/app-server activity updates `lastActivity`; sessions that need manual attention should stay visible.

--- a/PingIsland/Core/FeatureFlags.swift
+++ b/PingIsland/Core/FeatureFlags.swift
@@ -1,0 +1,69 @@
+//
+//  FeatureFlags.swift
+//  PingIsland
+//
+//  Isolated feature flags for staged runtime rollout.
+//
+
+import Foundation
+
+enum RuntimeFeatureFlag: String, CaseIterable, Sendable {
+    case nativeClaudeRuntime
+    case nativeCodexRuntime
+
+    nonisolated var defaultsKey: String {
+        switch self {
+        case .nativeClaudeRuntime:
+            return "feature.nativeClaudeRuntime"
+        case .nativeCodexRuntime:
+            return "feature.nativeCodexRuntime"
+        }
+    }
+
+    nonisolated var environmentKey: String {
+        switch self {
+        case .nativeClaudeRuntime:
+            return "PING_ISLAND_NATIVE_CLAUDE_RUNTIME"
+        case .nativeCodexRuntime:
+            return "PING_ISLAND_NATIVE_CODEX_RUNTIME"
+        }
+    }
+}
+
+enum FeatureFlags {
+    private static let truthyValues: Set<String> = ["1", "true", "yes", "on", "enabled"]
+    private static let falsyValues: Set<String> = ["0", "false", "no", "off", "disabled"]
+
+    nonisolated static func isEnabled(
+        _ flag: RuntimeFeatureFlag,
+        defaults: UserDefaults = .standard,
+        environment: [String: String] = Foundation.ProcessInfo.processInfo.environment
+    ) -> Bool {
+        if let rawValue = environment[flag.environmentKey]?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+            if truthyValues.contains(rawValue) {
+                return true
+            }
+            if falsyValues.contains(rawValue) {
+                return false
+            }
+        }
+
+        return defaults.bool(forKey: flag.defaultsKey)
+    }
+
+    nonisolated static func setEnabled(
+        _ isEnabled: Bool,
+        for flag: RuntimeFeatureFlag,
+        defaults: UserDefaults = .standard
+    ) {
+        defaults.set(isEnabled, forKey: flag.defaultsKey)
+    }
+
+    nonisolated static var nativeClaudeRuntime: Bool {
+        isEnabled(.nativeClaudeRuntime)
+    }
+
+    nonisolated static var nativeCodexRuntime: Bool {
+        isEnabled(.nativeCodexRuntime)
+    }
+}

--- a/PingIsland/Models/SessionEvent.swift
+++ b/PingIsland/Models/SessionEvent.swift
@@ -16,6 +16,14 @@ enum SessionEvent: Sendable {
     /// A hook event was received from a hook-based provider
     case hookReceived(HookEvent)
 
+    // MARK: - Native Runtime Events
+
+    /// A native runtime session was started.
+    case runtimeSessionStarted(SessionRuntimeHandle)
+
+    /// A native runtime session was stopped.
+    case runtimeSessionStopped(sessionId: String, reason: SessionRuntimeStopReason)
+
     // MARK: - Permission Events (user actions)
 
     /// User approved a permission request
@@ -385,6 +393,10 @@ extension SessionEvent: CustomStringConvertible {
         switch self {
         case .hookReceived(let event):
             return "hookReceived(\(event.event), session: \(event.sessionId.prefix(8)))"
+        case .runtimeSessionStarted(let handle):
+            return "runtimeSessionStarted(provider: \(handle.provider.rawValue), session: \(handle.sessionID.prefix(8)))"
+        case .runtimeSessionStopped(let sessionId, let reason):
+            return "runtimeSessionStopped(session: \(sessionId.prefix(8)), reason: \(reason.rawValue))"
         case .permissionApproved(let sessionId, let toolUseId):
             return "permissionApproved(session: \(sessionId.prefix(8)), tool: \(toolUseId.prefix(12)))"
         case .permissionAutoApprovalChanged(let sessionId, let isEnabled):

--- a/PingIsland/Models/SessionProvider.swift
+++ b/PingIsland/Models/SessionProvider.swift
@@ -21,6 +21,7 @@ enum SessionIngress: String, Equatable, Sendable {
     case hookBridge
     case remoteBridge
     case codexAppServer
+    case nativeRuntime
 }
 
 enum SessionClientKind: String, Codable, Equatable, Sendable {

--- a/PingIsland/Models/SessionState.swift
+++ b/PingIsland/Models/SessionState.swift
@@ -639,6 +639,14 @@ struct SessionState: Equatable, Identifiable, Sendable {
         scopedApprovalAction != nil
     }
 
+    nonisolated var isNativeRuntimeSession: Bool {
+        ingress == .nativeRuntime
+    }
+
+    nonisolated var shouldShowTerminateActionInPrimaryUI: Bool {
+        isNativeRuntimeSession && phase != .ended
+    }
+
     /// Timestamp used when sorting sessions that need manual attention.
     nonisolated var attentionRequestedAt: Date? {
         if let permission = activePermission {

--- a/PingIsland/Services/Codex/CodexAppServerMonitor.swift
+++ b/PingIsland/Services/Codex/CodexAppServerMonitor.swift
@@ -187,6 +187,84 @@ actor CodexAppServerMonitor {
         return snapshot
     }
 
+    func startThread(cwd: String, model: String? = nil) async throws -> CodexThreadSnapshot {
+        if websocket == nil {
+            await start()
+        }
+
+        let response = try await sendRequest(
+            method: "thread/start",
+            params: [
+                "model": model as Any,
+                "modelProvider": NSNull(),
+                "profile": NSNull(),
+                "cwd": cwd,
+                "approvalPolicy": NSNull(),
+                "sandbox": NSNull(),
+                "config": NSNull(),
+                "baseInstructions": NSNull(),
+                "developerInstructions": NSNull(),
+                "compactPrompt": NSNull(),
+                "includeApplyPatchTool": NSNull(),
+                "experimentalRawEvents": false,
+                "persistExtendedHistory": true,
+            ]
+        )
+
+        guard let thread = response["thread"] as? [String: Any],
+              let threadId = thread["id"] as? String else {
+            throw NSError(domain: "CodexAppServer", code: 4, userInfo: [
+                NSLocalizedDescriptionKey: "Invalid thread/start response"
+            ])
+        }
+
+        return try await readThread(threadId: threadId, includeTurns: true)
+    }
+
+    func resumeThread(threadId: String, cwd: String? = nil, model: String? = nil) async throws -> CodexThreadSnapshot {
+        if websocket == nil {
+            await start()
+        }
+
+        let response = try await sendRequest(
+            method: "thread/resume",
+            params: [
+                "threadId": threadId,
+                "model": model as Any,
+                "modelProvider": NSNull(),
+                "cwd": cwd as Any,
+                "approvalPolicy": NSNull(),
+                "sandbox": NSNull(),
+                "config": NSNull(),
+                "baseInstructions": NSNull(),
+                "developerInstructions": NSNull(),
+                "persistExtendedHistory": true,
+            ]
+        )
+
+        guard let thread = response["thread"] as? [String: Any],
+              let resumedThreadID = thread["id"] as? String else {
+            throw NSError(domain: "CodexAppServer", code: 5, userInfo: [
+                NSLocalizedDescriptionKey: "Invalid thread/resume response"
+            ])
+        }
+
+        return try await readThread(threadId: resumedThreadID, includeTurns: true)
+    }
+
+    func archiveThread(threadId: String) async throws {
+        if websocket == nil {
+            await start()
+        }
+
+        _ = try await sendRequest(
+            method: "thread/archive",
+            params: [
+                "threadId": threadId
+            ]
+        )
+    }
+
     func continueThread(threadId: String, expectedTurnId: String, text: String) async throws {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }

--- a/PingIsland/Services/Hooks/HookInstaller.swift
+++ b/PingIsland/Services/Hooks/HookInstaller.swift
@@ -241,6 +241,33 @@ struct HookInstaller {
         install(profile, persistPreference: true)
     }
 
+    static func createTemporarySettingsFile(for profileID: String) -> URL? {
+        guard let profile = ClientProfileRegistry.managedHookProfile(id: profileID) else {
+            return nil
+        }
+
+        installBridgeLauncherIfNeeded()
+
+        let directory = islandSupportDirectory()
+            .appendingPathComponent("tmp", isDirectory: true)
+            .appendingPathComponent("native-runtime-hooks", isDirectory: true)
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        let fileURL = directory.appendingPathComponent("\(profile.id)-\(UUID().uuidString).json")
+        let command = bridgeCommand(source: profile.bridgeSource, extraArguments: profile.bridgeExtraArguments)
+        var hooks: [String: Any] = [:]
+        for event in profile.events {
+            hooks[event.name] = makeHookEntries(command: command, event: event)
+        }
+        writeJSONObject(["hooks": hooks], to: fileURL)
+        return fileURL
+    }
+
+    static func removeTemporarySettingsFile(at url: URL?) {
+        guard let url else { return }
+        try? FileManager.default.removeItem(at: url)
+    }
+
     static func reinstall(_ profile: ManagedHookClientProfile) {
         uninstall(profile, persistPreference: false)
         install(profile, persistPreference: true)

--- a/PingIsland/Services/Hooks/HookSocketServer.swift
+++ b/PingIsland/Services/Hooks/HookSocketServer.swift
@@ -97,8 +97,27 @@ struct HookEvent: Sendable {
     }
 }
 
-private extension HookEvent {
-    func withToolUseId(_ toolUseId: String) -> HookEvent {
+extension HookEvent {
+    nonisolated func withToolUseId(_ toolUseId: String) -> HookEvent {
+        HookEvent(
+            sessionId: sessionId,
+            cwd: cwd,
+            event: event,
+            status: status,
+            provider: provider,
+            clientInfo: clientInfo,
+            pid: pid,
+            tty: tty,
+            tool: tool,
+            toolInput: toolInput,
+            toolUseId: toolUseId,
+            notificationType: notificationType,
+            message: message,
+            ingress: ingress
+        )
+    }
+
+    nonisolated func withIngress(_ ingress: SessionIngress) -> HookEvent {
         HookEvent(
             sessionId: sessionId,
             cwd: cwd,

--- a/PingIsland/Services/Remote/RemoteConnectorManager.swift
+++ b/PingIsland/Services/Remote/RemoteConnectorManager.swift
@@ -593,7 +593,7 @@ final class RemoteConnectorManager: ObservableObject {
         endpoints.first { $0.id == id }
     }
 
-    static func resolvedRemoteHostHint(
+    nonisolated static func resolvedRemoteHostHint(
         payloadRemoteHost: String?,
         endpoint: RemoteEndpoint?
     ) -> String? {
@@ -697,7 +697,7 @@ final class RemoteConnectorManager: ObservableObject {
         defaults.set(data, forKey: persistenceKey)
     }
 
-    private static func sanitizedNonEmpty(_ value: String?) -> String? {
+    nonisolated private static func sanitizedNonEmpty(_ value: String?) -> String? {
         guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
               !trimmed.isEmpty else {
             return nil
@@ -705,7 +705,7 @@ final class RemoteConnectorManager: ObservableObject {
         return trimmed
     }
 
-    private static func isIPAddressLike(_ value: String) -> Bool {
+    nonisolated private static func isIPAddressLike(_ value: String) -> Bool {
         let candidate = value.trimmingCharacters(in: .whitespacesAndNewlines)
         let ipv4Parts = candidate.split(separator: ".")
         if ipv4Parts.count == 4,

--- a/PingIsland/Services/Runtime/Claude/ClaudeRuntime.swift
+++ b/PingIsland/Services/Runtime/Claude/ClaudeRuntime.swift
@@ -1,0 +1,246 @@
+//
+//  ClaudeRuntime.swift
+//  PingIsland
+//
+//  Isolated native runtime scaffold for Claude sessions.
+//
+
+import Foundation
+
+actor ClaudeRuntime: SessionRuntime {
+    let provider: SessionProvider = .claude
+    nonisolated let events: AsyncStream<SessionRuntimeEvent>
+
+    private let featureFlag: RuntimeFeatureFlag = .nativeClaudeRuntime
+    private var continuation: AsyncStream<SessionRuntimeEvent>.Continuation?
+    private struct ActiveSession {
+        let handle: SessionRuntimeHandle
+        let process: Process
+        let inputPipe: Pipe
+        let pollingTask: Task<Void, Never>
+        let settingsURL: URL?
+    }
+
+    private var activeSessions: [String: ActiveSession] = [:]
+
+    init() {
+        var capturedContinuation: AsyncStream<SessionRuntimeEvent>.Continuation?
+        self.events = AsyncStream { continuation in
+            capturedContinuation = continuation
+        }
+        self.continuation = capturedContinuation
+    }
+
+    func prepare() async {
+        continuation?.yield(.availabilityChanged(await isAvailable()))
+    }
+
+    func shutdown() async {
+        let sessions = activeSessions.values
+        activeSessions.removeAll()
+        for session in sessions {
+            session.pollingTask.cancel()
+            session.process.terminate()
+            HookInstaller.removeTemporarySettingsFile(at: session.settingsURL)
+        }
+        continuation?.finish()
+    }
+
+    func isAvailable() async -> Bool {
+        FeatureFlags.isEnabled(featureFlag) && Self.resolveClaudeExecutable() != nil
+    }
+
+    func startSession(_ request: SessionRuntimeLaunchRequest) async throws -> SessionRuntimeHandle {
+        guard request.provider == provider else {
+            throw SessionRuntimeError.unsupportedProvider(request.provider)
+        }
+        guard FeatureFlags.isEnabled(featureFlag) else {
+            throw SessionRuntimeError.runtimeDisabled(provider)
+        }
+        guard await isAvailable() else {
+            throw SessionRuntimeError.runtimeUnavailable(provider)
+        }
+
+        let sessionID = request.preferredSessionID ?? UUID().uuidString
+        let transcriptPath = JSONLInterruptWatcher.resolveFallbackFilePath(sessionId: sessionID, cwd: request.cwd)
+        let executable = Self.resolveClaudeExecutable()!
+        let settingsURL = HookInstaller.createTemporarySettingsFile(for: "claude-hooks")
+        let (process, inputPipe) = try Self.makeClaudeProcess(
+            executable: executable,
+            sessionID: sessionID,
+            cwd: request.cwd,
+            resumeSessionID: request.resumeSessionID,
+            settingsURL: settingsURL
+        )
+        try process.run()
+
+        let handle = SessionRuntimeHandle(
+            sessionID: sessionID,
+            provider: provider,
+            cwd: request.cwd,
+            createdAt: Date(),
+            resumeToken: request.resumeSessionID,
+            runtimeIdentifier: "native-claude",
+            sessionFilePath: transcriptPath
+        )
+        await ConversationParser.shared.resetState(for: sessionID)
+        let pollingTask = makePollingTask(sessionID: sessionID, cwd: request.cwd, transcriptPath: transcriptPath)
+        activeSessions[sessionID] = ActiveSession(
+            handle: handle,
+            process: process,
+            inputPipe: inputPipe,
+            pollingTask: pollingTask,
+            settingsURL: settingsURL
+        )
+        process.terminationHandler = { [weak self] process in
+            Task {
+                await self?.handleProcessExit(sessionID: sessionID, process: process)
+            }
+        }
+        continuation?.yield(.started(handle))
+        return handle
+    }
+
+    func resumeSession(id: String) async throws -> SessionRuntimeHandle {
+        guard FeatureFlags.isEnabled(featureFlag) else {
+            throw SessionRuntimeError.runtimeDisabled(provider)
+        }
+        if let existing = activeSessions[id]?.handle {
+            return existing
+        }
+        return try await startSession(
+            SessionRuntimeLaunchRequest(
+                provider: provider,
+                cwd: FileManager.default.homeDirectoryForCurrentUser.path,
+                resumeSessionID: id,
+                preferredSessionID: id
+            )
+        )
+    }
+
+    func terminateSession(id: String) async throws {
+        guard let session = activeSessions.removeValue(forKey: id) else {
+            throw SessionRuntimeError.sessionNotFound(id)
+        }
+        session.pollingTask.cancel()
+        if session.process.isRunning {
+            session.process.terminate()
+        }
+        HookInstaller.removeTemporarySettingsFile(at: session.settingsURL)
+        continuation?.yield(.stopped(sessionID: id, reason: .cancelled))
+    }
+
+    func sendUserInput(sessionId: String, text: String) async throws {
+        guard let session = activeSessions[sessionId] else {
+            throw SessionRuntimeError.sessionNotFound(sessionId)
+        }
+
+        guard let data = "\(text)\n".data(using: .utf8) else {
+            throw SessionRuntimeError.unsupportedOperation("sendUserInputEncoding")
+        }
+
+        try session.inputPipe.fileHandleForWriting.write(contentsOf: data)
+    }
+
+    private func handleProcessExit(sessionID: String, process: Process) {
+        guard let active = activeSessions[sessionID], active.process === process else {
+            return
+        }
+
+        activeSessions.removeValue(forKey: sessionID)
+        active.pollingTask.cancel()
+        HookInstaller.removeTemporarySettingsFile(at: active.settingsURL)
+        let reason: SessionRuntimeStopReason = process.terminationStatus == 0 ? .finished : .crashed
+        continuation?.yield(.stopped(sessionID: sessionID, reason: reason))
+    }
+
+    private func makePollingTask(sessionID: String, cwd: String, transcriptPath: String) -> Task<Void, Never> {
+        Task {
+            while !Task.isCancelled {
+                let result = await ConversationParser.shared.parseIncremental(
+                    sessionId: sessionID,
+                    cwd: cwd,
+                    explicitFilePath: transcriptPath
+                )
+
+                if result.clearDetected {
+                    await SessionStore.shared.process(.clearDetected(sessionId: sessionID))
+                }
+
+                if !result.newMessages.isEmpty || result.clearDetected {
+                    let payload = FileUpdatePayload(
+                        sessionId: sessionID,
+                        cwd: cwd,
+                        messages: result.newMessages,
+                        isIncremental: !result.clearDetected,
+                        completedToolIds: result.completedToolIds,
+                        toolResults: result.toolResults,
+                        structuredResults: result.structuredResults
+                    )
+                    await SessionStore.shared.process(.fileUpdated(payload))
+                }
+
+                do {
+                    try await Task.sleep(for: .milliseconds(750))
+                } catch {
+                    break
+                }
+            }
+        }
+    }
+
+    nonisolated private static func makeClaudeProcess(
+        executable: String,
+        sessionID: String,
+        cwd: String,
+        resumeSessionID: String?,
+        settingsURL: URL?
+    ) throws -> (Process, Pipe) {
+        let process = Process()
+        process.currentDirectoryURL = URL(fileURLWithPath: cwd)
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/script")
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+        let inputPipe = Pipe()
+        process.standardInput = inputPipe
+
+        var commandParts: [String] = [
+            "cd \(quoteShellArg(cwd))",
+            "exec \(quoteShellArg(executable))"
+        ]
+
+        if let resumeSessionID, !resumeSessionID.isEmpty {
+            commandParts[1] += " --resume \(quoteShellArg(resumeSessionID))"
+        } else {
+            commandParts[1] += " --session-id \(quoteShellArg(sessionID))"
+        }
+
+        if let settingsURL {
+            commandParts[1] += " --settings \(quoteShellArg(settingsURL.path))"
+        }
+
+        let shellCommand = commandParts.joined(separator: " && ")
+        process.arguments = ["-q", "/dev/null", "/bin/zsh", "-lc", shellCommand]
+        return (process, inputPipe)
+    }
+
+    nonisolated private static func quoteShellArg(_ value: String) -> String {
+        "'\(value.replacingOccurrences(of: "'", with: "'\\''"))'"
+    }
+
+    nonisolated private static func resolveClaudeExecutable(
+        environment: [String: String] = Foundation.ProcessInfo.processInfo.environment
+    ) -> String? {
+        if let explicit = environment["HAPPY_CLAUDE_PATH"], !explicit.isEmpty {
+            return explicit
+        }
+
+        let candidates = [
+            "/opt/homebrew/bin/claude",
+            "/usr/local/bin/claude",
+            "/usr/bin/claude",
+        ]
+
+        return candidates.first { FileManager.default.isExecutableFile(atPath: $0) }
+    }
+}

--- a/PingIsland/Services/Runtime/Codex/CodexRuntime.swift
+++ b/PingIsland/Services/Runtime/Codex/CodexRuntime.swift
@@ -1,0 +1,143 @@
+//
+//  CodexRuntime.swift
+//  PingIsland
+//
+//  Isolated native runtime scaffold for Codex sessions.
+//
+
+import Foundation
+
+actor CodexRuntime: SessionRuntime {
+    let provider: SessionProvider = .codex
+    nonisolated let events: AsyncStream<SessionRuntimeEvent>
+
+    private let featureFlag: RuntimeFeatureFlag = .nativeCodexRuntime
+    private let monitor: CodexAppServerMonitor
+    private var continuation: AsyncStream<SessionRuntimeEvent>.Continuation?
+    private var activeSessions: [String: SessionRuntimeHandle] = [:]
+
+    init(monitor: CodexAppServerMonitor = .shared) {
+        self.monitor = monitor
+        var capturedContinuation: AsyncStream<SessionRuntimeEvent>.Continuation?
+        self.events = AsyncStream { continuation in
+            capturedContinuation = continuation
+        }
+        self.continuation = capturedContinuation
+    }
+
+    func prepare() async {
+        await monitor.start()
+        continuation?.yield(.availabilityChanged(await isAvailable()))
+    }
+
+    func shutdown() async {
+        activeSessions.removeAll()
+        continuation?.finish()
+    }
+
+    func isAvailable() async -> Bool {
+        FeatureFlags.isEnabled(featureFlag) && Self.resolveCodexExecutable() != nil
+    }
+
+    func startSession(_ request: SessionRuntimeLaunchRequest) async throws -> SessionRuntimeHandle {
+        guard request.provider == provider else {
+            throw SessionRuntimeError.unsupportedProvider(request.provider)
+        }
+        guard FeatureFlags.isEnabled(featureFlag) else {
+            throw SessionRuntimeError.runtimeDisabled(provider)
+        }
+        guard await isAvailable() else {
+            throw SessionRuntimeError.runtimeUnavailable(provider)
+        }
+
+        let snapshot = try await monitor.startThread(cwd: request.cwd)
+        let sessionID = snapshot.threadId
+        let handle = SessionRuntimeHandle(
+            sessionID: sessionID,
+            provider: provider,
+            cwd: request.cwd,
+            createdAt: Date(),
+            resumeToken: sessionID,
+            runtimeIdentifier: "native-codex",
+            sessionFilePath: snapshot.clientInfo?.sessionFilePath
+        )
+        activeSessions[sessionID] = handle
+        continuation?.yield(.started(handle))
+        return handle
+    }
+
+    func resumeSession(id: String) async throws -> SessionRuntimeHandle {
+        guard FeatureFlags.isEnabled(featureFlag) else {
+            throw SessionRuntimeError.runtimeDisabled(provider)
+        }
+        if let existing = activeSessions[id] {
+            return existing
+        }
+
+        let snapshot = try await monitor.resumeThread(threadId: id, cwd: nil)
+        let handle = SessionRuntimeHandle(
+            sessionID: snapshot.threadId,
+            provider: provider,
+            cwd: snapshot.cwd,
+            createdAt: Date(),
+            resumeToken: snapshot.threadId,
+            runtimeIdentifier: "native-codex",
+            sessionFilePath: snapshot.clientInfo?.sessionFilePath
+        )
+        activeSessions[handle.sessionID] = handle
+        continuation?.yield(.started(handle))
+        return handle
+    }
+
+    func terminateSession(id: String) async throws {
+        guard activeSessions.removeValue(forKey: id) != nil else {
+            throw SessionRuntimeError.sessionNotFound(id)
+        }
+        try? await monitor.archiveThread(threadId: id)
+        continuation?.yield(.stopped(sessionID: id, reason: .cancelled))
+    }
+
+    func approve(sessionId: String, forSession: Bool) async throws {
+        guard activeSessions[sessionId] != nil else {
+            throw SessionRuntimeError.sessionNotFound(sessionId)
+        }
+        await monitor.approve(threadId: sessionId, forSession: forSession)
+    }
+
+    func deny(sessionId: String, reason: String?) async throws {
+        guard activeSessions[sessionId] != nil else {
+            throw SessionRuntimeError.sessionNotFound(sessionId)
+        }
+        _ = reason
+        await monitor.deny(threadId: sessionId)
+    }
+
+    func answer(sessionId: String, answers: [String : [String]]) async throws {
+        guard activeSessions[sessionId] != nil else {
+            throw SessionRuntimeError.sessionNotFound(sessionId)
+        }
+        await monitor.answer(threadId: sessionId, answers: answers)
+    }
+
+    func continueSession(sessionId: String, expectedTurnId: String?, text: String) async throws {
+        guard activeSessions[sessionId] != nil else {
+            throw SessionRuntimeError.sessionNotFound(sessionId)
+        }
+        try await monitor.continueThread(
+            threadId: sessionId,
+            expectedTurnId: expectedTurnId ?? "",
+            text: text
+        )
+    }
+
+    nonisolated private static func resolveCodexExecutable() -> String? {
+        let candidates = [
+            "/Applications/Codex.app/Contents/Resources/codex",
+            "/opt/homebrew/bin/codex",
+            "/usr/local/bin/codex",
+            "/usr/bin/codex",
+        ]
+
+        return candidates.first { FileManager.default.isExecutableFile(atPath: $0) }
+    }
+}

--- a/PingIsland/Services/Runtime/RuntimeCoordinator.swift
+++ b/PingIsland/Services/Runtime/RuntimeCoordinator.swift
@@ -1,0 +1,217 @@
+//
+//  RuntimeCoordinator.swift
+//  PingIsland
+//
+//  Lifecycle coordinator for isolated native runtimes.
+//
+
+import Foundation
+import os.log
+
+protocol RuntimeCoordinating: Sendable {
+    func start() async
+    func stop() async
+    func startSession(
+        provider: SessionProvider,
+        cwd: String,
+        preferredSessionID: String?,
+        metadata: [String: String]
+    ) async throws -> SessionRuntimeHandle
+    func terminateSession(provider: SessionProvider, sessionID: String) async throws
+    func sendUserInput(provider: SessionProvider, sessionID: String, text: String) async throws
+    func approveSession(provider: SessionProvider, sessionID: String, forSession: Bool) async throws
+    func denySession(provider: SessionProvider, sessionID: String, reason: String?) async throws
+    func answerSession(provider: SessionProvider, sessionID: String, answers: [String: [String]]) async throws
+    func continueSession(provider: SessionProvider, sessionID: String, expectedTurnId: String?, text: String) async throws
+    func managesNativeSession(sessionID: String, provider: SessionProvider?) async -> Bool
+}
+
+actor RuntimeCoordinator {
+    static let shared = RuntimeCoordinator()
+
+    nonisolated private static let logger = Logger(subsystem: "com.wudanwu.pingisland", category: "NativeRuntime")
+
+    private let registry: RuntimeSessionRegistry
+    private var runtimes: [SessionProvider: any SessionRuntime] = [:]
+    private var listenerTasks: [SessionProvider: Task<Void, Never>] = [:]
+    private var started = false
+
+    init(
+        registry: RuntimeSessionRegistry = .shared,
+        runtimes: [SessionProvider: any SessionRuntime] = [:]
+    ) {
+        self.registry = registry
+        self.runtimes = runtimes
+    }
+
+    func start() async {
+        guard !started else { return }
+        started = true
+
+        if runtimes.isEmpty {
+            runtimes[.claude] = await MainActor.run { ClaudeRuntime() }
+            runtimes[.codex] = await MainActor.run { CodexRuntime() }
+        }
+
+        for flag in RuntimeFeatureFlag.allCases where FeatureFlags.isEnabled(flag) {
+            if let provider = provider(for: flag), let runtime = runtimes[provider] {
+                if listenerTasks[provider] == nil {
+                    let events = runtime.events
+                    listenerTasks[provider] = Task { [weak self] in
+                        for await event in events {
+                            await self?.handleRuntimeEvent(event)
+                        }
+                    }
+                }
+                await runtime.prepare()
+                Self.logger.info("Prepared native runtime for \(provider.rawValue, privacy: .public)")
+            }
+        }
+    }
+
+    func stop() async {
+        guard started else { return }
+        started = false
+
+        for (_, task) in listenerTasks {
+            task.cancel()
+        }
+        listenerTasks.removeAll()
+
+        for (_, runtime) in runtimes {
+            await runtime.shutdown()
+        }
+    }
+
+    func isRuntimeEnabled(for provider: SessionProvider) -> Bool {
+        switch provider {
+        case .claude:
+            return FeatureFlags.nativeClaudeRuntime
+        case .codex:
+            return FeatureFlags.nativeCodexRuntime
+        case .copilot:
+            return false
+        }
+    }
+
+    func isRuntimeAvailable(for provider: SessionProvider) async -> Bool {
+        guard let runtime = runtimes[provider] else { return false }
+        return await runtime.isAvailable()
+    }
+
+    @discardableResult
+    func startSession(
+        provider: SessionProvider,
+        cwd: String,
+        preferredSessionID: String? = nil,
+        metadata: [String: String] = [:]
+    ) async throws -> SessionRuntimeHandle {
+        guard let runtime = runtimes[provider] else {
+            throw SessionRuntimeError.unsupportedProvider(provider)
+        }
+
+        let handle = try await runtime.startSession(
+            SessionRuntimeLaunchRequest(
+                provider: provider,
+                cwd: cwd,
+                preferredSessionID: preferredSessionID,
+                metadata: metadata
+            )
+        )
+        await registry.upsert(handle: handle)
+        return handle
+    }
+
+    @discardableResult
+    func resumeSession(provider: SessionProvider, sessionID: String) async throws -> SessionRuntimeHandle {
+        guard let runtime = runtimes[provider] else {
+            throw SessionRuntimeError.unsupportedProvider(provider)
+        }
+
+        let handle = try await runtime.resumeSession(id: sessionID)
+        await registry.upsert(handle: handle)
+        return handle
+    }
+
+    func terminateSession(provider: SessionProvider, sessionID: String) async throws {
+        guard let runtime = runtimes[provider] else {
+            throw SessionRuntimeError.unsupportedProvider(provider)
+        }
+
+        try await runtime.terminateSession(id: sessionID)
+        await registry.remove(sessionID: sessionID)
+    }
+
+    func sendUserInput(provider: SessionProvider, sessionID: String, text: String) async throws {
+        guard let runtime = runtimes[provider] else {
+            throw SessionRuntimeError.unsupportedProvider(provider)
+        }
+        try await runtime.sendUserInput(sessionId: sessionID, text: text)
+    }
+
+    func approveSession(provider: SessionProvider, sessionID: String, forSession: Bool) async throws {
+        guard let runtime = runtimes[provider] else {
+            throw SessionRuntimeError.unsupportedProvider(provider)
+        }
+        try await runtime.approve(sessionId: sessionID, forSession: forSession)
+    }
+
+    func denySession(provider: SessionProvider, sessionID: String, reason: String?) async throws {
+        guard let runtime = runtimes[provider] else {
+            throw SessionRuntimeError.unsupportedProvider(provider)
+        }
+        try await runtime.deny(sessionId: sessionID, reason: reason)
+    }
+
+    func answerSession(provider: SessionProvider, sessionID: String, answers: [String: [String]]) async throws {
+        guard let runtime = runtimes[provider] else {
+            throw SessionRuntimeError.unsupportedProvider(provider)
+        }
+        try await runtime.answer(sessionId: sessionID, answers: answers)
+    }
+
+    func continueSession(provider: SessionProvider, sessionID: String, expectedTurnId: String?, text: String) async throws {
+        guard let runtime = runtimes[provider] else {
+            throw SessionRuntimeError.unsupportedProvider(provider)
+        }
+        try await runtime.continueSession(sessionId: sessionID, expectedTurnId: expectedTurnId, text: text)
+    }
+
+    func sessionRecords() async -> [String: RuntimeSessionRecord] {
+        await registry.allRecords()
+    }
+
+    func managesNativeSession(sessionID: String, provider: SessionProvider? = nil) async -> Bool {
+        guard let record = await registry.record(for: sessionID) else {
+            return false
+        }
+        if let provider {
+            return record.provider == provider
+        }
+        return true
+    }
+
+    private func handleRuntimeEvent(_ event: SessionRuntimeEvent) async {
+        switch event {
+        case .started(let handle):
+            await registry.upsert(handle: handle)
+            await SessionStore.shared.process(.runtimeSessionStarted(handle))
+        case .stopped(let sessionID, let reason):
+            await registry.remove(sessionID: sessionID)
+            await SessionStore.shared.process(.runtimeSessionStopped(sessionId: sessionID, reason: reason))
+        case .availabilityChanged(let isAvailable):
+            Self.logger.info("Native runtime availability changed: \(isAvailable, privacy: .public)")
+        }
+    }
+
+    private func provider(for flag: RuntimeFeatureFlag) -> SessionProvider? {
+        switch flag {
+        case .nativeClaudeRuntime:
+            return .claude
+        case .nativeCodexRuntime:
+            return .codex
+        }
+    }
+}
+
+extension RuntimeCoordinator: RuntimeCoordinating {}

--- a/PingIsland/Services/Runtime/RuntimeCoordinator.swift
+++ b/PingIsland/Services/Runtime/RuntimeCoordinator.swift
@@ -24,6 +24,7 @@ protocol RuntimeCoordinating: Sendable {
     func answerSession(provider: SessionProvider, sessionID: String, answers: [String: [String]]) async throws
     func continueSession(provider: SessionProvider, sessionID: String, expectedTurnId: String?, text: String) async throws
     func managesNativeSession(sessionID: String, provider: SessionProvider?) async -> Bool
+    func launchPreferredSession(provider: SessionProvider, cwd: String) async throws -> SessionRuntimeHandle
 }
 
 actor RuntimeCoordinator {
@@ -56,7 +57,7 @@ actor RuntimeCoordinator {
         for flag in RuntimeFeatureFlag.allCases where FeatureFlags.isEnabled(flag) {
             if let provider = provider(for: flag), let runtime = runtimes[provider] {
                 if listenerTasks[provider] == nil {
-                    let events = runtime.events
+                    let events = await runtime.events
                     listenerTasks[provider] = Task { [weak self] in
                         for await event in events {
                             await self?.handleRuntimeEvent(event)
@@ -189,6 +190,11 @@ actor RuntimeCoordinator {
             return record.provider == provider
         }
         return true
+    }
+
+    @discardableResult
+    func launchPreferredSession(provider: SessionProvider, cwd: String) async throws -> SessionRuntimeHandle {
+        try await startSession(provider: provider, cwd: cwd, preferredSessionID: nil, metadata: [:])
     }
 
     private func handleRuntimeEvent(_ event: SessionRuntimeEvent) async {

--- a/PingIsland/Services/Runtime/RuntimeSessionRegistry.swift
+++ b/PingIsland/Services/Runtime/RuntimeSessionRegistry.swift
@@ -1,0 +1,86 @@
+//
+//  RuntimeSessionRegistry.swift
+//  PingIsland
+//
+//  Persistent registry for native runtime sessions.
+//
+
+import Foundation
+
+struct RuntimeSessionRecord: Codable, Equatable, Sendable {
+    let sessionID: String
+    let provider: SessionProvider
+    let cwd: String
+    let createdAt: Date
+    var updatedAt: Date
+    let resumeToken: String?
+    let runtimeIdentifier: String
+
+    nonisolated init(handle: SessionRuntimeHandle, updatedAt: Date = Date()) {
+        self.sessionID = handle.sessionID
+        self.provider = handle.provider
+        self.cwd = handle.cwd
+        self.createdAt = handle.createdAt
+        self.updatedAt = updatedAt
+        self.resumeToken = handle.resumeToken
+        self.runtimeIdentifier = handle.runtimeIdentifier
+    }
+}
+
+actor RuntimeSessionRegistry {
+    static let shared = RuntimeSessionRegistry()
+
+    private let fileURL: URL
+    private var didLoad = false
+    private var records: [String: RuntimeSessionRecord] = [:]
+
+    init(fileURL: URL = RuntimeSupportPaths.sessionsFileURL) {
+        self.fileURL = fileURL
+    }
+
+    func allRecords() -> [String: RuntimeSessionRecord] {
+        loadIfNeeded()
+        return records
+    }
+
+    func record(for sessionID: String) -> RuntimeSessionRecord? {
+        loadIfNeeded()
+        return records[sessionID]
+    }
+
+    func upsert(handle: SessionRuntimeHandle, updatedAt: Date = Date()) {
+        loadIfNeeded()
+        records[handle.sessionID] = RuntimeSessionRecord(handle: handle, updatedAt: updatedAt)
+        save()
+    }
+
+    func remove(sessionID: String) {
+        loadIfNeeded()
+        records.removeValue(forKey: sessionID)
+        save()
+    }
+
+    private func loadIfNeeded() {
+        guard !didLoad else { return }
+        didLoad = true
+
+        guard let data = try? Data(contentsOf: fileURL),
+              let decoded = try? JSONDecoder().decode([String: RuntimeSessionRecord].self, from: data) else {
+            records = [:]
+            return
+        }
+
+        records = decoded
+    }
+
+    private func save() {
+        let directoryURL = fileURL.deletingLastPathComponent()
+        try? FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+
+        guard let data = try? encoder.encode(records) else { return }
+        try? data.write(to: fileURL, options: [.atomic])
+    }
+}

--- a/PingIsland/Services/Runtime/RuntimeSupportPaths.swift
+++ b/PingIsland/Services/Runtime/RuntimeSupportPaths.swift
@@ -1,0 +1,25 @@
+//
+//  RuntimeSupportPaths.swift
+//  PingIsland
+//
+//  Native runtime storage paths isolated from the legacy implementation.
+//
+
+import Foundation
+
+enum RuntimeSupportPaths {
+    nonisolated static let directoryName = "PingIsland/native-runtime"
+
+    nonisolated static var rootDirectoryURL: URL {
+        FileManager.default
+            .urls(for: .applicationSupportDirectory, in: .userDomainMask)
+            .first?
+            .appendingPathComponent(directoryName, isDirectory: true)
+            ?? URL(fileURLWithPath: NSHomeDirectory())
+                .appendingPathComponent("Library/Application Support/\(directoryName)", isDirectory: true)
+    }
+
+    nonisolated static var sessionsFileURL: URL {
+        rootDirectoryURL.appendingPathComponent("runtime-sessions.json", isDirectory: false)
+    }
+}

--- a/PingIsland/Services/Runtime/SessionRuntime.swift
+++ b/PingIsland/Services/Runtime/SessionRuntime.swift
@@ -1,0 +1,115 @@
+//
+//  SessionRuntime.swift
+//  PingIsland
+//
+//  Provider-agnostic native runtime protocol.
+//
+
+import Foundation
+
+struct SessionRuntimeLaunchRequest: Sendable {
+    let provider: SessionProvider
+    let cwd: String
+    let resumeSessionID: String?
+    let preferredSessionID: String?
+    let metadata: [String: String]
+
+    init(
+        provider: SessionProvider,
+        cwd: String,
+        resumeSessionID: String? = nil,
+        preferredSessionID: String? = nil,
+        metadata: [String: String] = [:]
+    ) {
+        self.provider = provider
+        self.cwd = cwd
+        self.resumeSessionID = resumeSessionID
+        self.preferredSessionID = preferredSessionID
+        self.metadata = metadata
+    }
+}
+
+struct SessionRuntimeHandle: Codable, Equatable, Sendable {
+    let sessionID: String
+    let provider: SessionProvider
+    let cwd: String
+    let createdAt: Date
+    let resumeToken: String?
+    let runtimeIdentifier: String
+    let sessionFilePath: String?
+}
+
+enum SessionRuntimeStopReason: String, Codable, Equatable, Sendable {
+    case finished
+    case cancelled
+    case crashed
+    case unavailable
+}
+
+enum SessionRuntimeEvent: Sendable {
+    case started(SessionRuntimeHandle)
+    case stopped(sessionID: String, reason: SessionRuntimeStopReason)
+    case availabilityChanged(Bool)
+}
+
+enum SessionRuntimeError: LocalizedError, Equatable, Sendable {
+    case unsupportedProvider(SessionProvider)
+    case runtimeDisabled(SessionProvider)
+    case runtimeUnavailable(SessionProvider)
+    case sessionNotFound(String)
+    case unsupportedOperation(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .unsupportedProvider(let provider):
+            return "Provider \(provider.rawValue) is not supported by the native runtime."
+        case .runtimeDisabled(let provider):
+            return "Native runtime for \(provider.rawValue) is disabled."
+        case .runtimeUnavailable(let provider):
+            return "Native runtime for \(provider.rawValue) is unavailable on this machine."
+        case .sessionNotFound(let sessionID):
+            return "Native runtime session \(sessionID) could not be found."
+        case .unsupportedOperation(let operation):
+            return "Operation \(operation) is not implemented by this runtime yet."
+        }
+    }
+}
+
+protocol SessionRuntime: Sendable {
+    var provider: SessionProvider { get }
+    var events: AsyncStream<SessionRuntimeEvent> { get }
+
+    func prepare() async
+    func shutdown() async
+    func isAvailable() async -> Bool
+    func startSession(_ request: SessionRuntimeLaunchRequest) async throws -> SessionRuntimeHandle
+    func resumeSession(id: String) async throws -> SessionRuntimeHandle
+    func terminateSession(id: String) async throws
+    func sendUserInput(sessionId: String, text: String) async throws
+    func approve(sessionId: String, forSession: Bool) async throws
+    func deny(sessionId: String, reason: String?) async throws
+    func answer(sessionId: String, answers: [String: [String]]) async throws
+    func continueSession(sessionId: String, expectedTurnId: String?, text: String) async throws
+}
+
+extension SessionRuntime {
+    func sendUserInput(sessionId: String, text: String) async throws {
+        throw SessionRuntimeError.unsupportedOperation("sendUserInput")
+    }
+
+    func approve(sessionId: String, forSession: Bool) async throws {
+        throw SessionRuntimeError.unsupportedOperation("approve")
+    }
+
+    func deny(sessionId: String, reason: String?) async throws {
+        throw SessionRuntimeError.unsupportedOperation("deny")
+    }
+
+    func answer(sessionId: String, answers: [String: [String]]) async throws {
+        throw SessionRuntimeError.unsupportedOperation("answer")
+    }
+
+    func continueSession(sessionId: String, expectedTurnId: String?, text: String) async throws {
+        try await sendUserInput(sessionId: sessionId, text: text)
+    }
+}

--- a/PingIsland/Services/Session/SessionMonitor.swift
+++ b/PingIsland/Services/Session/SessionMonitor.swift
@@ -15,11 +15,13 @@ class SessionMonitor: ObservableObject {
     @Published var instances: [SessionState] = []
     @Published var pendingInstances: [SessionState] = []
 
+    private let runtimeCoordinator: any RuntimeCoordinating
     private var cancellables = Set<AnyCancellable>()
     private var hasStarted = false
     private var allSessions: [SessionState] = []
 
-    init() {
+    init(runtimeCoordinator: any RuntimeCoordinating = RuntimeCoordinator.shared) {
+        self.runtimeCoordinator = runtimeCoordinator
         SessionStore.shared.sessionsPublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] sessions in
@@ -48,107 +50,9 @@ class SessionMonitor: ObservableObject {
         guard !hasStarted else { return }
         hasStarted = true
 
-        let handleHookEvent: @Sendable (HookEvent) -> Void = { event in
-            Task {
-                let shouldAutoApprovePermission = await Self.shouldAutoApproveClaudePermission(for: event)
-
-                if !shouldAutoApprovePermission {
-                    await MainActor.run {
-                        SoundManager.shared.handleEvent(event.event)
-                    }
-                }
-
-                await SessionStore.shared.process(.hookReceived(event))
-
-                if shouldAutoApprovePermission,
-                   let approvedToolUseId = await Self.resolvePendingApprovalToolUseId(for: event.sessionId, fallback: event.toolUseId) {
-                    if event.ingress == .remoteBridge {
-                        await MainActor.run {
-                            RemoteConnectorManager.shared.respondToPermission(
-                                toolUseId: approvedToolUseId,
-                                decision: "approveForSession"
-                            )
-                        }
-                    } else {
-                        await MainActor.run {
-                            HookSocketServer.shared.respondToPermission(
-                                toolUseId: approvedToolUseId,
-                                decision: "approveForSession"
-                            )
-                        }
-                    }
-                    await SessionStore.shared.process(
-                        .permissionApproved(sessionId: event.sessionId, toolUseId: approvedToolUseId)
-                    )
-                    return
-                }
-
-                if let autoAnswer = await MainActor.run(body: { Self.defaultQoderAutoAnswer(for: event) }) {
-                    await MainActor.run {
-                        if event.ingress == .remoteBridge {
-                            RemoteConnectorManager.shared.respondToIntervention(
-                                toolUseId: autoAnswer.toolUseId,
-                                decision: "answer",
-                                updatedInput: autoAnswer.updatedInput
-                            )
-                        } else {
-                            HookSocketServer.shared.respondToIntervention(
-                                toolUseId: autoAnswer.toolUseId,
-                                decision: "answer",
-                                updatedInput: autoAnswer.updatedInput
-                            )
-                        }
-                    }
-                    await SessionStore.shared.process(
-                        .interventionResolved(
-                            sessionId: event.sessionId,
-                            nextPhase: .processing,
-                            submittedAnswers: autoAnswer.answers
-                        )
-                    )
-                }
-
-                if event.event == "PostToolUse",
-                   let toolUseId = event.toolUseId,
-                   let session = await SessionStore.shared.session(for: event.sessionId),
-                   session.activePermission?.toolUseId != toolUseId {
-                    await MainActor.run {
-                        if event.ingress == .remoteBridge {
-                            RemoteConnectorManager.shared.respondToPermission(
-                                toolUseId: toolUseId,
-                                decision: "cancel"
-                            )
-                        } else {
-                            HookSocketServer.shared.cancelPendingPermission(toolUseId: toolUseId)
-                        }
-                    }
-                }
-            }
-
-            let sessionPhase = event.sessionPhase
-            if Self.shouldWatchTranscript(for: event, phase: sessionPhase) {
-                Task {
-                    let session = await SessionStore.shared.session(for: event.sessionId)
-                    await MainActor.run {
-                        InterruptWatcherManager.shared.startWatching(
-                            sessionId: event.sessionId,
-                            cwd: event.cwd,
-                            explicitFilePath: session?.clientInfo.sessionFilePath
-                        )
-                    }
-                }
-            }
-
-            if Self.shouldStopWatchingTranscript(for: event) {
-                Task { @MainActor in
-                    InterruptWatcherManager.shared.stopWatching(sessionId: event.sessionId)
-                }
-            }
-
-            if event.event == "Stop", event.ingress != .remoteBridge {
-                Task { @MainActor in
-                    HookSocketServer.shared.cancelPendingPermissions(sessionId: event.sessionId)
-                }
+        let handleHookEvent: @Sendable (HookEvent) -> Void = { [self] event in
+            Task { @MainActor in
+                await self.handleIncomingHookEvent(event)
             }
         }
 
@@ -166,6 +70,10 @@ class SessionMonitor: ObservableObject {
         Task {
             await CodexAppServerMonitor.shared.start()
         }
+
+        Task {
+            await runtimeCoordinator.start()
+        }
         RemoteConnectorManager.shared.start(
             onEvent: handleHookEvent,
             onPermissionFailure: { sessionId, toolUseId in
@@ -178,12 +86,133 @@ class SessionMonitor: ObservableObject {
         )
     }
 
+    func handleIncomingHookEvent(_ event: HookEvent) async {
+        let effectiveEvent: HookEvent
+        if await runtimeCoordinator.managesNativeSession(sessionID: event.sessionId, provider: event.provider) {
+            effectiveEvent = event.withIngress(.nativeRuntime)
+        } else {
+            effectiveEvent = event
+        }
+
+        let shouldAutoApprovePermission = await Self.shouldAutoApproveClaudePermission(for: effectiveEvent)
+
+        if !shouldAutoApprovePermission {
+            SoundManager.shared.handleEvent(effectiveEvent.event)
+        }
+
+        await SessionStore.shared.process(.hookReceived(effectiveEvent))
+
+        if shouldAutoApprovePermission,
+           let approvedToolUseId = await Self.resolvePendingApprovalToolUseId(for: effectiveEvent.sessionId, fallback: effectiveEvent.toolUseId) {
+            if effectiveEvent.ingress == .remoteBridge {
+                RemoteConnectorManager.shared.respondToPermission(
+                    toolUseId: approvedToolUseId,
+                    decision: "approveForSession"
+                )
+            } else {
+                HookSocketServer.shared.respondToPermission(
+                    toolUseId: approvedToolUseId,
+                    decision: "approveForSession"
+                )
+            }
+            await SessionStore.shared.process(
+                .permissionApproved(sessionId: effectiveEvent.sessionId, toolUseId: approvedToolUseId)
+            )
+            return
+        }
+
+        if let autoAnswer = Self.defaultQoderAutoAnswer(for: effectiveEvent) {
+            if effectiveEvent.ingress == .remoteBridge {
+                RemoteConnectorManager.shared.respondToIntervention(
+                    toolUseId: autoAnswer.toolUseId,
+                    decision: "answer",
+                    updatedInput: autoAnswer.updatedInput
+                )
+            } else {
+                HookSocketServer.shared.respondToIntervention(
+                    toolUseId: autoAnswer.toolUseId,
+                    decision: "answer",
+                    updatedInput: autoAnswer.updatedInput
+                )
+            }
+            await SessionStore.shared.process(
+                .interventionResolved(
+                    sessionId: effectiveEvent.sessionId,
+                    nextPhase: .processing,
+                    submittedAnswers: autoAnswer.answers
+                )
+            )
+        }
+
+        if effectiveEvent.event == "PostToolUse",
+           let toolUseId = effectiveEvent.toolUseId,
+           let session = await SessionStore.shared.session(for: effectiveEvent.sessionId),
+           session.activePermission?.toolUseId != toolUseId {
+            if effectiveEvent.ingress == .remoteBridge {
+                RemoteConnectorManager.shared.respondToPermission(
+                    toolUseId: toolUseId,
+                    decision: "cancel"
+                )
+            } else {
+                HookSocketServer.shared.cancelPendingPermission(toolUseId: toolUseId)
+            }
+        }
+
+        let sessionPhase = effectiveEvent.sessionPhase
+        if Self.shouldWatchTranscript(for: effectiveEvent, phase: sessionPhase) {
+            let session = await SessionStore.shared.session(for: effectiveEvent.sessionId)
+            InterruptWatcherManager.shared.startWatching(
+                sessionId: effectiveEvent.sessionId,
+                cwd: effectiveEvent.cwd,
+                explicitFilePath: session?.clientInfo.sessionFilePath
+            )
+        }
+
+        if Self.shouldStopWatchingTranscript(for: effectiveEvent) {
+            InterruptWatcherManager.shared.stopWatching(sessionId: effectiveEvent.sessionId)
+        }
+
+        if effectiveEvent.event == "Stop", effectiveEvent.ingress != .remoteBridge {
+            HookSocketServer.shared.cancelPendingPermissions(sessionId: effectiveEvent.sessionId)
+        }
+    }
+
     func stopMonitoring() {
         hasStarted = false
         HookSocketServer.shared.stop()
         RemoteConnectorManager.shared.stop()
         Task {
             await CodexAppServerMonitor.shared.stop()
+        }
+        Task {
+            await runtimeCoordinator.stop()
+        }
+    }
+
+    // MARK: - Native Runtime
+
+    func startNativeSession(provider: SessionProvider, cwd: String, preferredSessionID: String? = nil) {
+        Task {
+            _ = try? await runtimeCoordinator.startSession(
+                provider: provider,
+                cwd: cwd,
+                preferredSessionID: preferredSessionID,
+                metadata: [:]
+            )
+        }
+    }
+
+    func terminateNativeSession(sessionId: String) {
+        Task {
+            guard let session = await SessionStore.shared.session(for: sessionId),
+                  session.ingress == .nativeRuntime else {
+                return
+            }
+
+            try? await runtimeCoordinator.terminateSession(
+                provider: session.provider,
+                sessionID: session.sessionId
+            )
         }
     }
 
@@ -192,6 +221,15 @@ class SessionMonitor: ObservableObject {
     func approvePermission(sessionId: String, forSession: Bool = false) {
         Task {
             guard let session = await SessionStore.shared.session(for: sessionId) else {
+                return
+            }
+
+            if session.ingress == .nativeRuntime {
+                try? await runtimeCoordinator.approveSession(
+                    provider: session.provider,
+                    sessionID: session.sessionId,
+                    forSession: forSession
+                )
                 return
             }
 
@@ -248,6 +286,15 @@ class SessionMonitor: ObservableObject {
                 return
             }
 
+            if session.ingress == .nativeRuntime {
+                try? await runtimeCoordinator.denySession(
+                    provider: session.provider,
+                    sessionID: session.sessionId,
+                    reason: reason
+                )
+                return
+            }
+
             if session.ingress == .codexAppServer {
                 let resolvedSessionId = await SessionStore.shared.resolvedCodexSessionId(for: sessionId)
                 await CodexAppServerMonitor.shared.deny(threadId: resolvedSessionId)
@@ -279,6 +326,15 @@ class SessionMonitor: ObservableObject {
     func answerIntervention(sessionId: String, answers: [String: [String]]) {
         Task {
             guard let session = await SessionStore.shared.session(for: sessionId) else {
+                return
+            }
+
+            if session.ingress == .nativeRuntime {
+                try? await runtimeCoordinator.answerSession(
+                    provider: session.provider,
+                    sessionID: session.sessionId,
+                    answers: answers
+                )
                 return
             }
 
@@ -356,12 +412,38 @@ class SessionMonitor: ObservableObject {
     }
 
     func continueCodexThread(sessionId: String, expectedTurnId: String, text: String) async throws {
+        if let session = await SessionStore.shared.session(for: sessionId),
+           session.ingress == .nativeRuntime {
+            try await runtimeCoordinator.continueSession(
+                provider: session.provider,
+                sessionID: session.sessionId,
+                expectedTurnId: expectedTurnId,
+                text: text
+            )
+            return
+        }
+
         let resolvedSessionId = await SessionStore.shared.resolvedCodexSessionId(for: sessionId)
         try await CodexAppServerMonitor.shared.continueThread(
             threadId: resolvedSessionId,
             expectedTurnId: expectedTurnId,
             text: text
         )
+    }
+
+    func sendNativeSessionInput(sessionId: String, text: String) {
+        Task {
+            guard let session = await SessionStore.shared.session(for: sessionId),
+                  session.ingress == .nativeRuntime else {
+                return
+            }
+
+            try? await runtimeCoordinator.sendUserInput(
+                provider: session.provider,
+                sessionID: session.sessionId,
+                text: text
+            )
+        }
     }
 
     /// Archive (remove) a session from the instances list

--- a/PingIsland/Services/State/SessionStore.swift
+++ b/PingIsland/Services/State/SessionStore.swift
@@ -88,6 +88,12 @@ actor SessionStore {
         case .hookReceived(let hookEvent):
             await processHookEvent(hookEvent)
 
+        case .runtimeSessionStarted(let handle):
+            processNativeRuntimeSessionStarted(handle)
+
+        case .runtimeSessionStopped(let sessionId, _):
+            await processSessionEnd(sessionId: sessionId)
+
         case .permissionApproved(let sessionId, let toolUseId):
             await processPermissionApproved(sessionId: sessionId, toolUseId: toolUseId)
 
@@ -164,6 +170,73 @@ actor SessionStore {
     }
 
     // MARK: - Hook Event Processing
+
+    private func processNativeRuntimeSessionStarted(_ handle: SessionRuntimeHandle) {
+        let restoredAssociation = persistedAssociation(for: handle.provider, sessionId: handle.sessionID)
+        let projectName = restoredAssociation?.projectName
+            ?? Self.projectName(for: handle.cwd, fallback: handle.provider.displayName)
+
+        let runtimeClientInfo: SessionClientInfo
+        switch handle.provider {
+        case .claude:
+            runtimeClientInfo = SessionClientInfo(
+                kind: .claudeCode,
+                name: "Claude Native",
+                origin: "native-runtime",
+                sessionFilePath: handle.sessionFilePath,
+                processName: "claude"
+            )
+        case .codex:
+            runtimeClientInfo = SessionClientInfo(
+                kind: .codexCLI,
+                name: "Codex Native",
+                origin: "native-runtime",
+                sessionFilePath: handle.sessionFilePath,
+                processName: "codex"
+            )
+        case .copilot:
+            runtimeClientInfo = SessionClientInfo.default(for: .copilot)
+        }
+
+        let resolvedClientInfo = normalizedClientInfo(
+            (restoredAssociation?.clientInfo ?? runtimeClientInfo).merged(with: runtimeClientInfo),
+            provider: handle.provider,
+            sessionId: handle.sessionID
+        )
+
+        let existing = sessions[handle.sessionID]
+        let session = SessionState(
+            sessionId: handle.sessionID,
+            cwd: handle.cwd,
+            projectName: projectName,
+            provider: handle.provider,
+            clientInfo: resolvedClientInfo,
+            ingress: .nativeRuntime,
+            sessionName: restoredAssociation?.sessionName ?? existing?.sessionName,
+            pid: existing?.pid,
+            tty: existing?.tty,
+            isInTmux: existing?.isInTmux ?? false,
+            autoApprovePermissions: existing?.autoApprovePermissions ?? false,
+            phase: existing?.phase == .ended ? .idle : (existing?.phase ?? .idle),
+            chatItems: existing?.chatItems ?? [],
+            toolTracker: existing?.toolTracker ?? ToolTracker(),
+            completedErrorToolIDs: existing?.completedErrorToolIDs ?? [],
+            subagentState: existing?.subagentState ?? SubagentState(),
+            conversationInfo: existing?.conversationInfo ?? ConversationInfo(
+                summary: nil,
+                lastMessage: nil,
+                lastMessageRole: nil,
+                lastToolName: nil,
+                firstUserMessage: nil,
+                lastUserMessageDate: nil
+            ),
+            needsClearReconciliation: existing?.needsClearReconciliation ?? false,
+            lastActivity: Date(),
+            createdAt: existing?.createdAt ?? handle.createdAt
+        )
+
+        sessions[handle.sessionID] = session
+    }
 
     private func processHookEvent(_ event: HookEvent) async {
         let sessionId = event.provider == .codex
@@ -2723,6 +2796,8 @@ actor SessionStore {
         case .remoteBridge:
             return codexHookPlaceholderPruneDelayNs
         case .codexAppServer:
+            return codexAppServerPlaceholderPruneDelayNs
+        case .nativeRuntime:
             return codexAppServerPlaceholderPruneDelayNs
         }
     }

--- a/PingIsland/UI/Views/ChatView.swift
+++ b/PingIsland/UI/Views/ChatView.swift
@@ -630,6 +630,11 @@ struct ChatView: View {
     }
 
     private func sendToSession(_ text: String) async {
+        if session.ingress == .nativeRuntime {
+            sessionMonitor.sendNativeSessionInput(sessionId: session.sessionId, text: text)
+            return
+        }
+
         guard session.isInTmux else { return }
         guard let tty = session.tty else { return }
 

--- a/PingIsland/UI/Views/ChatView.swift
+++ b/PingIsland/UI/Views/ChatView.swift
@@ -201,31 +201,50 @@ struct ChatView: View {
     @State private var isHeaderHovered = false
 
     private var chatHeader: some View {
-        Button {
-            viewModel.exitChat()
-        } label: {
-            HStack(spacing: 8) {
-                Image(systemName: "chevron.left")
-                    .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.white.opacity(isHeaderHovered ? 1.0 : 0.6))
-                    .frame(width: 24, height: 24)
+        HStack(spacing: 8) {
+            Button {
+                viewModel.exitChat()
+            } label: {
+                HStack(spacing: 8) {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundColor(.white.opacity(isHeaderHovered ? 1.0 : 0.6))
+                        .frame(width: 24, height: 24)
 
-                Text(session.displayTitle)
-                    .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.white.opacity(isHeaderHovered ? 1.0 : 0.85))
-                    .lineLimit(1)
-
-                Spacer()
+                    Text(session.displayTitle)
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundColor(.white.opacity(isHeaderHovered ? 1.0 : 0.85))
+                        .lineLimit(1)
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 10)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(isHeaderHovered ? Color.white.opacity(0.08) : Color.clear)
+                )
             }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 10)
-            .background(
-                RoundedRectangle(cornerRadius: 8)
-                    .fill(isHeaderHovered ? Color.white.opacity(0.08) : Color.clear)
-            )
+            .buttonStyle(.plain)
+            .onHover { isHeaderHovered = $0 }
+
+            Spacer()
+
+            if session.isNativeRuntimeSession, session.phase != .ended {
+                Button {
+                    sessionMonitor.terminateNativeSession(sessionId: session.sessionId)
+                } label: {
+                    Image(systemName: "stop.circle.fill")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundColor(.white.opacity(0.72))
+                        .frame(width: 28, height: 28)
+                        .background(
+                            Circle()
+                                .fill(Color.white.opacity(0.08))
+                        )
+                }
+                .buttonStyle(.plain)
+                .help("Stop native runtime session")
+            }
         }
-        .buttonStyle(.plain)
-        .onHover { isHeaderHovered = $0 }
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
         .background(Color.black.opacity(0.2))

--- a/PingIsland/UI/Views/SessionListView.swift
+++ b/PingIsland/UI/Views/SessionListView.swift
@@ -5,6 +5,7 @@
 //  Minimal instances list matching Dynamic Island aesthetic
 //
 
+import AppKit
 import Combine
 import SwiftUI
 
@@ -32,6 +33,37 @@ struct SessionListView: View {
             Text("Run Claude Code, Codex CLI, or Codex App")
                 .font(.system(size: 11))
                 .foregroundColor(.white.opacity(0.25))
+
+            if FeatureFlags.nativeClaudeRuntime || FeatureFlags.nativeCodexRuntime {
+                HStack(spacing: 8) {
+                    if FeatureFlags.nativeClaudeRuntime {
+                        Button(action: { launchNativeRuntime(.claude) }) {
+                            Text("Launch Claude Native")
+                                .font(.system(size: 11, weight: .semibold))
+                                .foregroundColor(.white.opacity(0.86))
+                                .padding(.horizontal, 10)
+                                .padding(.vertical, 7)
+                                .background(nativeRuntimeTint(for: .claude).opacity(0.26))
+                                .clipShape(Capsule())
+                        }
+                        .buttonStyle(.plain)
+                    }
+
+                    if FeatureFlags.nativeCodexRuntime {
+                        Button(action: { launchNativeRuntime(.codex) }) {
+                            Text("Launch Codex Native")
+                                .font(.system(size: 11, weight: .semibold))
+                                .foregroundColor(.white.opacity(0.86))
+                                .padding(.horizontal, 10)
+                                .padding(.vertical, 7)
+                                .background(nativeRuntimeTint(for: .codex).opacity(0.26))
+                                .clipShape(Capsule())
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding(.top, 8)
+            }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(
@@ -65,6 +97,7 @@ struct SessionListView: View {
                     onFocus: { activateSession(session) },
                     onChat: { openChat(session) },
                     onArchive: { archiveSession(session) },
+                    onTerminate: { terminateSession(session) },
                     onApprove: { approveSession(session) },
                     onApproveForSession: { approveSessionForScope(session) },
                     onReject: { rejectSession(session) }
@@ -137,6 +170,35 @@ struct SessionListView: View {
     private func archiveSession(_ session: SessionState) {
         sessionMonitor.archiveSession(sessionId: session.sessionId)
     }
+
+    private func terminateSession(_ session: SessionState) {
+        sessionMonitor.terminateNativeSession(sessionId: session.sessionId)
+    }
+
+    private func launchNativeRuntime(_ provider: SessionProvider) {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.showsHiddenFiles = true
+        panel.directoryURL = FileManager.default.homeDirectoryForCurrentUser
+        panel.message = "选择 \(provider.displayName) Native Runtime 工作目录"
+        panel.prompt = "启动"
+
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        sessionMonitor.startNativeSession(provider: provider, cwd: url.path)
+    }
+
+    private func nativeRuntimeTint(for provider: SessionProvider) -> Color {
+        switch provider {
+        case .claude:
+            return Color(red: 0.95, green: 0.67, blue: 0.28)
+        case .codex:
+            return Color(red: 0.34, green: 0.72, blue: 0.96)
+        case .copilot:
+            return Color.white.opacity(0.5)
+        }
+    }
 }
 
 // MARK: - Instance Row
@@ -149,6 +211,7 @@ struct InstanceRow: View {
     let onFocus: () -> Void
     let onChat: () -> Void
     let onArchive: () -> Void
+    let onTerminate: () -> Void
     let onApprove: () -> Void
     let onApproveForSession: () -> Void
     let onReject: () -> Void
@@ -189,6 +252,10 @@ struct InstanceRow: View {
 
     private var terminalSourceLabel: String? {
         session.terminalSourceBadgeLabel
+    }
+
+    private var showsNativeRuntimeBadge: Bool {
+        session.ingress == .nativeRuntime
     }
 
     private var titleFontSize: CGFloat {
@@ -238,6 +305,14 @@ struct InstanceRow: View {
                             fontDesign: .monospaced
                         )
                         metaBadge(providerLabel, tint: providerColor.opacity(0.2))
+                        if showsNativeRuntimeBadge {
+                            metaBadge(
+                                "NATIVE",
+                                tint: Color.white.opacity(0.12),
+                                foreground: .white.opacity(0.92),
+                                fontDesign: .monospaced
+                            )
+                        }
                         if session.isRemoteSession {
                             remoteSessionBadge()
                         }
@@ -479,6 +554,16 @@ struct InstanceRow: View {
                 compact: true
             )
 
+            if showsNativeRuntimeBadge {
+                metaBadge(
+                    "NATIVE",
+                    tint: Color.white.opacity(0.12),
+                    foreground: .white.opacity(0.9),
+                    fontDesign: .monospaced,
+                    compact: true
+                )
+            }
+
             if session.isRemoteSession {
                 remoteSessionBadge(compact: true)
             }
@@ -617,6 +702,9 @@ struct InstanceRow: View {
         }
 
         if session.phase == .processing {
+            if session.isNativeRuntimeSession {
+                return sanitized(session.lastMessage) ?? AppLocalization.string("Native runtime 正在处理…")
+            }
             return sanitized(session.lastMessage) ?? AppLocalization.string("工作中...")
         }
 
@@ -625,6 +713,9 @@ struct InstanceRow: View {
         }
 
         if session.phase == .waitingForInput, session.intervention == nil {
+            if session.isNativeRuntimeSession {
+                return sanitized(session.lastMessage) ?? AppLocalization.string("Native session 已就绪")
+            }
             return sanitized(session.lastMessage) ?? AppLocalization.string("等待你的下一条消息")
         }
 
@@ -666,6 +757,12 @@ struct InstanceRow: View {
                 if session.isInTmux && isYabaiAvailable {
                     IconButton(icon: "eye") {
                         onFocus()
+                    }
+                }
+
+                if session.shouldShowTerminateActionInPrimaryUI {
+                    IconButton(icon: "stop.circle") {
+                        onTerminate()
                     }
                 }
 
@@ -712,7 +809,9 @@ struct InstanceRow: View {
     private var compactDetailSummary: String? {
         switch session.phase {
         case .processing:
-            return AppLocalization.string("工作中...")
+            return session.isNativeRuntimeSession
+                ? AppLocalization.string("Native runtime 正在处理…")
+                : AppLocalization.string("工作中...")
         case .compacting:
             return AppLocalization.string("正在压缩上下文...")
         case .waitingForApproval:
@@ -720,11 +819,16 @@ struct InstanceRow: View {
                 ? AppLocalization.string("需要你的输入")
                 : AppLocalization.string("等待批准")
         case .waitingForInput:
-            return session.needsQuestionResponse
-                ? AppLocalization.string("需要你的输入")
+            if session.needsQuestionResponse {
+                return AppLocalization.string("需要你的输入")
+            }
+            return session.isNativeRuntimeSession
+                ? AppLocalization.string("Native session 已就绪")
                 : AppLocalization.string("等待你的下一条消息")
         case .ended:
-            return AppLocalization.string("会话已结束")
+            return session.isNativeRuntimeSession
+                ? AppLocalization.string("Native session 已结束")
+                : AppLocalization.string("会话已结束")
         case .idle:
             return sanitized(session.lastMessage) ?? session.projectName
         }

--- a/PingIsland/UI/Views/SettingsWindowView.swift
+++ b/PingIsland/UI/Views/SettingsWindowView.swift
@@ -4,6 +4,16 @@ import ServiceManagement
 import SwiftUI
 import UniformTypeIdentifiers
 
+protocol NativeRuntimeLaunching {
+    func startSession(provider: SessionProvider, cwd: String) async throws
+}
+
+struct SharedRuntimeLauncher: NativeRuntimeLaunching {
+    func startSession(provider: SessionProvider, cwd: String) async throws {
+        _ = try await RuntimeCoordinator.shared.launchPreferredSession(provider: provider, cwd: cwd)
+    }
+}
+
 private enum SettingsCategory: String, CaseIterable, Identifiable {
     case general
     case display
@@ -86,6 +96,28 @@ final class SettingsPanelViewModel: ObservableObject {
     @Published var nativeRuntimeStatusMessage: String?
 
     private var hookFeedbackClearTasks: [String: Task<Void, Never>] = [:]
+    private let runtimeLauncher: any NativeRuntimeLaunching
+    private let fileExists: @Sendable (String) -> Bool
+    private let setFeatureFlagEnabled: @Sendable (Bool, SessionProvider) -> Void
+
+    init(
+        runtimeLauncher: (any NativeRuntimeLaunching)? = nil,
+        fileExists: @escaping @Sendable (String) -> Bool = { FileManager.default.fileExists(atPath: $0) },
+        setFeatureFlagEnabled: @escaping @Sendable (Bool, SessionProvider) -> Void = { enabled, provider in
+            switch provider {
+            case .claude:
+                FeatureFlags.setEnabled(enabled, for: .nativeClaudeRuntime)
+            case .codex:
+                FeatureFlags.setEnabled(enabled, for: .nativeCodexRuntime)
+            case .copilot:
+                break
+            }
+        }
+    ) {
+        self.runtimeLauncher = runtimeLauncher ?? SharedRuntimeLauncher()
+        self.fileExists = fileExists
+        self.setFeatureFlagEnabled = setFeatureFlagEnabled
+    }
 
     var visibleHookProfiles: [ManagedHookClientProfile] {
         let profiles = ClientProfileRegistry.managedHookProfiles.filter { profile in
@@ -247,12 +279,11 @@ final class SettingsPanelViewModel: ObservableObject {
     }
 
     func setNativeRuntimeEnabled(_ enabled: Bool, for provider: SessionProvider) {
+        setFeatureFlagEnabled(enabled, provider)
         switch provider {
         case .claude:
-            FeatureFlags.setEnabled(enabled, for: .nativeClaudeRuntime)
             nativeClaudeRuntimeEnabled = enabled
         case .codex:
-            FeatureFlags.setEnabled(enabled, for: .nativeCodexRuntime)
             nativeCodexRuntimeEnabled = enabled
         case .copilot:
             break
@@ -281,14 +312,14 @@ final class SettingsPanelViewModel: ObservableObject {
             return
         }
 
-        guard FileManager.default.fileExists(atPath: cwd) else {
+        guard fileExists(cwd) else {
             nativeRuntimeStatusMessage = "目录不存在：\(cwd)"
             return
         }
 
         Task {
             do {
-                _ = try await RuntimeCoordinator.shared.startSession(provider: provider, cwd: cwd)
+                try await runtimeLauncher.startSession(provider: provider, cwd: cwd)
                 await MainActor.run {
                     nativeRuntimeStatusMessage = "\(provider.displayName) Native Runtime 已启动"
                 }

--- a/PingIsland/UI/Views/SettingsWindowView.swift
+++ b/PingIsland/UI/Views/SettingsWindowView.swift
@@ -14,7 +14,7 @@ struct SharedRuntimeLauncher: NativeRuntimeLaunching {
     }
 }
 
-private enum SettingsCategory: String, CaseIterable, Identifiable {
+enum SettingsCategory: String, CaseIterable, Identifiable {
     case general
     case display
     case mascot
@@ -70,6 +70,31 @@ private enum SettingsCategory: String, CaseIterable, Identifiable {
         case .integration: return Color(red: 0.16, green: 0.76, blue: 0.72)
         case .remote: return Color(red: 0.95, green: 0.54, blue: 0.20)
         case .about: return Color(red: 0.17, green: 0.60, blue: 0.96)
+        }
+    }
+}
+
+struct NativeRuntimePreviewUnlockState: Equatable {
+    private(set) var tapCount: Int = 0
+    private(set) var isUnlocked: Bool = false
+    let requiredTapCount: Int
+
+    init(tapCount: Int = 0, isUnlocked: Bool = false, requiredTapCount: Int = 6) {
+        self.tapCount = tapCount
+        self.isUnlocked = isUnlocked
+        self.requiredTapCount = requiredTapCount
+    }
+
+    mutating func registerTap(on category: SettingsCategory) {
+        guard !isUnlocked else { return }
+
+        if category == .general {
+            tapCount += 1
+            if tapCount >= requiredTapCount {
+                isUnlocked = true
+            }
+        } else {
+            tapCount = 0
         }
     }
 }
@@ -460,6 +485,7 @@ private struct SettingsPanelContentView: View {
     let presentation: SettingsPanelPresentation
     var onClose: (() -> Void)? = nil
     var onMinimize: (() -> Void)? = nil
+    @AppStorage("settings.nativeRuntimePreviewUnlocked") private var nativeRuntimePreviewUnlocked = false
 
     @StateObject private var viewModel = SettingsPanelViewModel()
     @ObservedObject private var settings = AppSettings.shared
@@ -468,6 +494,7 @@ private struct SettingsPanelContentView: View {
     @ObservedObject private var updateManager = UpdateManager.shared
     @ObservedObject private var remoteManager = RemoteConnectorManager.shared
     @State private var selectedCategory: SettingsCategory? = .general
+    @State private var nativeRuntimePreviewUnlockState = NativeRuntimePreviewUnlockState()
     @State private var pendingHookReinstallProfile: ManagedHookClientProfile?
     @State private var showingCustomHookInstallSheet = false
     @State private var showingRemoteHostSheet = false
@@ -504,6 +531,10 @@ private struct SettingsPanelContentView: View {
         .onAppear {
             viewModel.refresh()
             ensureValidSelectedSoundPack()
+            nativeRuntimePreviewUnlockState = NativeRuntimePreviewUnlockState(
+                tapCount: nativeRuntimePreviewUnlockState.tapCount,
+                isUnlocked: nativeRuntimePreviewUnlocked
+            )
         }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
             viewModel.refresh()
@@ -659,6 +690,10 @@ private struct SettingsPanelContentView: View {
                         VStack(alignment: .leading, spacing: 4) {
                             ForEach(section.categories) { category in
                                 Button {
+                                    nativeRuntimePreviewUnlockState.registerTap(on: category)
+                                    if nativeRuntimePreviewUnlockState.isUnlocked {
+                                        nativeRuntimePreviewUnlocked = true
+                                    }
                                     selectedCategory = category
                                 } label: {
                                     SidebarItemView(
@@ -1216,8 +1251,10 @@ private struct SettingsPanelContentView: View {
                 }
             }
 
-            SettingsSectionCard(title: "Native Runtime Preview") {
-                NativeRuntimePreviewSection(viewModel: viewModel)
+            if nativeRuntimePreviewUnlocked {
+                SettingsSectionCard(title: "Native Runtime Preview") {
+                    NativeRuntimePreviewSection(viewModel: viewModel)
+                }
             }
         }
     }

--- a/PingIsland/UI/Views/SettingsWindowView.swift
+++ b/PingIsland/UI/Views/SettingsWindowView.swift
@@ -80,6 +80,10 @@ final class SettingsPanelViewModel: ObservableObject {
     @Published private(set) var reinstallingHookProfileID: String?
     @Published private(set) var hookReinstallFeedbacks: [String: HookReinstallFeedback] = [:]
     @Published private(set) var customHookInstallations: [HookInstaller.CustomHookInstallation] = []
+    @Published var nativeClaudeRuntimeEnabled = FeatureFlags.nativeClaudeRuntime
+    @Published var nativeCodexRuntimeEnabled = FeatureFlags.nativeCodexRuntime
+    @Published var nativeRuntimeWorkingDirectory = FileManager.default.homeDirectoryForCurrentUser.path
+    @Published var nativeRuntimeStatusMessage: String?
 
     private var hookFeedbackClearTasks: [String: Task<Void, Never>] = [:]
 
@@ -112,6 +116,8 @@ final class SettingsPanelViewModel: ObservableObject {
         ScreenSelector.shared.refreshScreens()
         SoundPackCatalog.shared.refresh()
         refreshLocalizedState()
+        nativeClaudeRuntimeEnabled = FeatureFlags.nativeClaudeRuntime
+        nativeCodexRuntimeEnabled = FeatureFlags.nativeCodexRuntime
     }
 
     func refreshLocalizedState() {
@@ -238,6 +244,60 @@ final class SettingsPanelViewModel: ObservableObject {
             return
         }
         NSWorkspace.shared.open(url)
+    }
+
+    func setNativeRuntimeEnabled(_ enabled: Bool, for provider: SessionProvider) {
+        switch provider {
+        case .claude:
+            FeatureFlags.setEnabled(enabled, for: .nativeClaudeRuntime)
+            nativeClaudeRuntimeEnabled = enabled
+        case .codex:
+            FeatureFlags.setEnabled(enabled, for: .nativeCodexRuntime)
+            nativeCodexRuntimeEnabled = enabled
+        case .copilot:
+            break
+        }
+    }
+
+    func selectNativeRuntimeDirectory() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.showsHiddenFiles = true
+        panel.directoryURL = URL(fileURLWithPath: nativeRuntimeWorkingDirectory)
+        panel.message = "选择 Native Runtime 工作目录"
+        panel.prompt = "选择"
+
+        if panel.runModal() == .OK, let url = panel.url {
+            nativeRuntimeWorkingDirectory = url.path
+        }
+    }
+
+    func startNativeRuntimeSession(provider: SessionProvider) {
+        let cwd = nativeRuntimeWorkingDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !cwd.isEmpty else {
+            nativeRuntimeStatusMessage = "请先选择工作目录"
+            return
+        }
+
+        guard FileManager.default.fileExists(atPath: cwd) else {
+            nativeRuntimeStatusMessage = "目录不存在：\(cwd)"
+            return
+        }
+
+        Task {
+            do {
+                _ = try await RuntimeCoordinator.shared.startSession(provider: provider, cwd: cwd)
+                await MainActor.run {
+                    nativeRuntimeStatusMessage = "\(provider.displayName) Native Runtime 已启动"
+                }
+            } catch {
+                await MainActor.run {
+                    nativeRuntimeStatusMessage = error.localizedDescription
+                }
+            }
+        }
     }
 
     func exportLogs() {
@@ -1123,6 +1183,10 @@ private struct SettingsPanelContentView: View {
                         viewModel.openAccessibilitySettings()
                     }
                 }
+            }
+
+            SettingsSectionCard(title: "Native Runtime Preview") {
+                NativeRuntimePreviewSection(viewModel: viewModel)
             }
         }
     }
@@ -2583,6 +2647,99 @@ private struct SettingsClientIcon: View {
         return prefersBundledLogoOverAppIcon || resolvedAppIcon == nil
             ? logoAssetName
             : nil
+    }
+}
+
+private struct NativeRuntimePreviewSection: View {
+    @ObservedObject var viewModel: SettingsPanelViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("独立于当前默认实现，仅用于手动体验新的原生 Claude/Codex runtime。")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(.white.opacity(0.58))
+                    .fixedSize(horizontal: false, vertical: true)
+
+                HStack(spacing: 10) {
+                    Toggle(isOn: Binding(
+                        get: { viewModel.nativeClaudeRuntimeEnabled },
+                        set: { viewModel.setNativeRuntimeEnabled($0, for: .claude) }
+                    )) {
+                        Text("Claude Native Runtime")
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundColor(.white)
+                    }
+                    .toggleStyle(.switch)
+
+                    Toggle(isOn: Binding(
+                        get: { viewModel.nativeCodexRuntimeEnabled },
+                        set: { viewModel.setNativeRuntimeEnabled($0, for: .codex) }
+                    )) {
+                        Text("Codex Native Runtime")
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundColor(.white)
+                    }
+                    .toggleStyle(.switch)
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("工作目录")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(.white.opacity(0.7))
+
+                HStack(spacing: 8) {
+                    TextField("", text: $viewModel.nativeRuntimeWorkingDirectory)
+                        .textFieldStyle(.plain)
+                        .font(.system(size: 12, weight: .medium, design: .monospaced))
+                        .foregroundColor(.white)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 8)
+                        .background(
+                            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                                .fill(.white.opacity(0.06))
+                        )
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                                .strokeBorder(.white.opacity(0.1), lineWidth: 1)
+                        )
+
+                    HookManagementButton(
+                        title: "选择目录",
+                        tint: TerminalColors.blue,
+                        action: viewModel.selectNativeRuntimeDirectory
+                    )
+                }
+            }
+
+            HStack(spacing: 10) {
+                HookManagementButton(
+                    title: "启动 Claude",
+                    tint: brandTint(.claude),
+                    isDisabled: !viewModel.nativeClaudeRuntimeEnabled,
+                    action: { viewModel.startNativeRuntimeSession(provider: .claude) }
+                )
+
+                HookManagementButton(
+                    title: "启动 Codex",
+                    tint: brandTint(.codex),
+                    isDisabled: !viewModel.nativeCodexRuntimeEnabled,
+                    action: { viewModel.startNativeRuntimeSession(provider: .codex) }
+                )
+            }
+
+            if let nativeRuntimeStatusMessage = viewModel.nativeRuntimeStatusMessage,
+               !nativeRuntimeStatusMessage.isEmpty {
+                Text(nativeRuntimeStatusMessage)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(.white.opacity(0.68))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(.horizontal, 18)
+        .padding(.vertical, 14)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 

--- a/PingIslandTests/FeatureFlagsTests.swift
+++ b/PingIslandTests/FeatureFlagsTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import Ping_Island
+
+final class FeatureFlagsTests: XCTestCase {
+    func testEnvironmentOverridesUserDefaultsForTruthyValues() {
+        let defaults = UserDefaults(suiteName: #function)!
+        defaults.removePersistentDomain(forName: #function)
+        defaults.set(false, forKey: RuntimeFeatureFlag.nativeClaudeRuntime.defaultsKey)
+
+        XCTAssertTrue(
+            FeatureFlags.isEnabled(
+                .nativeClaudeRuntime,
+                defaults: defaults,
+                environment: [RuntimeFeatureFlag.nativeClaudeRuntime.environmentKey: "true"]
+            )
+        )
+    }
+
+    func testEnvironmentOverridesUserDefaultsForFalsyValues() {
+        let defaults = UserDefaults(suiteName: #function)!
+        defaults.removePersistentDomain(forName: #function)
+        defaults.set(true, forKey: RuntimeFeatureFlag.nativeCodexRuntime.defaultsKey)
+
+        XCTAssertFalse(
+            FeatureFlags.isEnabled(
+                .nativeCodexRuntime,
+                defaults: defaults,
+                environment: [RuntimeFeatureFlag.nativeCodexRuntime.environmentKey: "off"]
+            )
+        )
+    }
+
+    func testFallsBackToUserDefaultsWhenEnvironmentIsMissing() {
+        let defaults = UserDefaults(suiteName: #function)!
+        defaults.removePersistentDomain(forName: #function)
+        defaults.set(true, forKey: RuntimeFeatureFlag.nativeCodexRuntime.defaultsKey)
+
+        XCTAssertTrue(
+            FeatureFlags.isEnabled(
+                .nativeCodexRuntime,
+                defaults: defaults,
+                environment: [:]
+            )
+        )
+    }
+}

--- a/PingIslandTests/HookInstallerTemporarySettingsTests.swift
+++ b/PingIslandTests/HookInstallerTemporarySettingsTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+@testable import Ping_Island
+
+final class HookInstallerTemporarySettingsTests: XCTestCase {
+    func testCreateTemporarySettingsFileIncludesClaudeHookEvents() throws {
+        let settingsURL = try XCTUnwrap(HookInstaller.createTemporarySettingsFile(for: "claude-hooks"))
+        defer { HookInstaller.removeTemporarySettingsFile(at: settingsURL) }
+
+        let data = try Data(contentsOf: settingsURL)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let hooks = try XCTUnwrap(json["hooks"] as? [String: Any])
+
+        XCTAssertNotNil(hooks["SessionStart"])
+        XCTAssertNotNil(hooks["PreToolUse"])
+        XCTAssertNotNil(hooks["PermissionRequest"])
+        XCTAssertNotNil(hooks["Stop"])
+    }
+}

--- a/PingIslandTests/NativeRuntimePreviewUnlockStateTests.swift
+++ b/PingIslandTests/NativeRuntimePreviewUnlockStateTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import Ping_Island
+
+final class NativeRuntimePreviewUnlockStateTests: XCTestCase {
+    func testGeneralNeedsSixConsecutiveTapsToUnlock() {
+        var state = NativeRuntimePreviewUnlockState()
+
+        for _ in 0..<5 {
+            state.registerTap(on: .general)
+        }
+
+        XCTAssertFalse(state.isUnlocked)
+        XCTAssertEqual(state.tapCount, 5)
+
+        state.registerTap(on: .general)
+
+        XCTAssertTrue(state.isUnlocked)
+        XCTAssertEqual(state.tapCount, 6)
+    }
+
+    func testNonGeneralTapResetsProgress() {
+        var state = NativeRuntimePreviewUnlockState()
+
+        state.registerTap(on: .general)
+        state.registerTap(on: .general)
+        state.registerTap(on: .integration)
+
+        XCTAssertFalse(state.isUnlocked)
+        XCTAssertEqual(state.tapCount, 0)
+    }
+}

--- a/PingIslandTests/NativeRuntimeSessionStoreTests.swift
+++ b/PingIslandTests/NativeRuntimeSessionStoreTests.swift
@@ -1,0 +1,121 @@
+import XCTest
+@testable import Ping_Island
+
+@MainActor
+final class NativeRuntimeSessionStoreTests: XCTestCase {
+    private actor StubRuntime: SessionRuntime {
+        let provider: SessionProvider
+        nonisolated let events: AsyncStream<SessionRuntimeEvent>
+
+        private var continuation: AsyncStream<SessionRuntimeEvent>.Continuation?
+
+        init(provider: SessionProvider) {
+            self.provider = provider
+            var capturedContinuation: AsyncStream<SessionRuntimeEvent>.Continuation?
+            self.events = AsyncStream { continuation in
+                capturedContinuation = continuation
+            }
+            self.continuation = capturedContinuation
+        }
+
+        func prepare() async {}
+        func shutdown() async {}
+        func isAvailable() async -> Bool { true }
+
+        func startSession(_ request: SessionRuntimeLaunchRequest) async throws -> SessionRuntimeHandle {
+            let handle = SessionRuntimeHandle(
+                sessionID: request.preferredSessionID ?? UUID().uuidString,
+                provider: provider,
+                cwd: request.cwd,
+                createdAt: Date(),
+                resumeToken: request.resumeSessionID,
+                runtimeIdentifier: "stub-\(provider.rawValue)",
+                sessionFilePath: nil
+            )
+            continuation?.yield(.started(handle))
+            return handle
+        }
+
+        func resumeSession(id: String) async throws -> SessionRuntimeHandle {
+            let handle = SessionRuntimeHandle(
+                sessionID: id,
+                provider: provider,
+                cwd: "/tmp",
+                createdAt: Date(),
+                resumeToken: id,
+                runtimeIdentifier: "stub-\(provider.rawValue)",
+                sessionFilePath: nil
+            )
+            continuation?.yield(.started(handle))
+            return handle
+        }
+
+        func terminateSession(id: String) async throws {
+            continuation?.yield(.stopped(sessionID: id, reason: .cancelled))
+        }
+    }
+
+    private let claudeRuntime = StubRuntime(provider: .claude)
+    private let codexRuntime = StubRuntime(provider: .codex)
+
+    override func setUp() async throws {
+        FeatureFlags.setEnabled(true, for: .nativeClaudeRuntime)
+        FeatureFlags.setEnabled(true, for: .nativeCodexRuntime)
+    }
+
+    override func tearDown() async throws {
+        FeatureFlags.setEnabled(false, for: .nativeClaudeRuntime)
+        FeatureFlags.setEnabled(false, for: .nativeCodexRuntime)
+    }
+
+    func testRuntimeStartedCreatesSessionStateEntry() async throws {
+        let coordinator = RuntimeCoordinator(
+            runtimes: [
+                .claude: claudeRuntime,
+                .codex: codexRuntime,
+            ]
+        )
+        await coordinator.start()
+        defer { Task { await coordinator.stop() } }
+
+        let handle = try await coordinator.startSession(
+            provider: .claude,
+            cwd: "/tmp/native-runtime-test",
+            preferredSessionID: "native-claude-session"
+        )
+
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        let session = await SessionStore.shared.session(for: handle.sessionID)
+        XCTAssertEqual(session?.sessionId, "native-claude-session")
+        XCTAssertEqual(session?.provider, .claude)
+        XCTAssertEqual(session?.ingress, .nativeRuntime)
+        XCTAssertEqual(session?.cwd, "/tmp/native-runtime-test")
+        XCTAssertEqual(session?.clientInfo.origin, "native-runtime")
+    }
+
+    func testRuntimeStoppedMarksSessionEnded() async throws {
+        let coordinator = RuntimeCoordinator(
+            runtimes: [
+                .claude: claudeRuntime,
+                .codex: codexRuntime,
+            ]
+        )
+        await coordinator.start()
+        defer { Task { await coordinator.stop() } }
+
+        let handle = try await coordinator.startSession(
+            provider: .codex,
+            cwd: "/tmp/native-runtime-test-codex",
+            preferredSessionID: "native-codex-session"
+        )
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        try await coordinator.terminateSession(provider: .codex, sessionID: handle.sessionID)
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        let session = await SessionStore.shared.session(for: handle.sessionID)
+        XCTAssertEqual(session?.phase, .ended)
+        XCTAssertEqual(session?.ingress, .nativeRuntime)
+    }
+}

--- a/PingIslandTests/RuntimeSessionRegistryTests.swift
+++ b/PingIslandTests/RuntimeSessionRegistryTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+@testable import Ping_Island
+
+final class RuntimeSessionRegistryTests: XCTestCase {
+    func testUpsertPersistsAndReloadsRecords() async {
+        let tempDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let fileURL = tempDirectory.appendingPathComponent("runtime-sessions.json", isDirectory: false)
+
+        let registry = RuntimeSessionRegistry(fileURL: fileURL)
+        let handle = SessionRuntimeHandle(
+            sessionID: "ses_test_1",
+            provider: .claude,
+            cwd: "/tmp/project",
+            createdAt: Date(timeIntervalSince1970: 1234),
+            resumeToken: "resume-1",
+            runtimeIdentifier: "native-claude",
+            sessionFilePath: "/tmp/project/session.jsonl"
+        )
+
+        await registry.upsert(handle: handle, updatedAt: Date(timeIntervalSince1970: 5678))
+
+        let reloadedRegistry = RuntimeSessionRegistry(fileURL: fileURL)
+        let record = await reloadedRegistry.record(for: "ses_test_1")
+
+        XCTAssertEqual(record?.sessionID, "ses_test_1")
+        XCTAssertEqual(record?.provider, .claude)
+        XCTAssertEqual(record?.cwd, "/tmp/project")
+        XCTAssertEqual(record?.resumeToken, "resume-1")
+        XCTAssertEqual(record?.runtimeIdentifier, "native-claude")
+    }
+
+    func testRemoveDeletesPersistedRecord() async {
+        let tempDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let fileURL = tempDirectory.appendingPathComponent("runtime-sessions.json", isDirectory: false)
+
+        let registry = RuntimeSessionRegistry(fileURL: fileURL)
+        let handle = SessionRuntimeHandle(
+            sessionID: "ses_test_2",
+            provider: .codex,
+            cwd: "/tmp/project",
+            createdAt: Date(),
+            resumeToken: nil,
+            runtimeIdentifier: "native-codex",
+            sessionFilePath: nil
+        )
+
+        await registry.upsert(handle: handle)
+        await registry.remove(sessionID: "ses_test_2")
+
+        let reloadedRegistry = RuntimeSessionRegistry(fileURL: fileURL)
+        let record = await reloadedRegistry.record(for: "ses_test_2")
+
+        XCTAssertNil(record)
+    }
+}

--- a/PingIslandTests/SessionMonitorNativeRuntimeTests.swift
+++ b/PingIslandTests/SessionMonitorNativeRuntimeTests.swift
@@ -1,0 +1,267 @@
+import XCTest
+@testable import Ping_Island
+
+@MainActor
+final class SessionMonitorNativeRuntimeTests: XCTestCase {
+    private actor StubRuntimeCoordinator: RuntimeCoordinating {
+        var managedSessionIDs: Set<String> = []
+        var approvedSessionIDs: [(String, Bool)] = []
+        var deniedSessionIDs: [String] = []
+        var answeredSessionIDs: [(String, [String: [String]])] = []
+
+        func markManaged(_ sessionID: String) {
+            managedSessionIDs.insert(sessionID)
+        }
+
+        func approvals() -> [(String, Bool)] {
+            approvedSessionIDs
+        }
+
+        func denials() -> [String] {
+            deniedSessionIDs
+        }
+
+        func answers() -> [(String, [String: [String]])] {
+            answeredSessionIDs
+        }
+
+        func start() async {}
+        func stop() async {}
+
+        func startSession(
+            provider: SessionProvider,
+            cwd: String,
+            preferredSessionID: String?,
+            metadata: [String: String]
+        ) async throws -> SessionRuntimeHandle {
+            let sessionID = preferredSessionID ?? UUID().uuidString
+            managedSessionIDs.insert(sessionID)
+            return SessionRuntimeHandle(
+                sessionID: sessionID,
+                provider: provider,
+                cwd: cwd,
+                createdAt: Date(),
+                resumeToken: nil,
+                runtimeIdentifier: "stub",
+                sessionFilePath: nil
+            )
+        }
+
+        func terminateSession(provider: SessionProvider, sessionID: String) async throws {}
+        func sendUserInput(provider: SessionProvider, sessionID: String, text: String) async throws {}
+
+        func approveSession(provider: SessionProvider, sessionID: String, forSession: Bool) async throws {
+            approvedSessionIDs.append((sessionID, forSession))
+        }
+
+        func denySession(provider: SessionProvider, sessionID: String, reason: String?) async throws {
+            deniedSessionIDs.append(sessionID)
+        }
+
+        func answerSession(provider: SessionProvider, sessionID: String, answers: [String : [String]]) async throws {
+            answeredSessionIDs.append((sessionID, answers))
+        }
+        func continueSession(provider: SessionProvider, sessionID: String, expectedTurnId: String?, text: String) async throws {}
+
+        func managesNativeSession(sessionID: String, provider: SessionProvider?) async -> Bool {
+            managedSessionIDs.contains(sessionID)
+        }
+    }
+
+    func testHandleIncomingHookEventRoutesManagedSessionToNativeIngress() async {
+        let runtimeCoordinator = StubRuntimeCoordinator()
+        let monitor = SessionMonitor(runtimeCoordinator: runtimeCoordinator)
+        let sessionID = "native-hook-\(UUID().uuidString)"
+        await runtimeCoordinator.markManaged(sessionID)
+
+        let event = HookEvent(
+            sessionId: sessionID,
+            cwd: "/tmp/native-hook",
+            event: "SessionStart",
+            status: "processing",
+            provider: .claude,
+            clientInfo: SessionClientInfo(kind: .claudeCode, name: "Claude Code"),
+            pid: nil,
+            tty: nil,
+            tool: nil,
+            toolInput: nil,
+            toolUseId: nil,
+            notificationType: nil,
+            message: "Starting"
+        )
+
+        await monitor.handleIncomingHookEvent(event)
+
+        let session = await SessionStore.shared.session(for: sessionID)
+        XCTAssertEqual(session?.ingress, .nativeRuntime)
+        await SessionStore.shared.process(.sessionArchived(sessionId: sessionID))
+    }
+
+    func testApprovePermissionUsesNativeRuntimeCoordinatorForNativeSession() async {
+        let runtimeCoordinator = StubRuntimeCoordinator()
+        let monitor = SessionMonitor(runtimeCoordinator: runtimeCoordinator)
+        let sessionID = "native-approval-\(UUID().uuidString)"
+
+        await SessionStore.shared.process(.runtimeSessionStarted(
+            SessionRuntimeHandle(
+                sessionID: sessionID,
+                provider: .claude,
+                cwd: "/tmp/native-approval",
+                createdAt: Date(),
+                resumeToken: nil,
+                runtimeIdentifier: "stub",
+                sessionFilePath: nil
+            )
+        ))
+        await runtimeCoordinator.markManaged(sessionID)
+        await SessionStore.shared.process(.hookReceived(
+            HookEvent(
+                sessionId: sessionID,
+                cwd: "/tmp/native-approval",
+                event: "PermissionRequest",
+                status: "waiting_for_approval",
+                provider: .claude,
+                clientInfo: SessionClientInfo(kind: .claudeCode, name: "Claude Code"),
+                pid: nil,
+                tty: nil,
+                tool: "Bash",
+                toolInput: ["command": AnyCodable("pwd")],
+                toolUseId: "tool-native-approve",
+                notificationType: nil,
+                message: nil,
+                ingress: .nativeRuntime
+            )
+        ))
+
+        monitor.approvePermission(sessionId: sessionID, forSession: true)
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        let approved = await runtimeCoordinator.approvals()
+        XCTAssertEqual(approved.count, 1)
+        XCTAssertEqual(approved.first?.0, sessionID)
+        XCTAssertEqual(approved.first?.1, true)
+
+        await SessionStore.shared.process(.sessionArchived(sessionId: sessionID))
+    }
+
+    func testHandleIncomingHookEventRoutesQuestionInterventionToNativeSession() async {
+        let runtimeCoordinator = StubRuntimeCoordinator()
+        let monitor = SessionMonitor(runtimeCoordinator: runtimeCoordinator)
+        let sessionID = "native-question-\(UUID().uuidString)"
+        await runtimeCoordinator.markManaged(sessionID)
+
+        await monitor.handleIncomingHookEvent(
+            HookEvent(
+                sessionId: sessionID,
+                cwd: "/tmp/native-question",
+                event: "PreToolUse",
+                status: "waiting_for_input",
+                provider: .claude,
+                clientInfo: SessionClientInfo(kind: .claudeCode, name: "Claude Code"),
+                pid: nil,
+                tty: nil,
+                tool: "AskUserQuestion",
+                toolInput: [
+                    "questions": AnyCodable([
+                        [
+                            "id": "color",
+                            "header": "颜色",
+                            "question": "请选择喜欢的颜色",
+                            "options": [["label": "蓝色"], ["label": "绿色"]]
+                        ]
+                    ])
+                ],
+                toolUseId: "tool-native-question",
+                notificationType: nil,
+                message: nil
+            )
+        )
+
+        let session = await SessionStore.shared.session(for: sessionID)
+        XCTAssertEqual(session?.ingress, .nativeRuntime)
+        XCTAssertEqual(session?.phase, .waitingForInput)
+        XCTAssertEqual(session?.intervention?.kind, .question)
+        XCTAssertEqual(session?.intervention?.questions.first?.prompt, "请选择喜欢的颜色")
+
+        await SessionStore.shared.process(.sessionArchived(sessionId: sessionID))
+    }
+
+    func testDenyAndAnswerUseNativeRuntimeCoordinatorForNativeSession() async {
+        let runtimeCoordinator = StubRuntimeCoordinator()
+        let monitor = SessionMonitor(runtimeCoordinator: runtimeCoordinator)
+        let sessionID = "native-deny-answer-\(UUID().uuidString)"
+
+        await SessionStore.shared.process(.runtimeSessionStarted(
+            SessionRuntimeHandle(
+                sessionID: sessionID,
+                provider: .claude,
+                cwd: "/tmp/native-deny-answer",
+                createdAt: Date(),
+                resumeToken: nil,
+                runtimeIdentifier: "stub",
+                sessionFilePath: nil
+            )
+        ))
+        await runtimeCoordinator.markManaged(sessionID)
+
+        await monitor.handleIncomingHookEvent(
+            HookEvent(
+                sessionId: sessionID,
+                cwd: "/tmp/native-deny-answer",
+                event: "PreToolUse",
+                status: "waiting_for_input",
+                provider: .claude,
+                clientInfo: SessionClientInfo(kind: .claudeCode, name: "Claude Code"),
+                pid: nil,
+                tty: nil,
+                tool: "AskUserQuestion",
+                toolInput: [
+                    "questions": AnyCodable([
+                        [
+                            "id": "mode",
+                            "header": "模式",
+                            "question": "请选择模式",
+                            "options": [["label": "自动"], ["label": "手动"]]
+                        ]
+                    ])
+                ],
+                toolUseId: "tool-native-ask",
+                notificationType: nil,
+                message: nil
+            )
+        )
+
+        monitor.answerIntervention(sessionId: sessionID, answers: ["mode": ["自动"]])
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        let answers = await runtimeCoordinator.answers()
+        XCTAssertEqual(answers.count, 1)
+        XCTAssertEqual(answers.first?.0, sessionID)
+        XCTAssertEqual(answers.first?.1["mode"], ["自动"])
+
+        await SessionStore.shared.process(.hookReceived(
+            HookEvent(
+                sessionId: sessionID,
+                cwd: "/tmp/native-deny-answer",
+                event: "PermissionRequest",
+                status: "waiting_for_approval",
+                provider: .claude,
+                clientInfo: SessionClientInfo(kind: .claudeCode, name: "Claude Code"),
+                pid: nil,
+                tty: nil,
+                tool: "Bash",
+                toolInput: ["command": AnyCodable("ls")],
+                toolUseId: "tool-native-deny",
+                notificationType: nil,
+                message: nil,
+                ingress: .nativeRuntime
+            )
+        ))
+
+        monitor.denyPermission(sessionId: sessionID, reason: "nope")
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        let denials = await runtimeCoordinator.denials()
+        XCTAssertEqual(denials, [sessionID])
+
+        await SessionStore.shared.process(.sessionArchived(sessionId: sessionID))
+    }
+}

--- a/PingIslandTests/SessionMonitorNativeRuntimeTests.swift
+++ b/PingIslandTests/SessionMonitorNativeRuntimeTests.swift
@@ -66,6 +66,15 @@ final class SessionMonitorNativeRuntimeTests: XCTestCase {
         func managesNativeSession(sessionID: String, provider: SessionProvider?) async -> Bool {
             managedSessionIDs.contains(sessionID)
         }
+
+        func launchPreferredSession(provider: SessionProvider, cwd: String) async throws -> SessionRuntimeHandle {
+            try await startSession(
+                provider: provider,
+                cwd: cwd,
+                preferredSessionID: nil,
+                metadata: [:]
+            )
+        }
     }
 
     func testHandleIncomingHookEventRoutesManagedSessionToNativeIngress() async {

--- a/PingIslandTests/SessionStateTests.swift
+++ b/PingIslandTests/SessionStateTests.swift
@@ -220,6 +220,26 @@ final class SessionStateTests: XCTestCase {
         XCTAssertTrue(session.shouldShowArchiveActionInPrimaryUI)
     }
 
+    func testNativeRuntimeSessionExposesTerminateActionUntilEnded() {
+        let activeSession = SessionState(
+            sessionId: "native-active",
+            cwd: "/tmp/project",
+            ingress: .nativeRuntime,
+            phase: .processing
+        )
+        let endedSession = SessionState(
+            sessionId: "native-ended",
+            cwd: "/tmp/project",
+            ingress: .nativeRuntime,
+            phase: .ended
+        )
+
+        XCTAssertTrue(activeSession.isNativeRuntimeSession)
+        XCTAssertTrue(activeSession.shouldShowTerminateActionInPrimaryUI)
+        XCTAssertTrue(endedSession.isNativeRuntimeSession)
+        XCTAssertFalse(endedSession.shouldShowTerminateActionInPrimaryUI)
+    }
+
     func testCodexAppLaunchURLUsesThreadsRoute() {
         let threadID = "019d6163-2ee9-7ae2-8c45-5f7a16209149"
 

--- a/PingIslandTests/SettingsPanelViewModelTests.swift
+++ b/PingIslandTests/SettingsPanelViewModelTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import Ping_Island
+
+@MainActor
+final class SettingsPanelViewModelTests: XCTestCase {
+    private actor StubRuntimeLauncher: NativeRuntimeLaunching {
+        var started: [(SessionProvider, String)] = []
+        var nextError: Error?
+
+        func startSession(provider: SessionProvider, cwd: String) async throws {
+            if let nextError {
+                throw nextError
+            }
+            started.append((provider, cwd))
+        }
+
+        func launches() -> [(SessionProvider, String)] {
+            started
+        }
+    }
+
+    func testStartNativeRuntimeSessionValidatesDirectoryBeforeLaunch() async {
+        let launcher = StubRuntimeLauncher()
+        let viewModel = SettingsPanelViewModel(
+            runtimeLauncher: launcher,
+            fileExists: { _ in false }
+        )
+        viewModel.nativeRuntimeWorkingDirectory = "/missing/path"
+
+        viewModel.startNativeRuntimeSession(provider: .claude)
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        XCTAssertEqual(viewModel.nativeRuntimeStatusMessage, "目录不存在：/missing/path")
+        let launches = await launcher.launches()
+        XCTAssertTrue(launches.isEmpty)
+    }
+
+    func testStartNativeRuntimeSessionCallsLauncherAndUpdatesStatus() async {
+        let launcher = StubRuntimeLauncher()
+        let viewModel = SettingsPanelViewModel(
+            runtimeLauncher: launcher,
+            fileExists: { _ in true }
+        )
+        viewModel.nativeRuntimeWorkingDirectory = "/tmp/native-ui-test"
+
+        viewModel.startNativeRuntimeSession(provider: .codex)
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        let launches = await launcher.launches()
+        XCTAssertEqual(launches.count, 1)
+        XCTAssertEqual(launches.first?.0, .codex)
+        XCTAssertEqual(launches.first?.1, "/tmp/native-ui-test")
+        XCTAssertEqual(viewModel.nativeRuntimeStatusMessage, "Codex Native Runtime 已启动")
+    }
+}


### PR DESCRIPTION
## Summary
- add an isolated native runtime layer for Claude and Codex behind feature flags
- route native runtime sessions through SessionStore and shared UI surfaces without changing the legacy default path
- expose native runtime preview launch controls plus native session terminate affordances in the UI

## Testing
- xcodebuild -project /Users/wudanwu/Island-native-runtime/PingIsland.xcodeproj -scheme PingIsland -configuration Debug CODE_SIGNING_ALLOWED=NO test -only-testing:PingIslandTests/FeatureFlagsTests -only-testing:PingIslandTests/RuntimeSessionRegistryTests -only-testing:PingIslandTests/NativeRuntimeSessionStoreTests -only-testing:PingIslandTests/SessionMonitorNativeRuntimeTests -only-testing:PingIslandTests/HookInstallerTemporarySettingsTests -only-testing:PingIslandTests/SettingsPanelViewModelTests -only-testing:PingIslandTests/SessionStateTests