### PR TITLE
[codex] fix Hermes gateway message delivery

### DIFF
--- a/PingIsland/Services/Hooks/HookInstaller.swift
+++ b/PingIsland/Services/Hooks/HookInstaller.swift
@@ -1736,6 +1736,12 @@ struct HookInstaller {
             if not prompt:
                 return None
 
+            _emit_session_start(
+                resolved_id,
+                platform=kwargs.get("platform"),
+                model=kwargs.get("model"),
+                **kwargs,
+            )
             _state_for(resolved_id)["last_user"] = prompt
             _emit(
                 _bridge_payload(
@@ -1787,6 +1793,17 @@ struct HookInstaller {
             reply = _stable_text(assistant_response) or _extract_assistant_message(kwargs)
             if reply:
                 _state_for(resolved_id)["last_assistant"] = reply
+                _emit(
+                    _bridge_payload(
+                        resolved_id,
+                        hook_event_name="Notification",
+                        notification_type="assistant_message",
+                        message=reply,
+                        platform=_stable_text(kwargs.get("platform")),
+                        model=_stable_text(kwargs.get("model")),
+                        cwd=_resolve_cwd(kwargs),
+                    )
+                )
 
 
         def _on_session_end(session_id=None, completed=None, interrupted=None, platform=None, model=None, **kwargs):

--- a/PingIsland/Services/Hooks/HookSocketServer.swift
+++ b/PingIsland/Services/Hooks/HookSocketServer.swift
@@ -11,6 +11,60 @@ import os.log
 
 private let logger = Logger(subsystem: "com.wudanwu.pingisland", category: "Hooks")
 
+private actor HermesHookDebugStore {
+    static let shared = HermesHookDebugStore()
+
+    private let fileManager = FileManager.default
+    private let formatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+
+    nonisolated static var debugDirectoryURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".ping-island-debug", isDirectory: true)
+            .appendingPathComponent("hermes-hooks", isDirectory: true)
+    }
+
+    private init() {}
+
+    func recordRuntime(_ message: String) {
+        let line = "[\(formatter.string(from: Date()))] \(message)\n"
+        append(data: Data(line.utf8), to: Self.debugDirectoryURL.appendingPathComponent("receiver.log"))
+    }
+
+    func recordEvent(_ fields: [String: Any]) {
+        guard JSONSerialization.isValidJSONObject(fields),
+              let data = try? JSONSerialization.data(withJSONObject: fields, options: [.sortedKeys])
+        else {
+            return
+        }
+
+        var line = data
+        line.append(0x0A)
+        let dateKey = formatter.string(from: Date()).prefix(10).replacingOccurrences(of: "-", with: "")
+        append(data: line, to: Self.debugDirectoryURL.appendingPathComponent("\(dateKey)-receiver.jsonl"))
+    }
+
+    private func append(data: Data, to url: URL) {
+        do {
+            try fileManager.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            if !fileManager.fileExists(atPath: url.path) {
+                try data.write(to: url, options: .atomic)
+                return
+            }
+
+            let handle = try FileHandle(forWritingTo: url)
+            defer { try? handle.close() }
+            try handle.seekToEnd()
+            try handle.write(contentsOf: data)
+        } catch {
+            // Keep Hermes diagnostics best-effort so hook delivery never depends on local debug writes.
+        }
+    }
+}
+
 /// Event received from hook clients after bridge-envelope mapping.
 struct HookEvent: Sendable {
     let sessionId: String
@@ -1128,6 +1182,26 @@ class HookSocketServer {
             logger.info(
                 "Hermes bridge envelope event=\(envelope.eventType, privacy: .public) session=\(event.sessionId, privacy: .public) status=\(event.status, privacy: .public) message=\((event.message ?? "").prefix(120), privacy: .public)"
             )
+            Task {
+                await HermesHookDebugStore.shared.recordRuntime(
+                    "socket received event=\(envelope.eventType) session=\(event.sessionId) status=\(event.status) expectsResponse=\(expectsResponse)"
+                )
+                await HermesHookDebugStore.shared.recordEvent([
+                    "timestamp": ISO8601DateFormatter().string(from: Date()),
+                    "stage": "socket_received",
+                    "event_type": envelope.eventType,
+                    "session_id": event.sessionId,
+                    "status": event.status,
+                    "message": event.message ?? "",
+                    "preview": envelope.preview ?? "",
+                    "cwd": event.cwd,
+                    "tool_name": event.tool ?? "",
+                    "tool_use_id": event.toolUseId ?? "",
+                    "originator": event.clientInfo.originator ?? "",
+                    "thread_source": event.clientInfo.threadSource ?? "",
+                    "terminal_bundle_id": event.clientInfo.terminalBundleIdentifier ?? "",
+                ])
+            }
         }
 
         if event.event == "PreToolUse" && event.toolUseId == nil {


### PR DESCRIPTION
## Summary

This PR fixes Hermes gateway sessions not showing assistant message content while the session is active.

## Root cause

Hermes plugin hooks were successfully reaching `ping-island-bridge`, but the generated Hermes plugin only cached assistant text in `post_llm_call` and emitted it later in `Stop` / `SessionEnd`. That meant active Hermes sessions had no reply body to display in Ping Island until the turn was already finished.

## What changed

- emit a `SessionStart` proactively from `pre_llm_call` so gateway turns don't depend on the earlier lifecycle hook ordering
- emit a `Notification` carrying the assistant reply body from `post_llm_call`
- add best-effort Hermes receiver-side diagnostics in `HookSocketServer` to help localize future delivery issues

## Validation

- `swift test --package-path /Users/wudanwu/Island/Prototype --filter HookPayloadMapperTests`
- `xcodebuild -project /Users/wudanwu/Island/PingIsland.xcodeproj -scheme PingIsland -configuration Debug CODE_SIGNING_ALLOWED=NO test -only-testing:PingIslandTests/HermesIntegrationTests`

## Risks / gaps

- no `PingIslandUITests` run
- no full `PingIslandTests` run
- receiver-side Hermes debug files are diagnostics-only and still need follow-up cleanup policy if we want to keep them long-term
