### PR TITLE
Fix settings tab scroll carry-over

### DIFF
--- a/PingIsland/UI/Views/SettingsWindowView.swift
+++ b/PingIsland/UI/Views/SettingsWindowView.swift
@@ -1055,6 +1055,7 @@ private struct SettingsPanelContentView: View {
             .padding(.bottom, 24)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
+        .id(currentCategory)
         .accessibilityIdentifier("settings.detail.\(currentCategory.rawValue)")
         .background(
             UnevenRoundedRectangle(


### PR DESCRIPTION
## Summary
- reset the settings detail ScrollView when the sidebar category changes
- keep the fix local to the detail pane without adding extra scroll state
- address issue #75

## Testing
- xcodebuild -project PingIsland.xcodeproj -scheme PingIsland -configuration Debug CODE_SIGNING_ALLOWED=NO test -only-testing:PingIslandTests/SettingsWindowControllerTests -only-testing:PingIslandTests/AppLaunchConfigurationTests
