### PR TITLE
[codex] fix Chrome fullscreen suppression false positive

### DIFF
--- a/PingIsland/Core/NotchViewModel.swift
+++ b/PingIsland/Core/NotchViewModel.swift
@@ -164,6 +164,8 @@ class NotchViewModel: ObservableObject {
     private let fullscreenHoverActivationDelay: TimeInterval = 0.18
     private let fullscreenRevealZoneHeight: CGFloat = 8
     private let fullscreenRevealZoneHorizontalInset: CGFloat = 36
+    private let fullscreenStateSettleDelay: TimeInterval
+    private var fullscreenPhysicalNotchCollapseWorkItem: DispatchWorkItem?
 
     // MARK: - Initialization
 
@@ -174,7 +176,8 @@ class NotchViewModel: ObservableObject {
         hasPhysicalNotch: Bool,
         enableEventMonitoring: Bool = true,
         observeSystemEnvironment: Bool = true,
-        fullscreenActivityProvider: @escaping @MainActor (CGRect) -> Bool = FullscreenAppDetector.isFullscreenAppActive
+        fullscreenActivityProvider: @escaping @MainActor (CGRect) -> Bool = FullscreenAppDetector.isFullscreenAppActive,
+        fullscreenStateSettleDelay: TimeInterval = 0.18
     ) {
         self.geometry = NotchGeometry(
             deviceNotchRect: deviceNotchRect,
@@ -188,6 +191,7 @@ class NotchViewModel: ObservableObject {
         )
         self.events = enableEventMonitoring ? EventMonitors.shared : nil
         self.fullscreenActivityProvider = fullscreenActivityProvider
+        self.fullscreenStateSettleDelay = fullscreenStateSettleDelay
         if enableEventMonitoring {
             setupEventHandlers()
         }
@@ -232,9 +236,7 @@ class NotchViewModel: ObservableObject {
             isFullscreenActive
         let shouldUsePhysicalNotchCompact = hasPhysicalNotch && isFullscreenActive
 
-        if shouldUsePhysicalNotchCompact != isFullscreenPhysicalNotchCompactActive {
-            isFullscreenPhysicalNotchCompactActive = shouldUsePhysicalNotchCompact
-        }
+        applyPhysicalNotchFullscreenState(shouldUsePhysicalNotchCompact)
 
         guard shouldUseEdgeReveal != isFullscreenEdgeRevealActive else { return }
         isFullscreenEdgeRevealActive = shouldUseEdgeReveal
@@ -247,6 +249,37 @@ class NotchViewModel: ObservableObject {
                 notchClose()
             }
         }
+    }
+
+    func refreshFullscreenPresentationStateForTesting() {
+        refreshFullscreenPresentationState()
+    }
+
+    private func applyPhysicalNotchFullscreenState(_ shouldUsePhysicalNotchCompact: Bool) {
+        if shouldUsePhysicalNotchCompact {
+            fullscreenPhysicalNotchCollapseWorkItem?.cancel()
+            fullscreenPhysicalNotchCollapseWorkItem = nil
+            if !isFullscreenPhysicalNotchCompactActive {
+                isFullscreenPhysicalNotchCompactActive = true
+            }
+            return
+        }
+
+        guard isFullscreenPhysicalNotchCompactActive else { return }
+
+        fullscreenPhysicalNotchCollapseWorkItem?.cancel()
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            self.fullscreenPhysicalNotchCollapseWorkItem = nil
+            let isFullscreenActive = self.fullscreenActivityProvider(self.screenRect)
+            if self.hasPhysicalNotch && isFullscreenActive {
+                self.isFullscreenPhysicalNotchCompactActive = true
+            } else {
+                self.isFullscreenPhysicalNotchCompactActive = false
+            }
+        }
+        fullscreenPhysicalNotchCollapseWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + fullscreenStateSettleDelay, execute: workItem)
     }
 
     // MARK: - Event Handling

--- a/PingIsland/Utilities/FullscreenAppDetector.swift
+++ b/PingIsland/Utilities/FullscreenAppDetector.swift
@@ -27,16 +27,32 @@ struct FullscreenAppDetector {
                 continue
             }
 
-            let visibleBounds = bounds.intersection(screenFrame)
-            guard !visibleBounds.isNull else { continue }
-
-            let widthRatio = visibleBounds.width / screenFrame.width
-            let heightRatio = visibleBounds.height / screenFrame.height
-            if widthRatio >= 0.96 && heightRatio >= 0.94 {
+            if isLikelyFullscreenWindow(bounds: bounds, screenFrame: screenFrame) {
                 return true
             }
         }
 
         return false
+    }
+
+    static func isLikelyFullscreenWindow(bounds: CGRect, screenFrame: CGRect, tolerance: CGFloat = 2) -> Bool {
+        let visibleBounds = bounds.intersection(screenFrame)
+        guard !visibleBounds.isNull else { return false }
+
+        let widthRatio = visibleBounds.width / screenFrame.width
+        let heightRatio = visibleBounds.height / screenFrame.height
+        guard widthRatio >= 0.985, heightRatio >= 0.985 else {
+            return false
+        }
+
+        let leftInset = abs(visibleBounds.minX - screenFrame.minX)
+        let rightInset = abs(screenFrame.maxX - visibleBounds.maxX)
+        let bottomInset = abs(visibleBounds.minY - screenFrame.minY)
+        let topInset = abs(screenFrame.maxY - visibleBounds.maxY)
+
+        return leftInset <= tolerance
+            && rightInset <= tolerance
+            && bottomInset <= tolerance
+            && topInset <= tolerance
     }
 }

