### PR TITLE
Allow remote bridge to use user-provided compat libraries on older glibc systems

### DIFF
--- a/PingIsland/Services/Remote/RemoteConnectorManager.swift
+++ b/PingIsland/Services/Remote/RemoteConnectorManager.swift
@@ -627,6 +627,10 @@ final class RemoteConnectorManager: ObservableObject {
         let launcherScript = """
         #!/bin/sh
         SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+        COMPAT_LIB="$SCRIPT_DIR/../lib"
+        if [ -x "$COMPAT_LIB/ld-linux-x86-64.so.2" ]; then
+          exec "$COMPAT_LIB/ld-linux-x86-64.so.2" --library-path "$COMPAT_LIB" "$SCRIPT_DIR/PingIslandBridge" "$@"
+        fi
         exec "$SCRIPT_DIR/PingIslandBridge" "$@"
         """
         try await RemoteSSHCommandRunner.writeRemoteFile(


### PR DESCRIPTION
## Summary

  On Linux hosts with older glibc (e.g. glibc 2.32), PingIslandBridge fails to start with errors like:

  PingIslandBridge: /lib64/libc.so.6: version GLIBC_2.34' not found PingIslandBridge: /lib64/libstdc++.so.6: version GLIBCXX_3.4.30' not found

  Users on shared/managed machines often cannot upgrade the system glibc. This PR adds a fallback in the launcher script: if a user-provided dynamic linker exists at
  `<installRoot>/lib/ld-linux-x86-64.so.2`, the script uses it with `--library-path` to load compat libraries from the same directory. When absent, behavior is unchanged.

  ## How it works

  Users can self-rescue by placing compatible libraries in `~/.ping-island/lib/`:

  - `ld-linux-x86-64.so.2`, `libc.so.6`, `libm.so.6` (from glibc ≥ 2.35)
  - `libstdc++.so.6` (with GLIBCXX ≥ 3.4.30, e.g. from Ubuntu 22.04)
  - `libgcc_s.so.1`

  The `lib/` directory is not touched during bootstrap, so it survives reconnections.

  ## Test plan

  - [ ] Verify remote SSH connection works on a host with glibc < 2.35 after placing compat libs in `~/.ping-island/lib/`
  - [ ] Verify remote SSH connection still works normally on hosts with sufficient glibc (no `lib/` directory needed)
  - [ ] Verify reconnection does not overwrite the `lib/` directory

  🤖 Generated with [Claude Code](https://claude.com/claude-code)