### PR TITLE
Fix remote agent reconnect after sleep-disconnected SSH tunnels

### DIFF
--- a/PingIsland/Services/Remote/RemoteConnectorManager.swift
+++ b/PingIsland/Services/Remote/RemoteConnectorManager.swift
@@ -888,14 +888,11 @@ final class RemoteConnectorManager: ObservableObject {
         logger.notice(
             "Remote agent ensure/start endpoint=\(endpoint.id.uuidString, privacy: .public) target=\(endpoint.sshTarget, privacy: .public) controlSocket=\(endpoint.remoteControlSocketPath, privacy: .public)"
         )
-        let command = """
-        mkdir -p \(quoted(endpoint.remoteInstallRoot))/run \(quoted(endpoint.remoteInstallRoot))/logs
-        if [ -S \(quoted(endpoint.remoteControlSocketPath)) ]; then
-          exit 0
-        fi
-        nohup \(quoted(endpoint.remoteInstallRoot))/bin/ping-island-bridge --mode remote-agent-service --hook-socket \(quoted(endpoint.remoteHookSocketPath)) --control-socket \(quoted(endpoint.remoteControlSocketPath)) > \(quoted(endpoint.remoteInstallRoot))/logs/remote-agent.log 2>&1 &
-        sleep 1
-        """
+        let command = Self.remoteEnsureAgentRunningCommand(
+            installRoot: endpoint.remoteInstallRoot,
+            controlSocketPath: endpoint.remoteControlSocketPath,
+            hookSocketPath: endpoint.remoteHookSocketPath
+        )
         _ = try await RemoteSSHCommandRunner.runSSH(
             target: endpoint.sshTarget,
             port: endpoint.sshPort,
@@ -1243,6 +1240,24 @@ final class RemoteConnectorManager: ObservableObject {
         pkill -f \(shellQuote(agentPattern)) >/dev/null 2>&1 || true
         sleep 1
         rm -f \(shellQuote(controlSocketPath)) \(shellQuote(hookSocketPath)) \(shellQuote("\(installRoot)/bin/PingIslandBridge.tmp"))
+        """
+    }
+
+    nonisolated static func remoteEnsureAgentRunningCommand(
+        installRoot: String,
+        controlSocketPath: String,
+        hookSocketPath: String
+    ) -> String {
+        let servicePattern = "\(installRoot)/bin/[P]ingIslandBridge --mode remote-agent-service"
+        return """
+        mkdir -p \(shellQuote("\(installRoot)/run")) \(shellQuote("\(installRoot)/logs"))
+        if [ -S \(shellQuote(controlSocketPath)) ] && pgrep -f \(shellQuote(servicePattern)) >/dev/null 2>&1; then
+          exit 0
+        fi
+        pkill -f \(shellQuote(servicePattern)) >/dev/null 2>&1 || true
+        rm -f \(shellQuote(controlSocketPath)) \(shellQuote(hookSocketPath))
+        nohup \(shellQuote("\(installRoot)/bin/ping-island-bridge")) --mode remote-agent-service --hook-socket \(shellQuote(hookSocketPath)) --control-socket \(shellQuote(controlSocketPath)) > \(shellQuote("\(installRoot)/logs/remote-agent.log")) 2>&1 &
+        sleep 1
         """
     }
 

--- a/PingIslandTests/RemoteHookConfigurationTests.swift
+++ b/PingIslandTests/RemoteHookConfigurationTests.swift
@@ -27,6 +27,20 @@ final class RemoteHookConfigurationTests: XCTestCase {
         XCTAssertTrue(command.contains("chmod 755 '/root/.ping-island/bin/PingIslandBridge' '/root/.ping-island/bin/ping-island-bridge'"))
     }
 
+    func testRemoteEnsureAgentRunningCommandReplacesStaleSocketStateBeforeRestart() {
+        let command = RemoteConnectorManager.remoteEnsureAgentRunningCommand(
+            installRoot: "/root/.ping-island",
+            controlSocketPath: "/root/.ping-island/run/agent-control.sock",
+            hookSocketPath: "/root/.ping-island/run/agent-hook.sock"
+        )
+
+        XCTAssertTrue(command.contains("mkdir -p '/root/.ping-island/run' '/root/.ping-island/logs'"))
+        XCTAssertTrue(command.contains("if [ -S '/root/.ping-island/run/agent-control.sock' ] && pgrep -f '/root/.ping-island/bin/[P]ingIslandBridge --mode remote-agent-service' >/dev/null 2>&1; then"))
+        XCTAssertTrue(command.contains("pkill -f '/root/.ping-island/bin/[P]ingIslandBridge --mode remote-agent-service' >/dev/null 2>&1 || true"))
+        XCTAssertTrue(command.contains("rm -f '/root/.ping-island/run/agent-control.sock' '/root/.ping-island/run/agent-hook.sock'"))
+        XCTAssertTrue(command.contains("nohup '/root/.ping-island/bin/ping-island-bridge' --mode remote-agent-service --hook-socket '/root/.ping-island/run/agent-hook.sock' --control-socket '/root/.ping-island/run/agent-control.sock' > '/root/.ping-island/logs/remote-agent.log' 2>&1 &"))
+    }
+
     func testRemoteBootstrapUninstallCommandStopsBridgeAndRemovesInstallRoot() {
         let command = RemoteConnectorManager.remoteBootstrapUninstallCommand(
             installRoot: "/root/.ping-island",

--- a/Prototype/Sources/IslandBridge/main.swift
+++ b/Prototype/Sources/IslandBridge/main.swift
@@ -25,6 +25,7 @@ struct IslandBridgeMain {
     private static let stdinFollowUpPollTimeoutMs = 10
 
     static func main() async {
+        Self.configureProcessSignalHandling()
         do {
             switch try parseMode(arguments: CommandLine.arguments) {
             case .hook:
@@ -92,6 +93,12 @@ struct IslandBridgeMain {
             FileHandle.standardError.write(Data("PingIslandBridge error: \(error.localizedDescription)\n".utf8))
             Foundation.exit(1)
         }
+    }
+
+    private static func configureProcessSignalHandling() {
+        #if canImport(Glibc) || canImport(Musl)
+        _ = signal(SIGPIPE, SIG_IGN)
+        #endif
     }
 
     private static func parseMode(arguments: [String]) throws -> BridgeRuntimeMode {
@@ -333,6 +340,7 @@ private struct JSONStreamCompletionState {
             return false
         }
     }
+
 }
 
 private enum BridgeDebugLogger {


### PR DESCRIPTION
## Summary
- ignore SIGPIPE in the Linux bridge entrypoint so remote-agent-service survives broken SSH control sockets
- make remote agent ensure/start verify process liveness instead of trusting stale socket files
- cover the reconnect shell command with a regression test
- address issue #88

## Testing
- xcodebuild -project PingIsland.xcodeproj -scheme PingIsland -configuration Debug CODE_SIGNING_ALLOWED=NO test -only-testing:PingIslandTests/RemoteHookConfigurationTests
- swift test --package-path Prototype
- xcodebuild -project PingIsland.xcodeproj -scheme PingIsland -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/ping-island-issue88-derived.XAAVkH CODE_SIGNING_ALLOWED=NO test -only-testing:PingIslandTests