--- a/PingIslandTests/FullscreenAppDetectorTests.swift
+++ b/PingIslandTests/FullscreenAppDetectorTests.swift
@@ -1,0 +1,28 @@
+import CoreGraphics
+import XCTest
+@testable import Ping_Island
+
+final class FullscreenAppDetectorTests: XCTestCase {
+    func testNearlyScreenSizedWindowWithMenuBarInsetIsNotFullscreen() {
+        let screen = CGRect(x: 0, y: 0, width: 1512, height: 982)
+        let maximizedChromeLikeWindow = CGRect(x: 0, y: 28, width: 1512, height: 954)
+
+        XCTAssertFalse(
+            FullscreenAppDetector.isLikelyFullscreenWindow(
+                bounds: maximizedChromeLikeWindow,
+                screenFrame: screen
+            )
+        )
+    }
+
+    func testEdgeToEdgeWindowIsFullscreen() {
+        let screen = CGRect(x: 0, y: 0, width: 1512, height: 982)
+
+        XCTAssertTrue(
+            FullscreenAppDetector.isLikelyFullscreenWindow(
+                bounds: screen,
+                screenFrame: screen
+            )
+        )
+    }
+}

--- a/PingIslandTests/NotchViewModelTests.swift
+++ b/PingIslandTests/NotchViewModelTests.swift
@@ -108,6 +108,72 @@ final class NotchViewModelTests: XCTestCase {
         }
     }
 
+    func testPhysicalNotchFullscreenStateWaitsForStableExitSignal() async {
+        var isFullscreenActive = true
+
+        let viewModel = await MainActor.run {
+            NotchViewModel(
+                deviceNotchRect: CGRect(x: 0, y: 0, width: 220, height: 38),
+                screenRect: CGRect(x: 0, y: 0, width: 1512, height: 982),
+                windowHeight: 320,
+                hasPhysicalNotch: true,
+                enableEventMonitoring: false,
+                observeSystemEnvironment: false,
+                fullscreenActivityProvider: { _ in isFullscreenActive },
+                fullscreenStateSettleDelay: 0.05
+            )
+        }
+
+        await MainActor.run {
+            XCTAssertTrue(viewModel.isFullscreenPhysicalNotchCompactActive)
+            isFullscreenActive = false
+            viewModel.refreshFullscreenPresentationStateForTesting()
+            XCTAssertTrue(viewModel.isFullscreenPhysicalNotchCompactActive)
+        }
+
+        try? await Task.sleep(nanoseconds: 120_000_000)
+
+        await MainActor.run {
+            XCTAssertFalse(viewModel.isFullscreenPhysicalNotchCompactActive)
+        }
+    }
+
+    func testPhysicalNotchFullscreenStateIgnoresTransientWindowAnimationGap() async {
+        var isFullscreenActive = true
+
+        let viewModel = await MainActor.run {
+            NotchViewModel(
+                deviceNotchRect: CGRect(x: 0, y: 0, width: 220, height: 38),
+                screenRect: CGRect(x: 0, y: 0, width: 1512, height: 982),
+                windowHeight: 320,
+                hasPhysicalNotch: true,
+                enableEventMonitoring: false,
+                observeSystemEnvironment: false,
+                fullscreenActivityProvider: { _ in isFullscreenActive },
+                fullscreenStateSettleDelay: 0.05
+            )
+        }
+
+        await MainActor.run {
+            XCTAssertTrue(viewModel.isFullscreenPhysicalNotchCompactActive)
+            isFullscreenActive = false
+            viewModel.refreshFullscreenPresentationStateForTesting()
+        }
+
+        try? await Task.sleep(nanoseconds: 20_000_000)
+
+        await MainActor.run {
+            isFullscreenActive = true
+            viewModel.refreshFullscreenPresentationStateForTesting()
+        }
+
+        try? await Task.sleep(nanoseconds: 120_000_000)
+
+        await MainActor.run {
+            XCTAssertTrue(viewModel.isFullscreenPhysicalNotchCompactActive)
+        }
+    }
+
     func testToggleChatClosesWhenSameSessionIsAlreadyVisible() async {
         await MainActor.run {
             let viewModel = makeViewModel()


### PR DESCRIPTION
## Summary
- tighten fullscreen suppression detection so ordinary maximized Chrome windows do not count as fullscreen
- require edge-to-edge window coverage instead of relying on loose size ratios alone
- add regression coverage for a Chrome-like maximized frame and the true fullscreen case

## Root cause
The fullscreen detector treated near-screen-sized frontmost windows as fullscreen. Chrome's maximized window can satisfy that heuristic even when it is not in real macOS fullscreen mode, so Ping Island disappeared whenever Chrome became frontmost with fullscreen hiding enabled.

## Verification
- xcodebuild -project PingIsland.xcodeproj -scheme PingIsland -configuration Debug CODE_SIGNING_ALLOWED=NO test -only-testing:PingIslandTests/FullscreenAppDetectorTests -only-testing:PingIslandTests/NotchViewModelTests