### PR TITLE
Stabilize settings persistence CI

### DIFF
--- a/PingIsland/Core/Settings.swift
+++ b/PingIsland/Core/Settings.swift
@@ -453,12 +453,23 @@ final class AppSettingsStore: ObservableObject {
     var subagentVisibilityMode: SubagentVisibilityMode {
         get { subagentVisibilityModeStorage }
         set {
-            guard subagentVisibilityModeStorage != newValue else { return }
-            objectWillChange.send()
-            subagentVisibilityModeStorage = newValue
+            let shouldUpdatePublishedState = subagentVisibilityModeStorage != newValue
+            if shouldUpdatePublishedState {
+                objectWillChange.send()
+                subagentVisibilityModeStorage = newValue
+            }
+
             guard !isBootstrapping else { return }
-            defaults.set(newValue.rawValue, forKey: Keys.subagentVisibilityMode)
-            defaults.set(newValue.rawValue, forKey: Keys.legacyCodexSubagentVisibilityMode)
+
+            let persistedValue = newValue.rawValue
+            let primaryStoredValue = defaults.string(forKey: Keys.subagentVisibilityMode)
+            let legacyStoredValue = defaults.string(forKey: Keys.legacyCodexSubagentVisibilityMode)
+            guard shouldUpdatePublishedState
+                    || primaryStoredValue != persistedValue
+                    || legacyStoredValue != persistedValue else { return }
+
+            defaults.set(persistedValue, forKey: Keys.subagentVisibilityMode)
+            defaults.set(persistedValue, forKey: Keys.legacyCodexSubagentVisibilityMode)
         }
     }
 

--- a/PingIslandTests/AppSettingsPersistenceTests.swift
+++ b/PingIslandTests/AppSettingsPersistenceTests.swift
@@ -4,11 +4,19 @@ import XCTest
 
 @MainActor
 final class AppSettingsPersistenceTests: XCTestCase {
+    private static var retainedStores: [AppSettingsStore] = []
+
     private func makeDefaults(testName: String = #function) -> UserDefaults {
         let suiteName = "PingIslandTests.AppSettingsPersistence.\(testName)"
         let defaults = UserDefaults(suiteName: suiteName)!
         defaults.removePersistentDomain(forName: suiteName)
         return defaults
+    }
+
+    private func makeStore(defaults: UserDefaults) -> AppSettingsStore {
+        let store = AppSettingsStore(defaults: defaults)
+        Self.retainedStores.append(store)
+        return store
     }
 
     func testShortcutLegacyDictionaryMigratesToDataStorage() {
@@ -28,7 +36,7 @@ final class AppSettingsPersistenceTests: XCTestCase {
             forKey: key
         )
 
-        let store = AppSettingsStore(defaults: defaults)
+        let store = makeStore(defaults: defaults)
 
         XCTAssertEqual(store.shortcut(for: .openActiveSession), expected)
         XCTAssertNotNil(defaults.data(forKey: key))
@@ -46,7 +54,7 @@ final class AppSettingsPersistenceTests: XCTestCase {
             forKey: key
         )
 
-        let store = AppSettingsStore(defaults: defaults)
+        let store = makeStore(defaults: defaults)
 
         XCTAssertEqual(store.mascotOverride(for: .codex), .qoder)
         XCTAssertNotNil(defaults.data(forKey: key))
@@ -56,7 +64,7 @@ final class AppSettingsPersistenceTests: XCTestCase {
     func testShortcutWritesTypedDataForFreshValues() {
         let defaults = makeDefaults()
         let key = "openSessionListShortcut"
-        let store = AppSettingsStore(defaults: defaults)
+        let store = makeStore(defaults: defaults)
         let shortcut = GlobalShortcut(
             keyCode: 44,
             modifierFlags: [.command, .shift]
@@ -64,20 +72,22 @@ final class AppSettingsPersistenceTests: XCTestCase {
 
         store.setShortcut(shortcut, for: .openSessionList)
 
-        XCTAssertEqual(AppSettingsStore(defaults: defaults).shortcut(for: .openSessionList), shortcut)
+        let reloadedStore = makeStore(defaults: defaults)
+        XCTAssertEqual(reloadedStore.shortcut(for: .openSessionList), shortcut)
         XCTAssertNotNil(defaults.data(forKey: key))
         XCTAssertNil(defaults.dictionary(forKey: key))
     }
 
     func testSubagentVisibilityModePersists() {
         let defaults = makeDefaults()
-        let store = AppSettingsStore(defaults: defaults)
+        let store = makeStore(defaults: defaults)
 
         XCTAssertEqual(store.subagentVisibilityMode, .visible)
 
         store.subagentVisibilityMode = .visible
 
-        XCTAssertEqual(AppSettingsStore(defaults: defaults).subagentVisibilityMode, .visible)
+        let reloadedStore = makeStore(defaults: defaults)
+        XCTAssertEqual(reloadedStore.subagentVisibilityMode, .visible)
         XCTAssertEqual(defaults.string(forKey: "subagentVisibilityMode"), SubagentVisibilityMode.visible.rawValue)
         XCTAssertEqual(defaults.string(forKey: "codexSubagentVisibilityMode"), SubagentVisibilityMode.visible.rawValue)
     }
@@ -86,7 +96,7 @@ final class AppSettingsPersistenceTests: XCTestCase {
         let defaults = makeDefaults()
         defaults.set(SubagentVisibilityMode.hidden.rawValue, forKey: "codexSubagentVisibilityMode")
 
-        let store = AppSettingsStore(defaults: defaults)
+        let store = makeStore(defaults: defaults)
 
         XCTAssertEqual(store.subagentVisibilityMode, .hidden)
         XCTAssertEqual(defaults.string(forKey: "subagentVisibilityMode"), SubagentVisibilityMode.hidden.rawValue)
@@ -96,20 +106,21 @@ final class AppSettingsPersistenceTests: XCTestCase {
         let defaults = makeDefaults()
         defaults.set("all", forKey: "subagentVisibilityMode")
 
-        let store = AppSettingsStore(defaults: defaults)
+        let store = makeStore(defaults: defaults)
 
         XCTAssertEqual(store.subagentVisibilityMode, .visible)
     }
 
     func testAutoOpenCompactedNotificationPanelPersists() {
         let defaults = makeDefaults()
-        let store = AppSettingsStore(defaults: defaults)
+        let store = makeStore(defaults: defaults)
 
         XCTAssertTrue(store.autoOpenCompactedNotificationPanel)
 
         store.autoOpenCompactedNotificationPanel = false
 
-        XCTAssertFalse(AppSettingsStore(defaults: defaults).autoOpenCompactedNotificationPanel)
+        let reloadedStore = makeStore(defaults: defaults)
+        XCTAssertFalse(reloadedStore.autoOpenCompactedNotificationPanel)
         XCTAssertEqual(defaults.object(forKey: "autoOpenCompactedNotificationPanel") as? Bool, false)
     }
 }


### PR DESCRIPTION
## Summary
- keep `subagentVisibilityMode` persistence idempotent while still backfilling the legacy defaults key
- harden `AppSettingsPersistenceTests` against the current XCTest deallocation abort
- keep this as a standalone CI-fix PR independent from feature branches

## Testing
- xcodebuild -project PingIsland.xcodeproj -scheme PingIsland -configuration Debug CODE_SIGNING_ALLOWED=NO test -only-testing:PingIslandTests/AppSettingsPersistenceTests
- xcodebuild -project PingIsland.xcodeproj -scheme PingIsland -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/ping-island-ci-fix-derived.gizaoS CODE_SIGNING_ALLOWED=NO test -only-testing:PingIslandTests
