### PR TITLE
[codex] fix Claude question form option clipping

### DIFF
--- a/PingIsland/UI/Components/SessionQuestionForm.swift
+++ b/PingIsland/UI/Components/SessionQuestionForm.swift
@@ -15,6 +15,25 @@ struct SessionQuestionForm: View {
         intervention.resolvedQuestions
     }
 
+    nonisolated static func shouldUseScrollableQuestionList(
+        for questions: [SessionInterventionQuestion]
+    ) -> Bool {
+        if questions.count > 1 {
+            return true
+        }
+
+        return questions.contains { question in
+            let weightedOptions = question.options.reduce(0) { partial, option in
+                partial + (option.detail == nil ? 1 : 2)
+            }
+            return weightedOptions >= 3 || question.allowsOther || question.isSecret
+        }
+    }
+
+    private var shouldUseScrollableQuestionList: Bool {
+        Self.shouldUseScrollableQuestionList(for: displayQuestions)
+    }
+
     init(
         intervention: SessionIntervention,
         submitLabel: String? = nil,
@@ -34,6 +53,47 @@ struct SessionQuestionForm: View {
     }
 
     var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Group {
+                if shouldUseScrollableQuestionList {
+                    ScrollView(.vertical, showsIndicators: false) {
+                        questionsContent
+                            .padding(.vertical, 1)
+                    }
+                    .scrollBounceBehavior(.basedOnSize)
+                    .frame(maxHeight: 230)
+                } else {
+                    questionsContent
+                }
+            }
+
+            HStack(spacing: 8) {
+                if let submitLabel {
+                    Button {
+                        onSubmit(submissionPayload())
+                    }
+                    label: {
+                        Text(appLocalized: submitLabel)
+                    }
+                    .buttonStyle(SessionQuestionButtonStyle(background: Color.white.opacity(0.9), foreground: .black))
+                    .disabled(!canSubmit || !isEditable)
+                }
+
+                if let secondaryActionTitle, let onSecondaryAction {
+                    Button {
+                        onSecondaryAction()
+                    }
+                    label: {
+                        Text(verbatim: secondaryActionTitle)
+                    }
+                    .buttonStyle(SessionQuestionButtonStyle(background: Color.white.opacity(0.1)))
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var questionsContent: some View {
         VStack(alignment: .leading, spacing: 12) {
             ForEach(displayQuestions) { question in
                 VStack(alignment: .leading, spacing: 8) {
@@ -69,31 +129,7 @@ struct SessionQuestionForm: View {
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
-
-            HStack(spacing: 8) {
-                if let submitLabel {
-                    Button {
-                        onSubmit(submissionPayload())
-                    }
-                    label: {
-                        Text(appLocalized: submitLabel)
-                    }
-                    .buttonStyle(SessionQuestionButtonStyle(background: Color.white.opacity(0.9), foreground: .black))
-                    .disabled(!canSubmit || !isEditable)
-                }
-
-                if let secondaryActionTitle, let onSecondaryAction {
-                    Button {
-                        onSecondaryAction()
-                    }
-                    label: {
-                        Text(verbatim: secondaryActionTitle)
-                    }
-                    .buttonStyle(SessionQuestionButtonStyle(background: Color.white.opacity(0.1)))
-                }
-            }
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     @ViewBuilder

--- a/PingIslandTests/SessionQuestionFormTests.swift
+++ b/PingIslandTests/SessionQuestionFormTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+@testable import Ping_Island
+
+final class SessionQuestionFormTests: XCTestCase {
+    func testScrollableQuestionListEnabledForThreeOptionQuestion() {
+        let questions = [
+            SessionInterventionQuestion(
+                id: "plan",
+                header: "方案",
+                prompt: "请选择一个方案",
+                detail: nil,
+                options: [
+                    .init(id: "a", title: "A", detail: nil),
+                    .init(id: "b", title: "B", detail: nil),
+                    .init(id: "c", title: "C", detail: nil),
+                ],
+                allowsMultiple: false,
+                allowsOther: false,
+                isSecret: false
+            )
+        ]
+
+        XCTAssertTrue(SessionQuestionForm.shouldUseScrollableQuestionList(for: questions))
+    }
+
+    func testScrollableQuestionListDisabledForTwoSimpleOptions() {
+        let questions = [
+            SessionInterventionQuestion(
+                id: "plan",
+                header: "方案",
+                prompt: "请选择一个方案",
+                detail: nil,
+                options: [
+                    .init(id: "a", title: "A", detail: nil),
+                    .init(id: "b", title: "B", detail: nil),
+                ],
+                allowsMultiple: false,
+                allowsOther: false,
+                isSecret: false
+            )
+        ]
+
+        XCTAssertFalse(SessionQuestionForm.shouldUseScrollableQuestionList(for: questions))
+    }
+}


### PR DESCRIPTION
## Summary

This PR fixes issue #48 where Claude follow-up question options at the bottom of the Island UI could become effectively unclickable, leaving both the Island and terminal sides stuck.

## Root cause

`SessionQuestionForm` rendered all questions inline with the submit actions but had no internal scroll path. When a question set was tall enough, the lower options could fall into the footer edge of the panel with no way to bring them fully into the safe clickable area.

## What changed

- adds a scrollable question region for tall question sets while keeping the submit / secondary actions anchored below
- introduces a small heuristic to enable the internal scroll region for multi-question or multi-option forms
- adds a regression test for the scrollable-question decision path

## Validation

- `xcodebuild -project PingIsland.xcodeproj -scheme PingIsland -configuration Debug CODE_SIGNING_ALLOWED=NO test -only-testing:PingIslandTests/SessionQuestionFormTests -only-testing:PingIslandTests/ClaudeAskUserQuestionSessionTests -only-testing:PingIslandTests/SessionMonitorAskUserQuestionTests`

## Risks / gaps

- no full `PingIslandTests` run
- no manual UI verification yet on the exact Claude issue flow from #48
