### PR TITLE
Fix OpenClaw being identified as Cursor

### DIFF
--- a/PingIsland/Models/SessionProvider.swift
+++ b/PingIsland/Models/SessionProvider.swift
@@ -135,11 +135,20 @@ struct SessionClientInfo: Codable, Equatable, Sendable {
     }
 
     nonisolated func resolvedProfile(for provider: SessionProvider) -> SessionClientProfile? {
-        ClientProfileRegistry.runtimeProfile(id: profileID)
+        if let inferredProfileID {
+            return ClientProfileRegistry.runtimeProfile(id: inferredProfileID)
+        }
+
+        return ClientProfileRegistry.runtimeProfile(id: profileID)
             ?? ClientProfileRegistry.defaultRuntimeProfile(for: provider, kind: kind)
     }
 
     nonisolated var brand: SessionClientBrand {
+        if let inferredProfileID,
+           let profile = ClientProfileRegistry.runtimeProfile(id: inferredProfileID) {
+            return profile.brand
+        }
+
         if let profile = ClientProfileRegistry.runtimeProfile(id: profileID) {
             return profile.brand
         }
@@ -157,10 +166,7 @@ struct SessionClientInfo: Codable, Equatable, Sendable {
     }
 
     nonisolated var isOpenClawGatewayClient: Bool {
-        profileID == "openclaw"
-            || threadSource?.lowercased() == "openclaw-hooks"
-            || name?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "openclaw"
-            || originator?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "openclaw"
+        inferredProfileID == "openclaw"
     }
 
     nonisolated var isQwenCodeClient: Bool {
@@ -191,6 +197,10 @@ struct SessionClientInfo: Codable, Equatable, Sendable {
 
     nonisolated func badgeLabel(for provider: SessionProvider) -> String {
         let profile = resolvedProfile(for: provider)
+        if let inferredProfileID,
+           let inferredProfile = ClientProfileRegistry.runtimeProfile(id: inferredProfileID) {
+            return inferredProfile.displayName
+        }
         if provider == .codex,
            kind == .codexCLI,
            let terminalSourceDisplayName {
@@ -206,6 +216,11 @@ struct SessionClientInfo: Codable, Equatable, Sendable {
     }
 
     nonisolated func subagentClientTypeLabel(for provider: SessionProvider) -> String {
+        if let inferredProfileID,
+           let inferredProfile = ClientProfileRegistry.runtimeProfile(id: inferredProfileID) {
+            return inferredProfile.displayName
+        }
+
         if provider == .codex {
             return provider.displayName
         }
@@ -311,6 +326,10 @@ struct SessionClientInfo: Codable, Equatable, Sendable {
     }
 
     nonisolated var ideHostProfile: ManagedIDEExtensionProfile? {
+        if inferredProfileID == "openclaw" {
+            return nil
+        }
+
         let detectedBundleIdentifier = terminalBundleIdentifier ?? bundleIdentifier
         let appName: String?
         if let detectedBundleIdentifier,
@@ -431,6 +450,30 @@ struct SessionClientInfo: Codable, Equatable, Sendable {
         }
 
         return normalized
+    }
+
+    private nonisolated var inferredProfileID: String? {
+        let normalizedThreadSource = threadSource?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        let normalizedName = name?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        let normalizedOriginator = originator?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        let normalizedSessionFilePath = sessionFilePath?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+
+        if normalizedThreadSource == "openclaw-hooks"
+            || normalizedName == "openclaw"
+            || normalizedOriginator == "openclaw"
+            || normalizedSessionFilePath?.contains("/.openclaw/") == true {
+            return "openclaw"
+        }
+
+        return nil
     }
 
     nonisolated func normalizedForClaudeRouting() -> SessionClientInfo {

--- a/PingIslandTests/OpenCodeIntegrationTests.swift
+++ b/PingIslandTests/OpenCodeIntegrationTests.swift
@@ -115,6 +115,31 @@ final class OpenCodeIntegrationTests: XCTestCase {
         XCTAssertEqual(session.lastMessage, "second hi")
     }
 
+    func testOpenClawSessionFilePathWinsOverCursorHostForClientIdentity() {
+        let clientInfo = SessionClientInfo(
+            kind: .custom,
+            profileID: "cursor",
+            name: "Cursor",
+            bundleIdentifier: "com.todesktop.230313mzl4w4u92",
+            originator: "Cursor",
+            sessionFilePath: NSHomeDirectory() + "/.openclaw/agents/main/sessions/openclaw-session.jsonl",
+            terminalBundleIdentifier: "com.todesktop.230313mzl4w4u92"
+        )
+        let session = SessionState(
+            sessionId: "openclaw-via-cursor",
+            cwd: "/Users/ping-island/Island",
+            projectName: "Island",
+            provider: .claude,
+            clientInfo: clientInfo
+        )
+
+        XCTAssertTrue(clientInfo.isOpenClawGatewayClient)
+        XCTAssertEqual(clientInfo.resolvedProfile(for: SessionProvider.claude)?.id, "openclaw")
+        XCTAssertEqual(clientInfo.badgeLabel(for: SessionProvider.claude), "OpenClaw")
+        XCTAssertEqual(MascotClient(clientInfo: clientInfo, provider: SessionProvider.claude), .openclaw)
+        XCTAssertTrue(session.shouldHideProjectContextInUI)
+    }
+
     func testOpenClawConversationParserReadsMultiTurnSessionFile() async throws {
         let root = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent(UUID().uuidString, isDirectory: true)


### PR DESCRIPTION
## Summary
- prefer concrete OpenClaw session evidence over surrounding IDE host labels
- fix OpenClaw sessions showing Cursor branding when they run inside Cursor
- restore OpenClaw's project-context suppression so the extra repo prefix disappears
- address issue #72

## Testing
- xcodebuild -project PingIsland.xcodeproj -scheme PingIsland -configuration Debug CODE_SIGNING_ALLOWED=NO test -only-testing:PingIslandTests/OpenCodeIntegrationTests -only-testing:PingIslandTests/SessionStateTests
- xcodebuild -project PingIsland.xcodeproj -scheme PingIsland -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/ping-island-issue72-derived.cgmjwS CODE_SIGNING_ALLOWED=NO test -only-testing:PingIslandTests
