### PR TITLE
Keep floating pet feedback aligned with docked completion UX

### DIFF
--- a/PingIsland/Services/Session/SessionMonitor.swift
+++ b/PingIsland/Services/Session/SessionMonitor.swift
@@ -15,6 +15,10 @@ class SessionMonitor: ObservableObject {
     @Published var instances: [SessionState] = []
     @Published var pendingInstances: [SessionState] = []
 
+    nonisolated static var isRunningUnderXCTest: Bool {
+        Foundation.ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+    }
+
     private let runtimeCoordinator: any RuntimeCoordinating
     private var cancellables = Set<AnyCancellable>()
     private var hasStarted = false

--- a/PingIsland/UI/Views/DetachedIslandPanelView.swift
+++ b/PingIsland/UI/Views/DetachedIslandPanelView.swift
@@ -148,10 +148,14 @@ enum DetachedIslandContentModel {
 
     static func canPresentBubble(
         from sessions: [SessionState],
-        mode: DetachedIslandBubbleContentMode
+        mode: DetachedIslandBubbleContentMode,
+        activeCompletionNotification: SessionCompletionNotification? = nil
     ) -> Bool {
         switch mode {
         case .hoverPreview:
+            if activeCompletionNotification != nil {
+                return true
+            }
             return IslandExpandedRouteResolver.highestPriorityAttentionSession(from: sessions) != nil
                 || !IslandExpandedRouteResolver.activePreviewSessions(from: sessions).isEmpty
         case .pinnedList:
@@ -163,10 +167,12 @@ enum DetachedIslandContentModel {
     static func route(
         for sessions: [SessionState],
         viewModel: NotchViewModel,
-        mode: DetachedIslandBubbleContentMode
+        mode: DetachedIslandBubbleContentMode,
+        activeCompletionNotification: SessionCompletionNotification? = nil
     ) -> IslandExpandedRoute {
         let trigger: IslandExpandedTrigger = switch mode {
-        case .hoverPreview: .hover
+        case .hoverPreview:
+            activeCompletionNotification == nil ? .hover : .notification
         case .pinnedList: .pinnedList
         }
 
@@ -174,7 +180,8 @@ enum DetachedIslandContentModel {
             surface: .floating,
             trigger: trigger,
             contentType: viewModel.contentType,
-            sessions: sessions
+            sessions: sessions,
+            activeCompletionNotification: activeCompletionNotification
         )
     }
 
@@ -263,6 +270,7 @@ enum DetachedIslandContentModel {
         bubbleState: DetachedIslandBubbleState,
         bubblePlacement: DetachedIslandBubblePlacement,
         measuredAttentionBubbleHeight: CGFloat? = nil,
+        activeCompletionNotification: SessionCompletionNotification? = nil,
         petScreenAnchor: CGPoint? = nil,
         availableFrame: CGRect? = nil
     ) -> DetachedIslandWindowLayout {
@@ -273,7 +281,11 @@ enum DetachedIslandContentModel {
         let hiddenAnchor = CGPoint(x: petSize.width / 2, y: petSize.height / 2)
 
         guard let mode = DetachedIslandBubbleContentMode(bubbleState: bubbleState),
-              canPresentBubble(from: sessions, mode: mode) else {
+              canPresentBubble(
+                from: sessions,
+                mode: mode,
+                activeCompletionNotification: activeCompletionNotification
+              ) else {
             return DetachedIslandWindowLayout(
                 containerSize: petSize,
                 petFrame: CGRect(origin: .zero, size: petSize),
@@ -284,7 +296,12 @@ enum DetachedIslandContentModel {
             )
         }
 
-        let route = route(for: sessions, viewModel: viewModel, mode: mode)
+        let route = route(
+            for: sessions,
+            viewModel: viewModel,
+            mode: mode,
+            activeCompletionNotification: activeCompletionNotification
+        )
         let bubbleSize = bubbleContentSize(
             for: route,
             sessions: sessions,
@@ -461,6 +478,7 @@ final class DetachedIslandInteractionModel: ObservableObject {
 @MainActor
 final class DetachedIslandBubbleViewState: ObservableObject {
     @Published var highlightedSessionStableID: String?
+    @Published private(set) var activeCompletionNotification: SessionCompletionNotification?
     @Published private(set) var renderedBubbleState: DetachedIslandBubbleState = .hidden
     @Published private(set) var isBubbleVisible = false
     @Published private(set) var measuredAttentionBubbleHeight: CGFloat?
@@ -482,6 +500,11 @@ final class DetachedIslandBubbleViewState: ObservableObject {
         guard measuredAttentionBubbleHeight != sanitized else { return }
         measuredAttentionBubbleHeight = sanitized
     }
+
+    func setActiveCompletionNotification(_ notification: SessionCompletionNotification?) {
+        guard activeCompletionNotification != notification else { return }
+        activeCompletionNotification = notification
+    }
 }
 
 struct DetachedIslandPanelView: View {
@@ -497,6 +520,8 @@ struct DetachedIslandPanelView: View {
     let onPetDragChanged: (CGSize) -> Void
     let onPetDragEnded: () -> Void
     let onAttentionActionCompleted: () -> Void
+    let onCompletionNotificationHoverChanged: (Bool) -> Void
+    let onDismissCompletionNotification: () -> Void
 
     private var sortedSessions: [SessionState] {
         DetachedIslandContentModel.sortedSessions(from: sessionMonitor.instances)
@@ -519,7 +544,8 @@ struct DetachedIslandPanelView: View {
         return DetachedIslandContentModel.route(
             for: sortedSessions,
             viewModel: viewModel,
-            mode: bubbleContentMode
+            mode: bubbleContentMode,
+            activeCompletionNotification: bubbleViewState.activeCompletionNotification
         )
     }
 
@@ -529,7 +555,8 @@ struct DetachedIslandPanelView: View {
             viewModel: viewModel,
             bubbleState: bubbleViewState.renderedBubbleState,
             bubblePlacement: interactionModel.bubblePlacement,
-            measuredAttentionBubbleHeight: bubbleViewState.measuredAttentionBubbleHeight
+            measuredAttentionBubbleHeight: bubbleViewState.measuredAttentionBubbleHeight,
+            activeCompletionNotification: bubbleViewState.activeCompletionNotification
         )
     }
 
@@ -572,7 +599,9 @@ struct DetachedIslandPanelView: View {
         )
         .preferredColorScheme(.dark)
         .onAppear {
-            sessionMonitor.startMonitoring()
+            if !SessionMonitor.isRunningUnderXCTest {
+                sessionMonitor.startMonitoring()
+            }
         }
         .onChange(of: bubbleRoute) { _, route in
             guard case .attentionNotification = route else {
@@ -620,16 +649,18 @@ struct DetachedIslandPanelView: View {
                 sessionMonitor: sessionMonitor,
                 viewModel: viewModel,
                 surface: .floating,
-                trigger: mode == .pinnedList ? .pinnedList : .hover,
+                trigger: mode == .pinnedList
+                    ? .pinnedList
+                    : (bubbleViewState.activeCompletionNotification == nil ? .hover : .notification),
                 style: .detached,
-                activeCompletionNotification: nil,
+                activeCompletionNotification: bubbleViewState.activeCompletionNotification,
                 highlightedSessionStableID: route == .sessionList
                     ? bubbleViewState.highlightedSessionStableID
                     : nil,
                 contentWidthOverride: contentWidth,
                 onAttentionActionCompleted: onAttentionActionCompleted,
-                onCompletionNotificationHoverChanged: { _ in },
-                onDismissCompletionNotification: {}
+                onCompletionNotificationHoverChanged: onCompletionNotificationHoverChanged,
+                onDismissCompletionNotification: onDismissCompletionNotification
             )
         }
     }

--- a/PingIsland/UI/Views/IslandExpandedRoute.swift
+++ b/PingIsland/UI/Views/IslandExpandedRoute.swift
@@ -21,7 +21,7 @@ enum IslandExpandedRoute: Equatable {
 }
 
 enum IslandExpandedRouteResolver {
-    static func resolve(
+    nonisolated static func resolve(
         surface: IslandExpandedSurface,
         trigger: IslandExpandedTrigger,
         contentType: NotchContentType,
@@ -38,9 +38,17 @@ enum IslandExpandedRouteResolver {
                 return .completionNotification(activeCompletionNotification)
             }
             return .sessionList
-        case (.docked, .hover), (.floating, .hover), (.floating, .notification):
+        case (.docked, .hover), (.floating, .hover):
             if let session = highestPriorityAttentionSession(from: sessions) {
                 return .attentionNotification(session)
+            }
+            return .hoverDashboard
+        case (.floating, .notification):
+            if let session = highestPriorityAttentionSession(from: sessions) {
+                return .attentionNotification(session)
+            }
+            if let activeCompletionNotification {
+                return .completionNotification(activeCompletionNotification)
             }
             return .hoverDashboard
         case (_, .click), (_, .pinnedList):
@@ -48,22 +56,22 @@ enum IslandExpandedRouteResolver {
         }
     }
 
-    static func orderedSessions(from sessions: [SessionState]) -> [SessionState] {
+    nonisolated static func orderedSessions(from sessions: [SessionState]) -> [SessionState] {
         sessions.sorted { $0.shouldSortBeforeInQueue($1) }
     }
 
-    static func activePreviewSessions(from sessions: [SessionState]) -> [SessionState] {
+    nonisolated static func activePreviewSessions(from sessions: [SessionState]) -> [SessionState] {
         orderedSessions(from: sessions).filter(\.phase.isActive)
     }
 
-    static func highestPriorityAttentionSession(from sessions: [SessionState]) -> SessionState? {
+    nonisolated static func highestPriorityAttentionSession(from sessions: [SessionState]) -> SessionState? {
         orderedSessions(from: sessions)
             .filter { $0.needsApprovalResponse || $0.needsQuestionResponse }
             .sorted(by: attentionSort)
             .first
     }
 
-    private static func attentionSort(_ lhs: SessionState, _ rhs: SessionState) -> Bool {
+    nonisolated private static func attentionSort(_ lhs: SessionState, _ rhs: SessionState) -> Bool {
         let lhsDate = lhs.attentionRequestedAt ?? lhs.lastUserMessageDate ?? lhs.lastActivity
         let rhsDate = rhs.attentionRequestedAt ?? rhs.lastUserMessageDate ?? rhs.lastActivity
         return lhsDate > rhsDate

--- a/PingIsland/UI/Views/NotchView.swift
+++ b/PingIsland/UI/Views/NotchView.swift
@@ -283,7 +283,9 @@ struct NotchView: View {
     private var lifecycleBody: some View {
         presentedBody
             .onAppear {
-                sessionMonitor.startMonitoring()
+                if !SessionMonitor.isRunningUnderXCTest {
+                    sessionMonitor.startMonitoring()
+                }
                 viewModel.updateIdleAutoHiddenState(hasVisibleSessionActivity: !shouldHideForIdleState)
                 isVisible = !viewModel.shouldHideWindowPresentation
                 viewModel.setManualAttentionActive(hasManualAttentionIndicator)

--- a/PingIsland/UI/Views/SessionManualAttentionTracker.swift
+++ b/PingIsland/UI/Views/SessionManualAttentionTracker.swift
@@ -42,7 +42,7 @@ struct SessionManualAttentionTracker {
         return attentionCandidates.sorted(by: attentionSort).first
     }
 
-    private func attentionSort(_ lhs: SessionState, _ rhs: SessionState) -> Bool {
+    nonisolated private func attentionSort(_ lhs: SessionState, _ rhs: SessionState) -> Bool {
         let lhsDate = lhs.attentionRequestedAt ?? lhs.lastUserMessageDate ?? lhs.lastActivity
         let rhsDate = rhs.attentionRequestedAt ?? rhs.lastUserMessageDate ?? rhs.lastActivity
         return lhsDate > rhsDate

--- a/PingIsland/UI/Window/DetachedIslandWindowController.swift
+++ b/PingIsland/UI/Window/DetachedIslandWindowController.swift
@@ -85,6 +85,12 @@ final class DetachedIslandViewController: NSViewController {
     var onAttentionActionCompleted: () -> Void = {} {
         didSet { refreshRootViewIfLoaded() }
     }
+    var onCompletionNotificationHoverChanged: (Bool) -> Void = { _ in } {
+        didSet { refreshRootViewIfLoaded() }
+    }
+    var onDismissCompletionNotification: () -> Void = {} {
+        didSet { refreshRootViewIfLoaded() }
+    }
     private var hostingView: TransparentHostingView<AppLocalizedRootView<DetachedIslandPanelView>>!
 
     init(
@@ -124,7 +130,9 @@ final class DetachedIslandViewController: NSViewController {
                 onPetDragStarted: onPetDragStarted,
                 onPetDragChanged: onPetDragChanged,
                 onPetDragEnded: onPetDragEnded,
-                onAttentionActionCompleted: onAttentionActionCompleted
+                onAttentionActionCompleted: onAttentionActionCompleted,
+                onCompletionNotificationHoverChanged: onCompletionNotificationHoverChanged,
+                onDismissCompletionNotification: onDismissCompletionNotification
             )
         }
     }
@@ -156,12 +164,27 @@ final class DetachedIslandWindowController: NSWindowController, NSWindowDelegate
     private var hasPendingWindowSizeUpdate = false
     private var interactionActivationWorkItem: DispatchWorkItem?
     private var bubbleVisibilityWorkItem: DispatchWorkItem?
+    private var completionNotificationDismissWorkItem: DispatchWorkItem?
     private var outsideClickMonitor: EventMonitor?
     private var floatingDragStartOrigin: CGPoint?
     private var petMouseDownPoint: CGPoint?
     private var petMouseDownScreenPoint: CGPoint?
     private var isPetDragActive = false
     private var isPetSecondaryClickArmed = false
+    private var hasPrimedSoundTransitions = false
+    private var previousProcessingIds = Set<String>()
+    private var previousAttentionSoundIds = Set<String>()
+    private var previousCompletionSoundIds = Set<String>()
+    private var previousTaskErrorIds = Set<String>()
+    private var previousResourceLimitIds = Set<String>()
+    private var previousCompletionNotificationPhases: [String: SessionPhase] = [:]
+    private var completionNotificationQueue: [SessionCompletionNotification] = []
+    private var activeCompletionNotification: SessionCompletionNotification? {
+        didSet {
+            bubbleViewState.setActiveCompletionNotification(activeCompletionNotification)
+        }
+    }
+    private var shouldDismissCompletionNotificationOnHoverExit = false
 
     init(
         viewModel: NotchViewModel,
@@ -216,12 +239,13 @@ final class DetachedIslandWindowController: NSWindowController, NSWindowDelegate
 
         super.init(window: window)
 
-        hostingController.onPetTap = { [weak interactionModel, weak sessionMonitor] in
+        hostingController.onPetTap = { [weak self, weak interactionModel, weak sessionMonitor] in
             let sessions = sessionMonitor?.instances ?? []
             interactionModel?.togglePrimaryBubble(
                 canPresentPreview: DetachedIslandContentModel.canPresentBubble(
                     from: sessions,
-                    mode: .hoverPreview
+                    mode: .hoverPreview,
+                    activeCompletionNotification: self?.activeCompletionNotification
                 ),
                 canPresentPinnedBubble: DetachedIslandContentModel.canPresentBubble(
                     from: sessions,
@@ -241,6 +265,12 @@ final class DetachedIslandWindowController: NSWindowController, NSWindowDelegate
         hostingController.onAttentionActionCompleted = { [weak self] in
             self?.dismissAttentionBubble()
         }
+        hostingController.onCompletionNotificationHoverChanged = { [weak self] isHovering in
+            self?.handleCompletionNotificationHover(isHovering)
+        }
+        hostingController.onDismissCompletionNotification = { [weak self] in
+            self?.dismissActiveCompletionNotification(closeBubble: true, advanceQueue: true)
+        }
         window.petMouseDownHandler = { [weak self] event in
             self?.handlePetMouseDown(event) ?? false
         }
@@ -259,6 +289,8 @@ final class DetachedIslandWindowController: NSWindowController, NSWindowDelegate
 
         window.delegate = self
         bindWindowSizeUpdates()
+        primeCompletionNotificationTracking(sessionMonitor.instances)
+        primeSoundTransitions(sessionMonitor.instances)
     }
 
     required init?(coder: NSCoder) {
@@ -273,7 +305,8 @@ final class DetachedIslandWindowController: NSWindowController, NSWindowDelegate
             sessionMonitor: sessionMonitor,
             bubbleState: bubbleViewState.renderedBubbleState,
             bubblePlacement: interactionModel.bubblePlacement,
-            measuredAttentionBubbleHeight: bubbleViewState.measuredAttentionBubbleHeight
+            measuredAttentionBubbleHeight: bubbleViewState.measuredAttentionBubbleHeight,
+            activeCompletionNotification: activeCompletionNotification
         )
         let initialFrame = NSRect(
             origin: origin,
@@ -296,6 +329,7 @@ final class DetachedIslandWindowController: NSWindowController, NSWindowDelegate
             bubbleState: bubbleViewState.renderedBubbleState,
             bubblePlacement: interactionModel.bubblePlacement,
             measuredAttentionBubbleHeight: bubbleViewState.measuredAttentionBubbleHeight,
+            activeCompletionNotification: activeCompletionNotification,
             petAnchorScreen: petAnchor,
             availableFrame: availableFrame(for: petAnchor)
         )
@@ -322,7 +356,8 @@ final class DetachedIslandWindowController: NSWindowController, NSWindowDelegate
         return DetachedIslandContentModel.route(
             for: sessionMonitor.instances,
             viewModel: viewModel,
-            mode: bubbleContentMode
+            mode: bubbleContentMode,
+            activeCompletionNotification: activeCompletionNotification
         )
     }
 
@@ -396,7 +431,8 @@ final class DetachedIslandWindowController: NSWindowController, NSWindowDelegate
     func presentHoverBubbleForTesting() {
         let canPresentBubble = DetachedIslandContentModel.canPresentBubble(
             from: sessionMonitor.instances,
-            mode: .hoverPreview
+            mode: .hoverPreview,
+            activeCompletionNotification: activeCompletionNotification
         )
         interactionModel.presentHoverPreview(canPresentBubble: canPresentBubble)
         syncBubblePresentation(to: interactionModel.bubbleState)
@@ -437,7 +473,13 @@ final class DetachedIslandWindowController: NSWindowController, NSWindowDelegate
     func applySessionSnapshotForTesting(_ sessions: [SessionState]) {
         sessionMonitor.instances = sessions
         handleManualAttentionChange()
+        handleCompletionNotificationChange(sessions)
+        handleSessionSoundTransitions(sessions)
         reconcileHighlightedSessionState()
+    }
+
+    var currentActiveCompletionNotificationForTesting: SessionCompletionNotification? {
+        activeCompletionNotification
     }
 
     func dismiss() {
@@ -445,6 +487,8 @@ final class DetachedIslandWindowController: NSWindowController, NSWindowDelegate
         interactionActivationWorkItem = nil
         bubbleVisibilityWorkItem?.cancel()
         bubbleVisibilityWorkItem = nil
+        completionNotificationDismissWorkItem?.cancel()
+        completionNotificationDismissWorkItem = nil
         outsideClickMonitor?.stop()
         outsideClickMonitor = nil
         floatingDragStartOrigin = nil
@@ -469,8 +513,10 @@ final class DetachedIslandWindowController: NSWindowController, NSWindowDelegate
         sessionMonitor.$instances
             .dropFirst()
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in
+            .sink { [weak self] instances in
                 self?.handleManualAttentionChange()
+                self?.handleCompletionNotificationChange(instances)
+                self?.handleSessionSoundTransitions(instances)
                 self?.reconcileHighlightedSessionState()
                 self?.reconcileBubbleStateWithAvailableContent()
                 self?.scheduleWindowSizeUpdate()
@@ -516,6 +562,50 @@ final class DetachedIslandWindowController: NSWindowController, NSWindowDelegate
                 self?.scheduleWindowSizeUpdate()
             }
             .store(in: &cancellables)
+
+        AppSettings.shared.$autoOpenCompletionPanel
+            .dropFirst()
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] isEnabled in
+                guard let self else { return }
+                if !isEnabled {
+                    self.removeCompletionNotifications(
+                        matching: { $0 == .completed || $0 == .ended },
+                        keepBubbleOpen: false
+                    )
+                } else {
+                    self.maybePresentNextCompletionNotification()
+                }
+            }
+            .store(in: &cancellables)
+
+        AppSettings.shared.$autoOpenCompactedNotificationPanel
+            .dropFirst()
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] isEnabled in
+                guard let self else { return }
+                if !isEnabled {
+                    self.removeCompletionNotifications(
+                        matching: { $0 == .compacted },
+                        keepBubbleOpen: false
+                    )
+                } else {
+                    self.maybePresentNextCompletionNotification()
+                }
+            }
+            .store(in: &cancellables)
+
+        AppSettings.shared.$temporarilyMuteNotificationsUntil
+            .dropFirst()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] mutedUntil in
+                guard let self,
+                      AppSettings.isNotificationMuteActive(until: mutedUntil) else { return }
+                self.clearCompletionNotifications(keepBubbleOpen: false)
+            }
+            .store(in: &cancellables)
     }
 
     private func scheduleWindowSizeUpdate() {
@@ -553,6 +643,7 @@ final class DetachedIslandWindowController: NSWindowController, NSWindowDelegate
             bubbleState: bubbleViewState.renderedBubbleState,
             bubblePlacement: interactionModel.bubblePlacement,
             measuredAttentionBubbleHeight: bubbleViewState.measuredAttentionBubbleHeight,
+            activeCompletionNotification: activeCompletionNotification,
             petAnchorScreen: petAnchorScreen,
             availableFrame: availableFrame(for: petAnchorScreen)
         )
@@ -584,6 +675,7 @@ final class DetachedIslandWindowController: NSWindowController, NSWindowDelegate
         bubbleState: DetachedIslandBubbleState = .hidden,
         bubblePlacement: DetachedIslandBubblePlacement = .topLeft,
         measuredAttentionBubbleHeight: CGFloat? = nil,
+        activeCompletionNotification: SessionCompletionNotification? = nil,
         petAnchorScreen: CGPoint? = nil,
         availableFrame: CGRect? = nil
     ) -> DetachedIslandWindowLayout {
@@ -593,6 +685,7 @@ final class DetachedIslandWindowController: NSWindowController, NSWindowDelegate
             bubbleState: bubbleState,
             bubblePlacement: bubblePlacement,
             measuredAttentionBubbleHeight: measuredAttentionBubbleHeight,
+            activeCompletionNotification: activeCompletionNotification,
             petScreenAnchor: petAnchorScreen,
             availableFrame: availableFrame
         )
@@ -604,6 +697,7 @@ final class DetachedIslandWindowController: NSWindowController, NSWindowDelegate
         bubbleState: DetachedIslandBubbleState = .hidden,
         bubblePlacement: DetachedIslandBubblePlacement = .topLeft,
         measuredAttentionBubbleHeight: CGFloat? = nil,
+        activeCompletionNotification: SessionCompletionNotification? = nil,
         petAnchorScreen: CGPoint? = nil,
         availableFrame: CGRect? = nil
     ) -> CGSize {
@@ -613,6 +707,7 @@ final class DetachedIslandWindowController: NSWindowController, NSWindowDelegate
             bubbleState: bubbleState,
             bubblePlacement: bubblePlacement,
             measuredAttentionBubbleHeight: measuredAttentionBubbleHeight,
+            activeCompletionNotification: activeCompletionNotification,
             petAnchorScreen: petAnchorScreen,
             availableFrame: availableFrame
         ).containerSize
@@ -883,7 +978,8 @@ final class DetachedIslandWindowController: NSWindowController, NSWindowDelegate
         guard interactionModel.bubbleState != .pinned else { return }
         guard DetachedIslandContentModel.canPresentBubble(
             from: sessionMonitor.instances,
-            mode: .hoverPreview
+            mode: .hoverPreview,
+            activeCompletionNotification: activeCompletionNotification
         ) else {
             return
         }
@@ -902,6 +998,8 @@ final class DetachedIslandWindowController: NSWindowController, NSWindowDelegate
         ) else {
             return
         }
+
+        clearCompletionNotifications(keepBubbleOpen: true)
 
         if interactionModel.bubbleState == .pinned {
             updateHighlightedSessionStableID(targetSession.stableId)
@@ -941,7 +1039,8 @@ final class DetachedIslandWindowController: NSWindowController, NSWindowDelegate
         case .hoverPreview:
             guard DetachedIslandContentModel.canPresentBubble(
                 from: sessionMonitor.instances,
-                mode: .hoverPreview
+                mode: .hoverPreview,
+                activeCompletionNotification: activeCompletionNotification
             ) else {
                 interactionModel.hidePinnedBubble()
                 return
@@ -999,6 +1098,7 @@ final class DetachedIslandWindowController: NSWindowController, NSWindowDelegate
             bubbleState: bubbleViewState.renderedBubbleState,
             bubblePlacement: interactionModel.bubblePlacement,
             measuredAttentionBubbleHeight: bubbleViewState.measuredAttentionBubbleHeight,
+            activeCompletionNotification: activeCompletionNotification,
             petAnchorScreen: petAnchorScreen,
             availableFrame: availableFrame(for: petAnchorScreen)
         )
@@ -1018,6 +1118,356 @@ final class DetachedIslandWindowController: NSWindowController, NSWindowDelegate
         }
 
         return viewModel.screenRect
+    }
+
+    private func primeCompletionNotificationTracking(_ instances: [SessionState]) {
+        previousCompletionNotificationPhases = Dictionary(
+            uniqueKeysWithValues: instances.map { ($0.stableId, $0.phase) }
+        )
+        synchronizeCompletionNotifications(with: instances)
+    }
+
+    private func handleCompletionNotificationChange(_ instances: [SessionState]) {
+        synchronizeCompletionNotifications(with: instances)
+
+        if AppSettings.areReminderNotificationsSuppressed {
+            if activeCompletionNotification != nil || !completionNotificationQueue.isEmpty {
+                clearCompletionNotifications(keepBubbleOpen: false)
+            }
+
+            previousCompletionNotificationPhases = Dictionary(
+                uniqueKeysWithValues: instances.map { ($0.stableId, $0.phase) }
+            )
+            return
+        }
+
+        let currentPhases = Dictionary(
+            uniqueKeysWithValues: instances.map { ($0.stableId, $0.phase) }
+        )
+
+        if interactionModel.bubbleState == .pinned && activeCompletionNotification == nil {
+            previousCompletionNotificationPhases = currentPhases
+            completionNotificationQueue.removeAll()
+            return
+        }
+
+        let newNotifications = instances
+            .compactMap { session -> SessionCompletionNotification? in
+                let previousPhase = previousCompletionNotificationPhases[session.stableId]
+
+                if shouldQueueCompactedNotification(for: session, previousPhase: previousPhase) {
+                    return SessionCompletionNotification(session: session, kind: .compacted)
+                }
+
+                if shouldQueueCompletedNotification(for: session, previousPhase: previousPhase) {
+                    return SessionCompletionNotification(session: session, kind: .completed)
+                }
+
+                if shouldQueueEndedNotification(for: session, previousPhase: previousPhase) {
+                    return SessionCompletionNotification(session: session, kind: .ended)
+                }
+
+                return nil
+            }
+            .sorted { $0.session.lastActivity < $1.session.lastActivity }
+
+        for notification in newNotifications {
+            enqueueCompletionNotification(notification)
+        }
+
+        previousCompletionNotificationPhases = currentPhases
+        maybePresentNextCompletionNotification()
+    }
+
+    private func shouldQueueCompletedNotification(
+        for session: SessionState,
+        previousPhase: SessionPhase?
+    ) -> Bool {
+        guard AppSettings.autoOpenCompletionPanel else { return false }
+        guard SessionCompletionStateEvaluator.isCompletedReadySession(session) else { return false }
+        guard previousPhase != .waitingForInput else { return false }
+        return true
+    }
+
+    private func shouldQueueEndedNotification(
+        for session: SessionState,
+        previousPhase: SessionPhase?
+    ) -> Bool {
+        guard AppSettings.autoOpenCompletionPanel else { return false }
+        guard session.phase == .ended else { return false }
+        guard previousPhase != .ended else { return false }
+        guard previousPhase != .waitingForInput else { return false }
+        return true
+    }
+
+    private func shouldQueueCompactedNotification(
+        for session: SessionState,
+        previousPhase: SessionPhase?
+    ) -> Bool {
+        guard AppSettings.autoOpenCompactedNotificationPanel else { return false }
+        guard previousPhase == .compacting else { return false }
+        guard session.phase != .compacting else { return false }
+        return true
+    }
+
+    private func synchronizeCompletionNotifications(with instances: [SessionState]) {
+        let sessionsById = Dictionary(uniqueKeysWithValues: instances.map { ($0.stableId, $0) })
+
+        if let active = activeCompletionNotification {
+            if let latest = sessionsById[active.session.stableId] {
+                activeCompletionNotification?.session = latest
+            } else {
+                dismissActiveCompletionNotification(closeBubble: false, advanceQueue: true)
+            }
+        }
+
+        completionNotificationQueue = completionNotificationQueue.compactMap { notification in
+            guard let latest = sessionsById[notification.session.stableId] else { return nil }
+            var updated = notification
+            updated.session = latest
+            return updated
+        }
+    }
+
+    private func enqueueCompletionNotification(_ notification: SessionCompletionNotification) {
+        if let active = activeCompletionNotification,
+           active.session.stableId == notification.session.stableId {
+            activeCompletionNotification?.session = notification.session
+            return
+        }
+
+        if let queuedIndex = completionNotificationQueue.firstIndex(where: {
+            $0.session.stableId == notification.session.stableId
+        }) {
+            var updated = completionNotificationQueue[queuedIndex]
+            updated.session = notification.session
+            completionNotificationQueue[queuedIndex] = updated
+            return
+        }
+
+        completionNotificationQueue.append(notification)
+    }
+
+    private func maybePresentNextCompletionNotification() {
+        guard !AppSettings.areReminderNotificationsSuppressed else { return }
+        guard activeCompletionNotification == nil else { return }
+        guard !completionNotificationQueue.isEmpty else { return }
+        guard case .instances = viewModel.contentType else { return }
+        guard interactionModel.bubbleState != .pinned else { return }
+        guard IslandExpandedRouteResolver.highestPriorityAttentionSession(
+            from: sessionMonitor.instances
+        ) == nil else {
+            return
+        }
+
+        let nextNotification = completionNotificationQueue.removeFirst()
+        activeCompletionNotification = nextNotification
+        shouldDismissCompletionNotificationOnHoverExit = false
+        interactionModel.presentHoverPreview(canPresentBubble: true)
+        scheduleCompletionNotificationDismissal(for: nextNotification.id)
+    }
+
+    private func scheduleCompletionNotificationDismissal(for notificationID: UUID) {
+        completionNotificationDismissWorkItem?.cancel()
+
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self,
+                  self.activeCompletionNotification?.id == notificationID else { return }
+            self.dismissActiveCompletionNotification(closeBubble: true, advanceQueue: true)
+        }
+
+        completionNotificationDismissWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5, execute: workItem)
+    }
+
+    private func clearCompletionNotifications(keepBubbleOpen: Bool) {
+        removeCompletionNotifications(matching: { _ in true }, keepBubbleOpen: keepBubbleOpen)
+    }
+
+    private func removeCompletionNotifications(
+        matching shouldRemove: (SessionCompletionNotification.Kind) -> Bool,
+        keepBubbleOpen: Bool
+    ) {
+        completionNotificationQueue.removeAll { shouldRemove($0.kind) }
+
+        if let activeCompletionNotification,
+           shouldRemove(activeCompletionNotification.kind) {
+            dismissActiveCompletionNotification(
+                closeBubble: !keepBubbleOpen,
+                advanceQueue: true
+            )
+        }
+    }
+
+    private func handleCompletionNotificationHover(_ isHovering: Bool) {
+        guard activeCompletionNotification != nil else {
+            shouldDismissCompletionNotificationOnHoverExit = false
+            return
+        }
+
+        if isHovering {
+            shouldDismissCompletionNotificationOnHoverExit = true
+            completionNotificationDismissWorkItem?.cancel()
+            completionNotificationDismissWorkItem = nil
+            return
+        }
+
+        guard shouldDismissCompletionNotificationOnHoverExit else { return }
+        shouldDismissCompletionNotificationOnHoverExit = false
+        dismissActiveCompletionNotification(closeBubble: true, advanceQueue: true)
+    }
+
+    private func dismissActiveCompletionNotification(
+        closeBubble: Bool,
+        advanceQueue: Bool
+    ) {
+        completionNotificationDismissWorkItem?.cancel()
+        completionNotificationDismissWorkItem = nil
+        shouldDismissCompletionNotificationOnHoverExit = false
+
+        guard activeCompletionNotification != nil else {
+            if advanceQueue {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) { [weak self] in
+                    self?.maybePresentNextCompletionNotification()
+                }
+            }
+            return
+        }
+
+        activeCompletionNotification = nil
+
+        if closeBubble, interactionModel.bubbleState == .hoverPreview {
+            if IslandExpandedRouteResolver.highestPriorityAttentionSession(
+                from: sessionMonitor.instances
+            ) != nil {
+                presentExistingAttentionIfNeeded()
+            } else {
+                interactionModel.hidePinnedBubble()
+            }
+        }
+
+        if advanceQueue {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) { [weak self] in
+                self?.maybePresentNextCompletionNotification()
+            }
+        }
+    }
+
+    private func primeSoundTransitions(_ instances: [SessionState]) {
+        previousProcessingIds = Set(
+            instances
+                .filter { $0.phase == .processing || $0.phase == .compacting }
+                .map(\.stableId)
+        )
+        previousAttentionSoundIds = Set(
+            instances
+                .filter { $0.needsApprovalResponse || ($0.phase == .waitingForInput && $0.intervention != nil) }
+                .map(\.stableId)
+        )
+        previousCompletionSoundIds = Set(
+            instances
+                .filter { $0.phase == .waitingForInput && $0.intervention == nil }
+                .map(\.stableId)
+        )
+        previousTaskErrorIds = Set(
+            instances.flatMap { session in
+                session.completedErrorToolIDs.map { "\(session.sessionId):\($0)" }
+            }
+        )
+        previousResourceLimitIds = Set(
+            instances
+                .filter { $0.phase == .compacting }
+                .map(\.stableId)
+        )
+        hasPrimedSoundTransitions = true
+    }
+
+    private func handleSessionSoundTransitions(_ instances: [SessionState]) {
+        if !hasPrimedSoundTransitions {
+            primeSoundTransitions(instances)
+            return
+        }
+
+        let processingSessions = instances.filter {
+            $0.phase == .processing || $0.phase == .compacting
+        }
+        let attentionSessions = instances.filter {
+            $0.needsApprovalResponse || ($0.phase == .waitingForInput && $0.intervention != nil)
+        }
+        let completedSessions = instances.filter { SessionCompletionStateEvaluator.isCompletedReadySession($0) }
+        let resourceLimitedSessions = instances.filter {
+            $0.phase == .compacting
+        }
+
+        let newProcessingIds = Set(processingSessions.map(\.stableId))
+        let newAttentionIds = Set(attentionSessions.map(\.stableId))
+        let newCompletedIds = Set(completedSessions.map(\.stableId))
+        let newTaskErrorIds = Set(
+            instances.flatMap { session in
+                session.completedErrorToolIDs.map { "\(session.sessionId):\($0)" }
+            }
+        )
+        let newResourceLimitIds = Set(resourceLimitedSessions.map(\.stableId))
+        let errorDeltaIds = newTaskErrorIds.subtracting(previousTaskErrorIds)
+        let errorSessions = instances.filter { session in
+            session.completedErrorToolIDs.contains { errorDeltaIds.contains("\(session.sessionId):\($0)") }
+        }
+        let completionDeltaIds = newCompletedIds.subtracting(previousCompletionSoundIds)
+        let newlyCompletedSessions = completedSessions.filter { session in
+            completionDeltaIds.contains(session.stableId)
+        }
+
+        let isNewAttention = !newAttentionIds.subtracting(previousAttentionSoundIds).isEmpty
+        let isNewCompletion = !completionDeltaIds.isEmpty
+        let isNewTaskError = !errorDeltaIds.isEmpty
+        let isNewResourceLimit = !newResourceLimitIds.subtracting(previousResourceLimitIds).isEmpty
+
+        if isNewTaskError {
+            playEventSoundIfNeeded(.taskError, sessions: errorSessions)
+        } else if isNewResourceLimit {
+            playEventSoundIfNeeded(.resourceLimit, sessions: resourceLimitedSessions)
+        } else if isNewAttention {
+            playEventSoundIfNeeded(.attentionRequired, sessions: attentionSessions)
+        } else if isNewCompletion {
+            playEventSoundIfNeeded(.taskCompleted, sessions: newlyCompletedSessions)
+        } else if !newProcessingIds.subtracting(previousProcessingIds).isEmpty {
+            playEventSoundIfNeeded(.processingStarted, sessions: processingSessions)
+        }
+
+        previousProcessingIds = newProcessingIds
+        previousAttentionSoundIds = newAttentionIds
+        previousCompletionSoundIds = newCompletedIds
+        previousTaskErrorIds = newTaskErrorIds
+        previousResourceLimitIds = newResourceLimitIds
+    }
+
+    private func playEventSoundIfNeeded(_ event: NotificationEvent, sessions: [SessionState]) {
+        guard AppSettings.soundEnabled else { return }
+
+        Task { [weak self] in
+            guard let self else { return }
+            let shouldPlaySound = await self.shouldPlayNotificationSound(for: sessions)
+            if shouldPlaySound {
+                _ = await MainActor.run {
+                    AppSettings.playSound(for: event)
+                }
+            }
+        }
+    }
+
+    private func shouldPlayNotificationSound(for sessions: [SessionState]) async -> Bool {
+        for session in sessions {
+            guard let pid = session.pid else {
+                return true
+            }
+
+            let isFocused = await TerminalVisibilityDetector.isSessionFocused(sessionPid: pid)
+            if !isFocused {
+                return true
+            }
+        }
+
+        return false
     }
 }
 

--- a/PingIslandTests/DetachedIslandWindowControllerTests.swift
+++ b/PingIslandTests/DetachedIslandWindowControllerTests.swift
@@ -588,6 +588,76 @@ final class DetachedIslandWindowControllerTests: XCTestCase {
         wait(for: [bubblePresented], timeout: 1.0)
     }
 
+    func testCompletedSessionAutoOpensCompletionBubbleInFloatingMode() {
+        let viewModel = makeViewModel()
+        let sessionMonitor = SessionMonitor()
+        sessionMonitor.instances = [makeSession(id: "active", phase: .processing)]
+
+        let controller = DetachedIslandWindowController(
+            viewModel: viewModel,
+            sessionMonitor: sessionMonitor,
+            onClose: {}
+        )
+        defer { controller.dismiss() }
+
+        controller.present(atPetAnchor: CGPoint(x: 1200, y: 220))
+
+        let completed = makeCompletedSession(id: "completed")
+        controller.applySessionSnapshotForTesting([completed])
+
+        let bubblePresented = expectation(description: "completion bubble auto-opens")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+            XCTAssertEqual(controller.renderedBubbleStateForTesting, .hoverPreview)
+            XCTAssertTrue(controller.isBubbleVisibleForTesting)
+
+            guard let notification = controller.currentActiveCompletionNotificationForTesting else {
+                XCTFail("Expected active completion notification")
+                bubblePresented.fulfill()
+                return
+            }
+
+            XCTAssertEqual(notification.session.stableId, completed.stableId)
+            XCTAssertEqual(notification.kind, .completed)
+            XCTAssertEqual(
+                controller.currentExpandedRoute,
+                .completionNotification(notification)
+            )
+            bubblePresented.fulfill()
+        }
+
+        wait(for: [bubblePresented], timeout: 1.0)
+    }
+
+    func testDisablingCompletionNotificationsPreventsFloatingCompletionBubble() {
+        let originalAutoOpenCompletionPanel = AppSettings.autoOpenCompletionPanel
+        AppSettings.autoOpenCompletionPanel = false
+        defer { AppSettings.autoOpenCompletionPanel = originalAutoOpenCompletionPanel }
+
+        let viewModel = makeViewModel()
+        let sessionMonitor = SessionMonitor()
+        sessionMonitor.instances = [makeSession(id: "active", phase: .processing)]
+
+        let controller = DetachedIslandWindowController(
+            viewModel: viewModel,
+            sessionMonitor: sessionMonitor,
+            onClose: {}
+        )
+        defer { controller.dismiss() }
+
+        controller.present(atPetAnchor: CGPoint(x: 1200, y: 220))
+        controller.applySessionSnapshotForTesting([makeCompletedSession(id: "completed")])
+
+        let noBubble = expectation(description: "completion bubble stays hidden")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+            XCTAssertNil(controller.currentActiveCompletionNotificationForTesting)
+            XCTAssertEqual(controller.renderedBubbleStateForTesting, .hidden)
+            XCTAssertFalse(controller.isBubbleVisibleForTesting)
+            noBubble.fulfill()
+        }
+
+        wait(for: [noBubble], timeout: 1.0)
+    }
+
     func testDismissAttentionBubbleHidesHoverPreview() {
         let viewModel = makeViewModel()
         let sessionMonitor = SessionMonitor()
@@ -846,6 +916,25 @@ final class DetachedIslandWindowControllerTests: XCTestCase {
             phase: phase,
             chatItems: chatItems,
             conversationInfo: conversationInfo
+        )
+    }
+
+    private func makeCompletedSession(id: String) -> SessionState {
+        makeSession(
+            id: id,
+            phase: .waitingForInput,
+            chatItems: [
+                ChatHistoryItem(id: "\(id)-user", type: .user("Do it"), timestamp: Date()),
+                ChatHistoryItem(id: "\(id)-assistant", type: .assistant("All done"), timestamp: Date())
+            ],
+            conversationInfo: ConversationInfo(
+                summary: nil,
+                lastMessage: "All done",
+                lastMessageRole: "assistant",
+                lastToolName: nil,
+                firstUserMessage: "Do it",
+                lastUserMessageDate: Date()
+            )
         )
     }
 

--- a/PingIslandTests/IslandExpandedRouteResolverTests.swift
+++ b/PingIslandTests/IslandExpandedRouteResolverTests.swift
@@ -83,6 +83,21 @@ final class IslandExpandedRouteResolverTests: XCTestCase {
         XCTAssertEqual(route, .attentionNotification(attention))
     }
 
+    func testFloatingNotificationWithCompletionResolvesToCompletionNotification() {
+        let completed = makeSession(id: "completed", phase: .waitingForInput)
+        let notification = SessionCompletionNotification(session: completed, kind: .completed)
+
+        let route = IslandExpandedRouteResolver.resolve(
+            surface: .floating,
+            trigger: .notification,
+            contentType: .instances,
+            sessions: [completed],
+            activeCompletionNotification: notification
+        )
+
+        XCTAssertEqual(route, .completionNotification(notification))
+    }
+
     private func makeSession(
         id: String,
         phase: SessionPhase,


### PR DESCRIPTION
## Summary
- keep floating pet mode playing the same stage-transition sounds as the docked Island
- route floating notification bubbles through the shared completion-notification path so finished agent tasks can surface completion previews in pet mode too
- add route coverage plus detached-window regression coverage for floating completion notifications

## Testing
- xcodebuild -project PingIsland.xcodeproj -scheme PingIsland -configuration Debug build
- xcodebuild -project PingIsland.xcodeproj -scheme PingIsland -configuration Debug CODE_SIGNING_ALLOWED=NO test -only-testing:PingIslandTests/IslandExpandedRouteResolverTests
- DetachedIslandWindowControllerTests still hang in this environment during xcodebuild test execution, so the full detached suite is called out here rather than claimed as passing