### PR TITLE
Show token usage on the Island board

### DIFF
--- a/PingIsland/Models/SessionState.swift
+++ b/PingIsland/Models/SessionState.swift
@@ -830,6 +830,19 @@ struct SessionState: Equatable, Identifiable, Sendable {
         return tool
     }
 
+    nonisolated var latestTaskTotalTokens: Int? {
+        for item in chatItems.reversed() {
+            guard case .toolCall(let tool) = item.type,
+                  case .task(let result) = tool.structuredResult,
+                  let totalTokens = result.totalTokens,
+                  totalTokens > 0 else {
+                continue
+            }
+            return totalTokens
+        }
+        return nil
+    }
+
     private nonisolated var latestToolCallIsCompletedFollowupQuestion: Bool {
         latestCompletedFollowupQuestionTool != nil
     }

--- a/PingIsland/UI/Views/NotchView.swift
+++ b/PingIsland/UI/Views/NotchView.swift
@@ -565,6 +565,38 @@ struct NotchView: View {
         max(0, closedCenterWidth - compactCenterContentInset)
     }
 
+    private var tokenUsageSession: SessionState? {
+        guard settings.showUsage else { return nil }
+
+        switch viewModel.contentType {
+        case .chat(let session):
+            return sessionMonitor.instances.first(where: { $0.sessionId == session.sessionId }) ?? session
+        case .instances:
+            let candidateSessions: [SessionState]
+            if viewModel.openReason == .notification,
+               let notification = activeCompletionNotification {
+                candidateSessions = [
+                    sessionMonitor.instances.first(where: { $0.sessionId == notification.session.sessionId }) ?? notification.session
+                ]
+            } else {
+                candidateSessions = sessionMonitor.instances
+                    .sorted(by: { $0.lastActivity > $1.lastActivity })
+            }
+
+            return candidateSessions.first(where: { $0.latestTaskTotalTokens != nil })
+        }
+    }
+
+    private var tokenUsageBadgeText: String? {
+        guard let totalTokens = tokenUsageSession?.latestTaskTotalTokens else { return nil }
+        let compactValue = totalTokens.formatted(
+            .number
+                .locale(settings.locale)
+                .notation(.compactName)
+        )
+        return "Token \(compactValue)"
+    }
+
     @ViewBuilder
     private var closedCenterContent: some View {
         HStack {
@@ -604,6 +636,10 @@ struct NotchView: View {
             }
 
             Spacer()
+
+            if let tokenUsageBadgeText {
+                NotchTokenUsageBadge(text: tokenUsageBadgeText)
+            }
 
             NotchTemporaryMuteButton(
                 isActive: areReminderNotificationsSuppressed,
@@ -1358,6 +1394,34 @@ private struct NotchTemporaryMuteButton: View {
             return Color.white.opacity(isHovering ? 0.22 : 0.12)
         }
         return .clear
+    }
+}
+
+private struct NotchTokenUsageBadge: View {
+    let text: String
+
+    var body: some View {
+        HStack(spacing: 5) {
+            Image(systemName: "number.circle.fill")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(.white.opacity(0.78))
+
+            Text(text)
+                .font(.system(size: 11, weight: .semibold, design: .rounded))
+                .foregroundStyle(.white.opacity(0.88))
+                .lineLimit(1)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(
+            Capsule(style: .continuous)
+                .fill(Color.white.opacity(0.08))
+        )
+        .overlay(
+            Capsule(style: .continuous)
+                .stroke(Color.white.opacity(0.08), lineWidth: 1)
+        )
+        .help("最近活跃会话的 Token 用量")
     }
 }
 

--- a/PingIsland/UI/Views/SettingsWindowView.swift
+++ b/PingIsland/UI/Views/SettingsWindowView.swift
@@ -1232,6 +1232,13 @@ private struct SettingsPanelContentView: View {
                 )
                 SettingsLineDivider()
 
+                SettingsToggleLine(
+                    title: "显示 Token 用量",
+                    subtitle: "在展开后的看板顶栏显示最近活跃会话的 token 用量",
+                    isOn: $settings.showUsage
+                )
+                SettingsLineDivider()
+
                 SettingsInfoLine(
                     title: "子 Agent 显示",
                     subtitle: "控制主列表里是否展示子 Agent 消息项；当前会影响 Codex、Qoder 等带子会话的客户端"

--- a/PingIslandTests/SessionStateTests.swift
+++ b/PingIslandTests/SessionStateTests.swift
@@ -1330,6 +1330,122 @@ final class SessionStateTests: XCTestCase {
         XCTAssertFalse(session.shouldShowClientFollowupPrompt)
     }
 
+    func testLatestTaskTotalTokensUsesNewestCompletedTaskResult() {
+        let session = SessionState(
+            sessionId: "task-usage",
+            cwd: "/tmp/project",
+            chatItems: [
+                ChatHistoryItem(
+                    id: "task-older",
+                    type: .toolCall(
+                        ToolCallItem(
+                            name: "Task",
+                            input: [:],
+                            status: .success,
+                            result: nil,
+                            structuredResult: .task(
+                                TaskResult(
+                                    agentId: "agent-1",
+                                    status: "completed",
+                                    content: "done",
+                                    prompt: nil,
+                                    totalDurationMs: 1000,
+                                    totalTokens: 1200,
+                                    totalToolUseCount: 2
+                                )
+                            ),
+                            subagentTools: []
+                        )
+                    ),
+                    timestamp: Date().addingTimeInterval(-1)
+                ),
+                ChatHistoryItem(
+                    id: "task-newer",
+                    type: .toolCall(
+                        ToolCallItem(
+                            name: "Task",
+                            input: [:],
+                            status: .success,
+                            result: nil,
+                            structuredResult: .task(
+                                TaskResult(
+                                    agentId: "agent-2",
+                                    status: "completed",
+                                    content: "done",
+                                    prompt: nil,
+                                    totalDurationMs: 1500,
+                                    totalTokens: 2400,
+                                    totalToolUseCount: 3
+                                )
+                            ),
+                            subagentTools: []
+                        )
+                    ),
+                    timestamp: Date()
+                )
+            ]
+        )
+
+        XCTAssertEqual(session.latestTaskTotalTokens, 2400)
+    }
+
+    func testLatestTaskTotalTokensSkipsNonTaskResultsAndMissingUsage() {
+        let session = SessionState(
+            sessionId: "task-usage-empty",
+            cwd: "/tmp/project",
+            chatItems: [
+                ChatHistoryItem(
+                    id: "read-result",
+                    type: .toolCall(
+                        ToolCallItem(
+                            name: "Read",
+                            input: [:],
+                            status: .success,
+                            result: nil,
+                            structuredResult: .read(
+                                ReadResult(
+                                    filePath: "/tmp/project/README.md",
+                                    content: "hello",
+                                    numLines: 1,
+                                    startLine: 1,
+                                    totalLines: 1
+                                )
+                            ),
+                            subagentTools: []
+                        )
+                    ),
+                    timestamp: Date().addingTimeInterval(-1)
+                ),
+                ChatHistoryItem(
+                    id: "task-without-usage",
+                    type: .toolCall(
+                        ToolCallItem(
+                            name: "Task",
+                            input: [:],
+                            status: .success,
+                            result: nil,
+                            structuredResult: .task(
+                                TaskResult(
+                                    agentId: "agent-3",
+                                    status: "completed",
+                                    content: "done",
+                                    prompt: nil,
+                                    totalDurationMs: 900,
+                                    totalTokens: nil,
+                                    totalToolUseCount: 1
+                                )
+                            ),
+                            subagentTools: []
+                        )
+                    ),
+                    timestamp: Date()
+                )
+            ]
+        )
+
+        XCTAssertNil(session.latestTaskTotalTokens)
+    }
+
     func testCodexAppPrefersDirectLaunchURLBeforeWorkspaceRouting() {
         XCTAssertTrue(
             SessionLauncher.shouldPrioritizeDirectLaunchURL(


### PR DESCRIPTION
## Summary
- surface the latest task token total in the expanded Island header
- add a display toggle for token usage in settings
- cover the new session-derived usage helper with regression tests
- address issue #70

## Testing
- xcodebuild -project PingIsland.xcodeproj -scheme PingIsland -configuration Debug CODE_SIGNING_ALLOWED=NO test -only-testing:PingIslandTests/SessionStateTests -only-testing:PingIslandTests/SettingsWindowControllerTests -only-testing:PingIslandTests/AppLaunchConfigurationTests
- xcodebuild -project PingIsland.xcodeproj -scheme PingIsland -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/ping-island-issue70-derived.V3j4lk CODE_SIGNING_ALLOWED=NO test -only-testing:PingIslandTests
