### PR TITLE
Adapt Island width and height to the system notch size

### DIFF
--- a/PingIsland/Core/Ext+NSScreen.swift
+++ b/PingIsland/Core/Ext+NSScreen.swift
@@ -8,26 +8,18 @@
 import AppKit
 
 extension NSScreen {
-    /// Returns the size of the notch on this screen (pixel-perfect using macOS APIs)
+    var notchMetrics: ScreenNotchMetrics {
+        ScreenNotchMetrics.detect(
+            screenFrame: frame,
+            safeAreaTop: safeAreaInsets.top,
+            auxiliaryTopLeftWidth: auxiliaryTopLeftArea?.width,
+            auxiliaryTopRightWidth: auxiliaryTopRightArea?.width
+        )
+    }
+
+    /// Returns the size of the notch on this screen using macOS safe-area APIs when available.
     var notchSize: CGSize {
-        guard safeAreaInsets.top > 0 else {
-            // Fallback for non-notch displays (matches typical MacBook notch)
-            return CGSize(width: 224, height: 38)
-        }
-
-        let notchHeight = safeAreaInsets.top
-        let fullWidth = frame.width
-        let leftPadding = auxiliaryTopLeftArea?.width ?? 0
-        let rightPadding = auxiliaryTopRightArea?.width ?? 0
-
-        guard leftPadding > 0, rightPadding > 0 else {
-            // Fallback if auxiliary areas unavailable
-            return CGSize(width: 180, height: notchHeight)
-        }
-
-        // +4 to match boring.notch's calculation for proper alignment
-        let notchWidth = fullWidth - leftPadding - rightPadding + 4
-        return CGSize(width: notchWidth, height: notchHeight)
+        notchMetrics.size
     }
 
     /// Whether this is the built-in display
@@ -48,6 +40,6 @@ extension NSScreen {
 
     /// Whether this screen has a physical notch (camera housing)
     var hasPhysicalNotch: Bool {
-        safeAreaInsets.top > 0
+        notchMetrics.hasPhysicalNotch
     }
 }

--- a/PingIsland/Core/NotchViewModel.swift
+++ b/PingIsland/Core/NotchViewModel.swift
@@ -54,7 +54,7 @@ class NotchViewModel: ObservableObject {
     let spacing: CGFloat = 12
     let hasPhysicalNotch: Bool
 
-    private static let defaultClosedHeight: CGFloat = 32
+    private static let defaultClosedHeight = ScreenNotchMetrics.fallbackClosedHeight
     private static let defaultClosedWidth: CGFloat = 266
     @Published private(set) var closedWidth: CGFloat
 
@@ -64,7 +64,7 @@ class NotchViewModel: ObservableObject {
     var closedHeight: CGFloat {
         usesPhysicalNotchClosedPresentation
             ? deviceNotchRect.height
-            : Self.defaultClosedHeight
+            : detectedClosedHeight
     }
     var usesPhysicalNotchClosedPresentation: Bool {
         hasPhysicalNotch && isFullscreenPhysicalNotchCompactActive
@@ -82,6 +82,12 @@ class NotchViewModel: ObservableObject {
             width: closedSize.width,
             height: closedSize.height
         )
+    }
+
+    private var detectedClosedHeight: CGFloat {
+        guard hasPhysicalNotch else { return Self.defaultClosedHeight }
+        let systemHeight = ceil(deviceNotchRect.height)
+        return systemHeight > 0 ? systemHeight : Self.defaultClosedHeight
     }
 
     /// Dynamic opened size based on content type

--- a/PingIsland/Core/NotchViewModel.swift
+++ b/PingIsland/Core/NotchViewModel.swift
@@ -90,6 +90,23 @@ class NotchViewModel: ObservableObject {
         return systemHeight > 0 ? systemHeight : Self.defaultClosedHeight
     }
 
+    private var detectedClosedWidth: CGFloat {
+        Self.detectedClosedWidth(
+            deviceNotchRect: deviceNotchRect,
+            hasPhysicalNotch: hasPhysicalNotch
+        )
+    }
+
+    private static func detectedClosedWidth(
+        deviceNotchRect: CGRect,
+        hasPhysicalNotch: Bool
+    ) -> CGFloat {
+        guard hasPhysicalNotch else { return defaultClosedWidth }
+        let systemWidth = ceil(deviceNotchRect.width)
+        guard systemWidth > 0 else { return defaultClosedWidth }
+        return max(defaultClosedWidth, systemWidth)
+    }
+
     /// Dynamic opened size based on content type
     var openedSize: CGSize {
         let maxAllowedHeight = maximumOpenedHeight
@@ -165,7 +182,10 @@ class NotchViewModel: ObservableObject {
             windowHeight: windowHeight
         )
         self.hasPhysicalNotch = hasPhysicalNotch
-        self.closedWidth = Self.defaultClosedWidth
+        self.closedWidth = Self.detectedClosedWidth(
+            deviceNotchRect: deviceNotchRect,
+            hasPhysicalNotch: hasPhysicalNotch
+        )
         self.events = enableEventMonitoring ? EventMonitors.shared : nil
         self.fullscreenActivityProvider = fullscreenActivityProvider
         if enableEventMonitoring {
@@ -490,7 +510,7 @@ class NotchViewModel: ObservableObject {
     }
 
     func setManualAttentionActive(_ isActive: Bool) {
-        let targetWidth = Self.defaultClosedWidth
+        let targetWidth = detectedClosedWidth
         guard closedWidth != targetWidth else { return }
         closedWidth = targetWidth
     }

--- a/PingIsland/Core/ScreenNotchMetrics.swift
+++ b/PingIsland/Core/ScreenNotchMetrics.swift
@@ -1,0 +1,54 @@
+//
+//  ScreenNotchMetrics.swift
+//  PingIsland
+//
+//  Centralizes system notch detection and fallbacks.
+//
+
+import CoreGraphics
+
+struct ScreenNotchMetrics: Equatable {
+    static let fallbackClosedHeight: CGFloat = 32
+    static let fallbackNotchWidth: CGFloat = 180
+    static let fallbackSize = CGSize(width: 224, height: 38)
+
+    let size: CGSize
+    let hasPhysicalNotch: Bool
+
+    var closedHeight: CGFloat {
+        hasPhysicalNotch ? size.height : Self.fallbackClosedHeight
+    }
+
+    static func detect(
+        screenFrame: CGRect,
+        safeAreaTop: CGFloat,
+        auxiliaryTopLeftWidth: CGFloat?,
+        auxiliaryTopRightWidth: CGFloat?
+    ) -> ScreenNotchMetrics {
+        let detectedHeight = ceil(safeAreaTop)
+        guard detectedHeight > 0 else {
+            return ScreenNotchMetrics(
+                size: Self.fallbackSize,
+                hasPhysicalNotch: false
+            )
+        }
+
+        let leftPadding = max(0, auxiliaryTopLeftWidth ?? 0)
+        let rightPadding = max(0, auxiliaryTopRightWidth ?? 0)
+        let detectedWidth: CGFloat
+
+        if leftPadding > 0, rightPadding > 0 {
+            detectedWidth = max(
+                Self.fallbackNotchWidth,
+                ceil(screenFrame.width - leftPadding - rightPadding + 4)
+            )
+        } else {
+            detectedWidth = Self.fallbackNotchWidth
+        }
+
+        return ScreenNotchMetrics(
+            size: CGSize(width: detectedWidth, height: detectedHeight),
+            hasPhysicalNotch: true
+        )
+    }
+}

--- a/PingIslandTests/NotchViewModelTests.swift
+++ b/PingIslandTests/NotchViewModelTests.swift
@@ -61,6 +61,23 @@ final class NotchViewModelTests: XCTestCase {
         }
     }
 
+    func testClosedHeightUsesDetectedSystemNotchHeight() async {
+        await MainActor.run {
+            let viewModel = NotchViewModel(
+                deviceNotchRect: CGRect(x: 0, y: 0, width: 220, height: 38),
+                screenRect: CGRect(x: 0, y: 0, width: 1512, height: 982),
+                windowHeight: 320,
+                hasPhysicalNotch: true,
+                enableEventMonitoring: false,
+                observeSystemEnvironment: false,
+                fullscreenActivityProvider: { _ in false }
+            )
+
+            XCTAssertEqual(viewModel.closedHeight, 38)
+            XCTAssertEqual(viewModel.closedSize, CGSize(width: 266, height: 38))
+        }
+    }
+
     func testPresentChatOpensClickedNotchAndShowsTargetSession() async {
         await MainActor.run {
             let viewModel = makeViewModel()

--- a/PingIslandTests/NotchViewModelTests.swift
+++ b/PingIslandTests/NotchViewModelTests.swift
@@ -78,6 +78,23 @@ final class NotchViewModelTests: XCTestCase {
         }
     }
 
+    func testClosedWidthExpandsToCoverWiderDetectedSystemNotch() async {
+        await MainActor.run {
+            let viewModel = NotchViewModel(
+                deviceNotchRect: CGRect(x: 0, y: 0, width: 312, height: 38),
+                screenRect: CGRect(x: 0, y: 0, width: 1728, height: 1117),
+                windowHeight: 320,
+                hasPhysicalNotch: true,
+                enableEventMonitoring: false,
+                observeSystemEnvironment: false,
+                fullscreenActivityProvider: { _ in false }
+            )
+
+            XCTAssertEqual(viewModel.closedWidth, 312)
+            XCTAssertEqual(viewModel.closedSize, CGSize(width: 312, height: 38))
+        }
+    }
+
     func testPresentChatOpensClickedNotchAndShowsTargetSession() async {
         await MainActor.run {
             let viewModel = makeViewModel()

--- a/PingIslandTests/ScreenNotchMetricsTests.swift
+++ b/PingIslandTests/ScreenNotchMetricsTests.swift
@@ -1,0 +1,44 @@
+import CoreGraphics
+import XCTest
+@testable import Ping_Island
+
+final class ScreenNotchMetricsTests: XCTestCase {
+    func testDetectUsesSafeAreaHeightForPhysicalNotchDisplays() {
+        let metrics = ScreenNotchMetrics.detect(
+            screenFrame: CGRect(x: 0, y: 0, width: 1512, height: 982),
+            safeAreaTop: 38,
+            auxiliaryTopLeftWidth: 620,
+            auxiliaryTopRightWidth: 620
+        )
+
+        XCTAssertTrue(metrics.hasPhysicalNotch)
+        XCTAssertEqual(metrics.size, CGSize(width: 276, height: 38))
+        XCTAssertEqual(metrics.closedHeight, 38)
+    }
+
+    func testDetectFallsBackToDefaultWidthWhenAuxiliaryAreasAreUnavailable() {
+        let metrics = ScreenNotchMetrics.detect(
+            screenFrame: CGRect(x: 0, y: 0, width: 1728, height: 1117),
+            safeAreaTop: 37,
+            auxiliaryTopLeftWidth: nil,
+            auxiliaryTopRightWidth: nil
+        )
+
+        XCTAssertTrue(metrics.hasPhysicalNotch)
+        XCTAssertEqual(metrics.size, CGSize(width: 180, height: 37))
+        XCTAssertEqual(metrics.closedHeight, 37)
+    }
+
+    func testDetectFallsBackForNonNotchDisplays() {
+        let metrics = ScreenNotchMetrics.detect(
+            screenFrame: CGRect(x: 0, y: 0, width: 1440, height: 900),
+            safeAreaTop: 0,
+            auxiliaryTopLeftWidth: nil,
+            auxiliaryTopRightWidth: nil
+        )
+
+        XCTAssertFalse(metrics.hasPhysicalNotch)
+        XCTAssertEqual(metrics.size, ScreenNotchMetrics.fallbackSize)
+        XCTAssertEqual(metrics.closedHeight, ScreenNotchMetrics.fallbackClosedHeight)
+    }
+}


### PR DESCRIPTION
## Summary
- derive notch metrics from macOS safe-area and auxiliary top-area APIs in one place
- use the detected notch height for the closed Island on physical-notch displays
- let the closed Island widen to match larger physical notches while preserving the existing minimum width elsewhere
- add unit tests covering notch detection fallbacks plus closed height and width behavior

## Testing
- `xcodebuild -project PingIsland.xcodeproj -scheme PingIsland -configuration Debug CODE_SIGNING_ALLOWED=NO test -only-testing:PingIslandTests/NotchViewModelTests -only-testing:PingIslandTests/ScreenNotchMetricsTests`

## Fixes
- Fixes #53
- Fixes #58

## Notes
- existing unrelated working-tree changes were intentionally left out of this branch commits
- manual visual verification on 16-inch MacBook Pro and 15-inch MacBook Air notch hardware is still pending
