### PR TITLE
Add musl libc support for static Linux cross-compilation

### DIFF
--- a/Prototype/Sources/IslandBridge/main.swift
+++ b/Prototype/Sources/IslandBridge/main.swift
@@ -2,6 +2,8 @@ import Foundation
 import IslandShared
 #if canImport(Darwin)
 import Darwin
+#elseif canImport(Musl)
+import Musl
 #elseif canImport(Glibc)
 import Glibc
 #endif
@@ -9,6 +11,9 @@ import Glibc
 #if canImport(Darwin)
 private let islandStreamSocketType: Int32 = SOCK_STREAM
 private let islandShutdownWrite: Int32 = SHUT_WR
+#elseif canImport(Musl)
+private let islandStreamSocketType: Int32 = Int32(SOCK_STREAM)
+private let islandShutdownWrite: Int32 = Int32(SHUT_WR)
 #elseif canImport(Glibc)
 private let islandStreamSocketType: Int32 = Int32(SOCK_STREAM.rawValue)
 private let islandShutdownWrite: Int32 = Int32(SHUT_WR)


### PR DESCRIPTION
## Summary
- Add `canImport(Musl)` branches for `SOCK_STREAM` and `SHUT_WR` constants in IslandBridge
- Enables building PingIslandBridge as a fully static binary via Swift Static Linux SDK (musl)
- Fixes GLIBC_2.33/2.34/2.35 version errors when deploying to older Linux hosts

## Context
The remote PingIslandBridge binary downloaded from GitHub Releases is dynamically linked
against glibc, which fails on hosts with older glibc versions. With this change, the binary
can be cross-compiled from macOS using:

```
TOOLCHAINS=org.swift.631202604131a swift build -c release \
  --product PingIslandBridge --swift-sdk x86_64-swift-linux-musl
```

Producing a zero-dependency static ELF binary.

## Test plan
- [x] Verify macOS build still works (`swift build --product PingIslandBridge`)
- [x] Cross-compile for Linux (`--swift-sdk x86_64-swift-linux-musl`)
- [x] Deploy static binary to remote Linux host and verify it runs without glibc errors
- [x] Verify remote agent service + attach mode work end-to-end