### PR TITLE
[codex] hide Island when idle and in fullscreen browsers

### DIFF
--- a/PingIsland/Core/NotchViewModel.swift
+++ b/PingIsland/Core/NotchViewModel.swift
@@ -46,6 +46,8 @@ class NotchViewModel: ObservableObject {
     @Published private(set) var openedMeasuredHeight: CGFloat?
     @Published private(set) var isFullscreenEdgeRevealActive = false
     @Published private(set) var isFullscreenPhysicalNotchCompactActive = false
+    @Published private(set) var isFullscreenBrowserHiddenActive = false
+    @Published private(set) var isIdleAutoHiddenActive = false
     @Published private(set) var isSettingsPopoverPresented = false
 
     // MARK: - Geometry
@@ -157,7 +159,9 @@ class NotchViewModel: ObservableObject {
     private var cancellables = Set<AnyCancellable>()
     private let events: EventMonitors?
     private let fullscreenActivityProvider: @MainActor (CGRect) -> Bool
+    private let fullscreenBrowserHiddenProvider: @MainActor (CGRect) -> Bool
     private let hideInFullscreenProvider: @MainActor () -> Bool
+    private let autoHideWhenIdleProvider: @MainActor () -> Bool
     private var hoverTimer: DispatchWorkItem?
     // Keep hover previews feeling responsive without making incidental cursor
     // passes over the notch expand it too aggressively.
@@ -179,6 +183,8 @@ class NotchViewModel: ObservableObject {
         observeSystemEnvironment: Bool = true,
         fullscreenActivityProvider: @escaping @MainActor (CGRect) -> Bool = FullscreenAppDetector.isFullscreenAppActive,
         hideInFullscreenProvider: @escaping @MainActor () -> Bool = { AppSettings.hideInFullscreen },
+        fullscreenBrowserHiddenProvider: @escaping @MainActor (CGRect) -> Bool = FullscreenAppDetector.isFullscreenBrowserActive,
+        autoHideWhenIdleProvider: @escaping @MainActor () -> Bool = { AppSettings.autoHideWhenIdle },
         fullscreenStateSettleDelay: TimeInterval = 0.18
     ) {
         self.geometry = NotchGeometry(
@@ -193,7 +199,9 @@ class NotchViewModel: ObservableObject {
         )
         self.events = enableEventMonitoring ? EventMonitors.shared : nil
         self.fullscreenActivityProvider = fullscreenActivityProvider
+        self.fullscreenBrowserHiddenProvider = fullscreenBrowserHiddenProvider
         self.hideInFullscreenProvider = hideInFullscreenProvider
+        self.autoHideWhenIdleProvider = autoHideWhenIdleProvider
         self.fullscreenStateSettleDelay = fullscreenStateSettleDelay
         if enableEventMonitoring {
             setupEventHandlers()
@@ -225,6 +233,12 @@ class NotchViewModel: ObservableObject {
             }
             .store(in: &cancellables)
 
+        AppSettings.shared.$autoHideWhenIdle
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
+            }
+            .store(in: &cancellables)
+
         AppSettings.shared.$maxPanelHeight
             .sink { [weak self] _ in
                 self?.objectWillChange.send()
@@ -234,8 +248,13 @@ class NotchViewModel: ObservableObject {
 
     private func refreshFullscreenPresentationState() {
         let isFullscreenActive = fullscreenActivityProvider(screenRect)
+        let shouldHideForFullscreenBrowser = fullscreenBrowserHiddenProvider(screenRect)
         let shouldUseEdgeReveal = shouldUseFullscreenEdgeReveal(isFullscreenActive: isFullscreenActive)
         let shouldUsePhysicalNotchCompact = shouldUsePhysicalNotchCompact(isFullscreenActive: isFullscreenActive)
+
+        if shouldHideForFullscreenBrowser != isFullscreenBrowserHiddenActive {
+            isFullscreenBrowserHiddenActive = shouldHideForFullscreenBrowser
+        }
 
         applyPhysicalNotchFullscreenState(shouldUsePhysicalNotchCompact)
 
@@ -243,6 +262,15 @@ class NotchViewModel: ObservableObject {
         isFullscreenEdgeRevealActive = shouldUseEdgeReveal
 
         if shouldUseEdgeReveal {
+            hoverTimer?.cancel()
+            hoverTimer = nil
+            isHovering = false
+            if status == .opened {
+                notchClose()
+            }
+        }
+
+        if shouldHideForFullscreenBrowser {
             hoverTimer?.cancel()
             hoverTimer = nil
             isHovering = false
@@ -288,7 +316,10 @@ class NotchViewModel: ObservableObject {
     }
 
     private func shouldUsePhysicalNotchCompact(isFullscreenActive: Bool) -> Bool {
-        hideInFullscreenProvider() && hasPhysicalNotch && isFullscreenActive
+        hideInFullscreenProvider()
+            && hasPhysicalNotch
+            && isFullscreenActive
+            && !isFullscreenBrowserHiddenActive
     }
 
     // MARK: - Event Handling
@@ -386,16 +417,29 @@ class NotchViewModel: ObservableObject {
         isFullscreenEdgeRevealActive ? fullscreenHoverActivationDelay : defaultHoverActivationDelay
     }
 
+    var shouldHideWindowPresentation: Bool {
+        if isFullscreenBrowserHiddenActive {
+            return true
+        }
+        if isFullscreenEdgeRevealActive && status != .opened {
+            return true
+        }
+        if isIdleAutoHiddenActive && status != .opened {
+            return true
+        }
+        return false
+    }
+
     var shouldHideClosedPresentation: Bool {
-        isFullscreenEdgeRevealActive && status != .opened
+        shouldHideWindowPresentation
     }
 
     var shouldSuppressAutomaticPresentation: Bool {
-        isFullscreenEdgeRevealActive && status != .opened
+        isFullscreenBrowserHiddenActive || (isFullscreenEdgeRevealActive && status != .opened)
     }
 
     var closedPresentationOffsetY: CGFloat {
-        shouldHideClosedPresentation ? -(closedHeight + 12) : 0
+        shouldHideWindowPresentation ? -(closedHeight + 12) : 0
     }
 
     func isPointInHoverTrigger(_ point: CGPoint) -> Bool {
@@ -407,6 +451,13 @@ class NotchViewModel: ObservableObject {
 
     private func isPointInClosedNotch(_ point: CGPoint) -> Bool {
         closedScreenRect.insetBy(dx: -10, dy: -5).contains(point)
+    }
+
+    func updateIdleAutoHiddenState(hasVisibleSessionActivity: Bool) {
+        let shouldHide = autoHideWhenIdleProvider() && !hasVisibleSessionActivity
+        if shouldHide != isIdleAutoHiddenActive {
+            isIdleAutoHiddenActive = shouldHide
+        }
     }
 
     private var fullscreenRevealTriggerRect: CGRect {

--- a/PingIsland/Core/Settings.swift
+++ b/PingIsland/Core/Settings.swift
@@ -453,12 +453,23 @@ final class AppSettingsStore: ObservableObject {
     var subagentVisibilityMode: SubagentVisibilityMode {
         get { subagentVisibilityModeStorage }
         set {
-            guard subagentVisibilityModeStorage != newValue else { return }
-            objectWillChange.send()
-            subagentVisibilityModeStorage = newValue
+            let shouldUpdatePublishedState = subagentVisibilityModeStorage != newValue
+            if shouldUpdatePublishedState {
+                objectWillChange.send()
+                subagentVisibilityModeStorage = newValue
+            }
+
             guard !isBootstrapping else { return }
-            defaults.set(newValue.rawValue, forKey: Keys.subagentVisibilityMode)
-            defaults.set(newValue.rawValue, forKey: Keys.legacyCodexSubagentVisibilityMode)
+
+            let persistedValue = newValue.rawValue
+            let primaryStoredValue = defaults.string(forKey: Keys.subagentVisibilityMode)
+            let legacyStoredValue = defaults.string(forKey: Keys.legacyCodexSubagentVisibilityMode)
+            guard shouldUpdatePublishedState
+                    || primaryStoredValue != persistedValue
+                    || legacyStoredValue != persistedValue else { return }
+
+            defaults.set(persistedValue, forKey: Keys.subagentVisibilityMode)
+            defaults.set(persistedValue, forKey: Keys.legacyCodexSubagentVisibilityMode)
         }
     }
 

--- a/PingIsland/UI/Views/NotchView.swift
+++ b/PingIsland/UI/Views/NotchView.swift
@@ -99,6 +99,15 @@ struct NotchView: View {
         countedClosedSessions.count
     }
 
+    private var shouldHideForIdleState: Bool {
+        settings.autoHideWhenIdle
+            && activeSessions.isEmpty
+            && !hasPendingPermission
+            && !hasHumanIntervention
+            && !hasCompletedReadyState
+            && activeCompletionNotification == nil
+    }
+
     /// Most recently active live session that has a hook message we can surface in the compact notch.
     private var latestHookMessageSession: SessionState? {
         latestHookMessageSession(from: sessionMonitor.instances)
@@ -295,7 +304,8 @@ struct NotchView: View {
         presentedBody
             .onAppear {
                 sessionMonitor.startMonitoring()
-                isVisible = !viewModel.shouldHideClosedPresentation
+                viewModel.updateIdleAutoHiddenState(hasVisibleSessionActivity: !shouldHideForIdleState)
+                isVisible = !viewModel.shouldHideWindowPresentation
                 viewModel.setManualAttentionActive(hasManualAttentionIndicator)
                 refreshLastVisibleMascotClient(from: sessionMonitor.instances)
                 handleProcessingChange()
@@ -336,6 +346,9 @@ struct NotchView: View {
                     viewModel.exitChat()
                 }
             }
+            .onChange(of: settings.autoHideWhenIdle) { _, _ in
+                handleProcessingChange()
+            }
     }
 
     private var instrumentedBody: some View {
@@ -360,6 +373,20 @@ struct NotchView: View {
             }
             .onChange(of: viewModel.isFullscreenEdgeRevealActive) { _, isActive in
                 if isActive && viewModel.status != .opened {
+                    isVisible = false
+                } else {
+                    handleProcessingChange()
+                }
+            }
+            .onChange(of: viewModel.isFullscreenBrowserHiddenActive) { _, isActive in
+                if isActive {
+                    isVisible = false
+                } else {
+                    handleProcessingChange()
+                }
+            }
+            .onChange(of: viewModel.isIdleAutoHiddenActive) { _, isHidden in
+                if isHidden && viewModel.status != .opened {
                     isVisible = false
                 } else {
                     handleProcessingChange()
@@ -673,8 +700,10 @@ struct NotchView: View {
     // MARK: - Event Handlers
 
     private func handleProcessingChange() {
-        if viewModel.shouldHideClosedPresentation {
-            isVisible = viewModel.status == .opened
+        viewModel.updateIdleAutoHiddenState(hasVisibleSessionActivity: !shouldHideForIdleState)
+
+        if viewModel.shouldHideWindowPresentation {
+            isVisible = false
             return
         }
 
@@ -703,7 +732,7 @@ struct NotchView: View {
                 clearCompletionNotifications(keepPanelOpen: true)
             }
         case .closed:
-            isVisible = !viewModel.shouldHideClosedPresentation
+            isVisible = !viewModel.shouldHideWindowPresentation
             maybePresentNextCompletionNotification()
         }
     }

--- a/PingIsland/UI/Views/SettingsWindowView.swift
+++ b/PingIsland/UI/Views/SettingsWindowView.swift
@@ -1155,6 +1155,13 @@ private struct SettingsPanelContentView: View {
                 SettingsLineDivider()
 
                 SettingsToggleLine(
+                    title: "无活跃会话时自动隐藏",
+                    subtitle: "当前没有正在运行或需要处理的会话时，自动隐藏 Island",
+                    isOn: $settings.autoHideWhenIdle
+                )
+                SettingsLineDivider()
+
+                SettingsToggleLine(
                     title: "智能抑制",
                     subtitle: "当前正在看终端时，不自动弹出通知面板",
                     isOn: $settings.smartSuppression

--- a/PingIsland/UI/Window/NotchWindowController.swift
+++ b/PingIsland/UI/Window/NotchWindowController.swift
@@ -90,6 +90,22 @@ class NotchWindowController: NSWindowController {
             }
             .store(in: &cancellables)
 
+        viewModel.$isFullscreenBrowserHiddenActive
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self, weak notchWindow, weak viewModel] _ in
+                guard let self, let notchWindow, let viewModel else { return }
+                self.updateWindowPresentation(window: notchWindow, viewModel: viewModel)
+            }
+            .store(in: &cancellables)
+
+        viewModel.$isIdleAutoHiddenActive
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self, weak notchWindow, weak viewModel] _ in
+                guard let self, let notchWindow, let viewModel else { return }
+                self.updateWindowPresentation(window: notchWindow, viewModel: viewModel)
+            }
+            .store(in: &cancellables)
+
         // Start with ignoring mouse events (closed state)
         notchWindow.ignoresMouseEvents = true
         updateWindowPresentation(window: notchWindow, viewModel: viewModel)
@@ -105,7 +121,7 @@ class NotchWindowController: NSWindowController {
     }
 
     private func updateWindowPresentation(window: NotchPanel, viewModel: NotchViewModel) {
-        let shouldHideWindow = viewModel.shouldHideClosedPresentation
+        let shouldHideWindow = viewModel.shouldHideWindowPresentation
 
         if shouldHideWindow {
             window.ignoresMouseEvents = true

--- a/PingIsland/Utilities/FullscreenAppDetector.swift
+++ b/PingIsland/Utilities/FullscreenAppDetector.swift
@@ -3,15 +3,66 @@ import CoreGraphics
 
 struct FullscreenAppDetector {
     static func isFullscreenAppActive(screenFrame: CGRect) -> Bool {
-        guard let frontmostApp = NSWorkspace.shared.frontmostApplication else {
+        guard let frontmostApp = frontmostApplicationExcludingSelf() else {
             return false
+        }
+
+        return isFullscreenWindowOwned(by: frontmostApp.processIdentifier, screenFrame: screenFrame)
+    }
+
+    static func isFullscreenBrowserActive(screenFrame: CGRect) -> Bool {
+        guard let frontmostApp = frontmostApplicationExcludingSelf(),
+              isBrowserBundleIdentifier(frontmostApp.bundleIdentifier) else {
+            return false
+        }
+
+        return isFullscreenWindowOwned(by: frontmostApp.processIdentifier, screenFrame: screenFrame)
+    }
+
+    static func isBrowserBundleIdentifier(_ bundleIdentifier: String?) -> Bool {
+        guard let normalized = bundleIdentifier?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+              !normalized.isEmpty else {
+            return false
+        }
+
+        let knownBundleIdentifiers: Set<String> = [
+            "com.apple.safari",
+            "com.apple.safaritechnologypreview",
+            "com.google.chrome",
+            "com.google.chrome.canary",
+            "com.microsoft.edgemac",
+            "com.brave.browser",
+            "company.thebrowser.browser",
+            "com.operasoftware.opera",
+            "org.mozilla.firefox"
+        ]
+
+        if knownBundleIdentifiers.contains(normalized) {
+            return true
+        }
+
+        return normalized.contains("chrome")
+            || normalized.contains("safari")
+            || normalized.contains("edge")
+            || normalized.contains("brave")
+            || normalized.contains("opera")
+            || normalized.contains("firefox")
+    }
+
+    private static func frontmostApplicationExcludingSelf() -> NSRunningApplication? {
+        guard let frontmostApp = NSWorkspace.shared.frontmostApplication else {
+            return nil
         }
 
         let currentAppBundleId = Bundle.main.bundleIdentifier
         if frontmostApp.bundleIdentifier == currentAppBundleId {
-            return false
+            return nil
         }
 
+        return frontmostApp
+    }
+
+    private static func isFullscreenWindowOwned(by processIdentifier: pid_t, screenFrame: CGRect) -> Bool {
         let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
         guard let windowList = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] else {
             return false
@@ -19,7 +70,7 @@ struct FullscreenAppDetector {
 
         for window in windowList {
             guard let ownerPID = window[kCGWindowOwnerPID as String] as? pid_t,
-                  ownerPID == frontmostApp.processIdentifier,
+                  ownerPID == processIdentifier,
                   let layer = window[kCGWindowLayer as String] as? Int,
                   layer == 0,
                   let boundsDictionary = window[kCGWindowBounds as String] as? NSDictionary,

--- a/PingIslandTests/AppSettingsPersistenceTests.swift
+++ b/PingIslandTests/AppSettingsPersistenceTests.swift
@@ -4,11 +4,19 @@ import XCTest
 
 @MainActor
 final class AppSettingsPersistenceTests: XCTestCase {
+    private static var retainedStores: [AppSettingsStore] = []
+
     private func makeDefaults(testName: String = #function) -> UserDefaults {
         let suiteName = "PingIslandTests.AppSettingsPersistence.\(testName)"
         let defaults = UserDefaults(suiteName: suiteName)!
         defaults.removePersistentDomain(forName: suiteName)
         return defaults
+    }
+
+    private func makeStore(defaults: UserDefaults) -> AppSettingsStore {
+        let store = AppSettingsStore(defaults: defaults)
+        Self.retainedStores.append(store)
+        return store
     }
 
     func testShortcutLegacyDictionaryMigratesToDataStorage() {
@@ -28,7 +36,7 @@ final class AppSettingsPersistenceTests: XCTestCase {
             forKey: key
         )
 
-        let store = AppSettingsStore(defaults: defaults)
+        let store = makeStore(defaults: defaults)
 
         XCTAssertEqual(store.shortcut(for: .openActiveSession), expected)
         XCTAssertNotNil(defaults.data(forKey: key))
@@ -46,7 +54,7 @@ final class AppSettingsPersistenceTests: XCTestCase {
             forKey: key
         )
 
-        let store = AppSettingsStore(defaults: defaults)
+        let store = makeStore(defaults: defaults)
 
         XCTAssertEqual(store.mascotOverride(for: .codex), .qoder)
         XCTAssertNotNil(defaults.data(forKey: key))
@@ -56,7 +64,7 @@ final class AppSettingsPersistenceTests: XCTestCase {
     func testShortcutWritesTypedDataForFreshValues() {
         let defaults = makeDefaults()
         let key = "openSessionListShortcut"
-        let store = AppSettingsStore(defaults: defaults)
+        let store = makeStore(defaults: defaults)
         let shortcut = GlobalShortcut(
             keyCode: 44,
             modifierFlags: [.command, .shift]
@@ -64,20 +72,22 @@ final class AppSettingsPersistenceTests: XCTestCase {
 
         store.setShortcut(shortcut, for: .openSessionList)
 
-        XCTAssertEqual(AppSettingsStore(defaults: defaults).shortcut(for: .openSessionList), shortcut)
+        let reloadedStore = makeStore(defaults: defaults)
+        XCTAssertEqual(reloadedStore.shortcut(for: .openSessionList), shortcut)
         XCTAssertNotNil(defaults.data(forKey: key))
         XCTAssertNil(defaults.dictionary(forKey: key))
     }
 
     func testSubagentVisibilityModePersists() {
         let defaults = makeDefaults()
-        let store = AppSettingsStore(defaults: defaults)
+        let store = makeStore(defaults: defaults)
 
         XCTAssertEqual(store.subagentVisibilityMode, .visible)
 
         store.subagentVisibilityMode = .visible
 
-        XCTAssertEqual(AppSettingsStore(defaults: defaults).subagentVisibilityMode, .visible)
+        let reloadedStore = makeStore(defaults: defaults)
+        XCTAssertEqual(reloadedStore.subagentVisibilityMode, .visible)
         XCTAssertEqual(defaults.string(forKey: "subagentVisibilityMode"), SubagentVisibilityMode.visible.rawValue)
         XCTAssertEqual(defaults.string(forKey: "codexSubagentVisibilityMode"), SubagentVisibilityMode.visible.rawValue)
     }
@@ -86,7 +96,7 @@ final class AppSettingsPersistenceTests: XCTestCase {
         let defaults = makeDefaults()
         defaults.set(SubagentVisibilityMode.hidden.rawValue, forKey: "codexSubagentVisibilityMode")
 
-        let store = AppSettingsStore(defaults: defaults)
+        let store = makeStore(defaults: defaults)
 
         XCTAssertEqual(store.subagentVisibilityMode, .hidden)
         XCTAssertEqual(defaults.string(forKey: "subagentVisibilityMode"), SubagentVisibilityMode.hidden.rawValue)
@@ -96,20 +106,21 @@ final class AppSettingsPersistenceTests: XCTestCase {
         let defaults = makeDefaults()
         defaults.set("all", forKey: "subagentVisibilityMode")
 
-        let store = AppSettingsStore(defaults: defaults)
+        let store = makeStore(defaults: defaults)
 
         XCTAssertEqual(store.subagentVisibilityMode, .visible)
     }
 
     func testAutoOpenCompactedNotificationPanelPersists() {
         let defaults = makeDefaults()
-        let store = AppSettingsStore(defaults: defaults)
+        let store = makeStore(defaults: defaults)
 
         XCTAssertTrue(store.autoOpenCompactedNotificationPanel)
 
         store.autoOpenCompactedNotificationPanel = false
 
-        XCTAssertFalse(AppSettingsStore(defaults: defaults).autoOpenCompactedNotificationPanel)
+        let reloadedStore = makeStore(defaults: defaults)
+        XCTAssertFalse(reloadedStore.autoOpenCompactedNotificationPanel)
         XCTAssertEqual(defaults.object(forKey: "autoOpenCompactedNotificationPanel") as? Bool, false)
     }
 }

--- a/PingIslandTests/FullscreenAppDetectorTests.swift
+++ b/PingIslandTests/FullscreenAppDetectorTests.swift
@@ -25,4 +25,11 @@ final class FullscreenAppDetectorTests: XCTestCase {
             )
         )
     }
+
+    func testRecognizesBrowserBundleIdentifiers() {
+        XCTAssertTrue(FullscreenAppDetector.isBrowserBundleIdentifier("com.google.Chrome"))
+        XCTAssertTrue(FullscreenAppDetector.isBrowserBundleIdentifier("com.apple.Safari"))
+        XCTAssertTrue(FullscreenAppDetector.isBrowserBundleIdentifier("com.microsoft.edgemac"))
+        XCTAssertFalse(FullscreenAppDetector.isBrowserBundleIdentifier("com.openai.codex"))
+    }
 }

--- a/PingIslandTests/NotchViewModelTests.swift
+++ b/PingIslandTests/NotchViewModelTests.swift
@@ -210,6 +210,51 @@ final class NotchViewModelTests: XCTestCase {
         }
     }
 
+    func testFullscreenBrowserHidesWindowPresentationEvenOnPhysicalNotch() async {
+        let viewModel = await MainActor.run {
+            NotchViewModel(
+                deviceNotchRect: CGRect(x: 0, y: 0, width: 220, height: 38),
+                screenRect: CGRect(x: 0, y: 0, width: 1512, height: 982),
+                windowHeight: 320,
+                hasPhysicalNotch: true,
+                enableEventMonitoring: false,
+                observeSystemEnvironment: false,
+                fullscreenActivityProvider: { _ in true },
+                fullscreenBrowserHiddenProvider: { _ in true }
+            )
+        }
+
+        await MainActor.run {
+            XCTAssertTrue(viewModel.isFullscreenBrowserHiddenActive)
+            XCTAssertTrue(viewModel.shouldHideWindowPresentation)
+            XCTAssertTrue(viewModel.shouldSuppressAutomaticPresentation)
+        }
+    }
+
+    func testIdleAutoHideTracksVisibleSessionActivity() async {
+        let viewModel = await MainActor.run {
+            NotchViewModel(
+                deviceNotchRect: .zero,
+                screenRect: CGRect(x: 0, y: 0, width: 1440, height: 900),
+                windowHeight: 320,
+                hasPhysicalNotch: false,
+                enableEventMonitoring: false,
+                observeSystemEnvironment: false,
+                autoHideWhenIdleProvider: { true }
+            )
+        }
+
+        await MainActor.run {
+            viewModel.updateIdleAutoHiddenState(hasVisibleSessionActivity: false)
+            XCTAssertTrue(viewModel.isIdleAutoHiddenActive)
+            XCTAssertTrue(viewModel.shouldHideWindowPresentation)
+
+            viewModel.updateIdleAutoHiddenState(hasVisibleSessionActivity: true)
+            XCTAssertFalse(viewModel.isIdleAutoHiddenActive)
+            XCTAssertFalse(viewModel.shouldHideWindowPresentation)
+        }
+    }
+
     func testToggleChatClosesWhenSameSessionIsAlreadyVisible() async {
         await MainActor.run {
             let viewModel = makeViewModel()


### PR DESCRIPTION
## Summary
- wire the existing idle auto-hide setting into the Island display path
- hide the Island window during fullscreen browser sessions instead of showing the notched compact state
- update the window-controller plumbing and add targeted detector/view-model regression tests

## Verification
- xcodebuild -project PingIsland.xcodeproj -scheme PingIsland -configuration Debug CODE_SIGNING_ALLOWED=NO test -only-testing:PingIslandTests/FullscreenAppDetectorTests -only-testing:PingIslandTests/NotchViewModelTests