### PR TITLE
[codex] Improve floating-pet dragging feedback

### DIFF
--- a/PingIsland/UI/Components/MascotView.swift
+++ b/PingIsland/UI/Components/MascotView.swift
@@ -348,29 +348,53 @@ struct MascotView: View {
     let status: MascotStatus
     var size: CGFloat = 40
     var animationTime: TimeInterval?
+    var isDragging: Bool = false
 
-    init(kind: MascotKind, status: MascotStatus, size: CGFloat = 40, animationTime: TimeInterval? = nil) {
+    init(
+        kind: MascotKind,
+        status: MascotStatus,
+        size: CGFloat = 40,
+        animationTime: TimeInterval? = nil,
+        isDragging: Bool = false
+    ) {
         self.kind = kind
         self.status = status
         self.size = size
         self.animationTime = animationTime
+        self.isDragging = isDragging
     }
 
-    init(provider: SessionProvider, status: MascotStatus, size: CGFloat = 40, animationTime: TimeInterval? = nil) {
-        self.init(kind: MascotKind(provider: provider), status: status, size: size, animationTime: animationTime)
+    init(
+        provider: SessionProvider,
+        status: MascotStatus,
+        size: CGFloat = 40,
+        animationTime: TimeInterval? = nil,
+        isDragging: Bool = false
+    ) {
+        self.init(
+            kind: MascotKind(provider: provider),
+            status: status,
+            size: size,
+            animationTime: animationTime,
+            isDragging: isDragging
+        )
     }
 
     var body: some View {
         ZStack {
-            switch status {
-            case .idle:
-                idleScene(time: animationTime)
-            case .working:
-                workingScene(time: animationTime)
-            case .warning:
-                warningScene(time: animationTime)
-            case .dragging:
+            if isDragging || status == .dragging {
                 draggingScene(time: animationTime)
+            } else {
+                switch status {
+                case .idle:
+                    idleScene(time: animationTime)
+                case .working:
+                    workingScene(time: animationTime)
+                case .warning:
+                    warningScene(time: animationTime)
+                case .dragging:
+                    draggingScene(time: animationTime)
+                }
             }
         }
         .frame(width: size, height: size)
@@ -397,7 +421,10 @@ struct MascotView: View {
     }
 
     private func draggingScene(time: TimeInterval?) -> some View {
-        canvasScene(interval: 0.03, mode: .dragging, time: time)
+        ZStack {
+            DragMotionOverlay(size: size, time: time)
+            canvasScene(interval: 0.025, mode: .dragging, time: time)
+        }
     }
 
     @ViewBuilder
@@ -1202,9 +1229,9 @@ struct MascotView: View {
             tailWag = 0.12
             headBob = -0.12
         case .dragging:
-            wingLift = -0.35 + CGFloat(sin(time * 7.0) * 0.10)
-            tailWag = CGFloat(sin(time * 5.8) * 0.22)
-            headBob = CGFloat(cos(time * 5.4) * 0.08)
+            wingLift = -0.4 + flapPhase * 0.82
+            tailWag = CGFloat(sin(time * 11.0) * 0.28)
+            headBob = CGFloat(sin(time * 8.0) * 0.1)
         }
 
         drawShadow(in: context, space: space, centerX: 9.0, y: 16.7, width: 8.7 - abs(motion.bounce) * 0.18, opacity: 0.2)
@@ -1672,13 +1699,20 @@ struct MascotView: View {
                 squashY: squashY
             )
         case .dragging:
-            let swing = CGFloat(sin(time * 4.6) * 0.35)
+            let cycle = time.truncatingRemainder(dividingBy: 0.72)
+            let pct = CGFloat(cycle / 0.72)
+            let lift = lerp(
+                [(0, 0), (0.18, -1.4), (0.34, -3.1), (0.56, -2.0), (0.78, -3.4), (1, 0)],
+                at: pct
+            )
+            let shake = CGFloat(sin(time * 14.5) * 0.38)
+            let stretch = CGFloat(sin(time * 9.5) * 0.03)
             return MascotMotion(
-                vertical: -1.4 + CGFloat(sin(time * 6.4) * 0.18),
-                bounce: -1.1,
-                shake: swing,
-                squashX: 1.03,
-                squashY: 0.97
+                vertical: lift,
+                bounce: lift,
+                shake: shake,
+                squashX: 1.03 + stretch,
+                squashY: 0.97 - (stretch * 0.8)
             )
         }
     }
@@ -1900,6 +1934,80 @@ private struct AlertHalo: View {
             .frame(width: size * (0.78 + pulse * 0.10))
             .blur(radius: size * 0.07)
     }
+}
+
+private struct DragMotionOverlay: View {
+    let size: CGFloat
+    var time: TimeInterval?
+
+    var body: some View {
+        if let time {
+            overlayBody(time: time)
+        } else {
+            TimelineView(.periodic(from: .now, by: 0.04)) { context in
+                overlayBody(time: context.date.timeIntervalSinceReferenceDate)
+            }
+        }
+    }
+
+    private func overlayBody(time: TimeInterval) -> some View {
+        let cycle = 0.9
+        let baseProgress = wrappedProgress((time / cycle).truncatingRemainder(dividingBy: 1))
+
+        return ZStack(alignment: .topLeading) {
+            ForEach(dragTrailConfigs.indices, id: \.self) { index in
+                let config = dragTrailConfigs[index]
+                let progress = wrappedProgress(baseProgress + config.phaseOffset)
+                let opacity = trailOpacity(progress: progress) * config.maxOpacity
+
+                if opacity > 0.01 {
+                    Capsule(style: .continuous)
+                        .fill(Color.white.opacity(opacity))
+                        .frame(
+                            width: size * CGFloat(config.widthScale - progress * 0.02),
+                            height: max(2, size * CGFloat(config.heightScale))
+                        )
+                        .rotationEffect(.degrees(config.rotation))
+                        .offset(
+                            x: size * CGFloat(config.startX - progress * config.travelX),
+                            y: size * CGFloat(config.startY + progress * config.travelY)
+                        )
+                }
+            }
+        }
+        .frame(width: size, height: size, alignment: .topLeading)
+    }
+
+    private func wrappedProgress(_ progress: Double) -> Double {
+        let wrapped = progress.truncatingRemainder(dividingBy: 1)
+        return wrapped >= 0 ? wrapped : wrapped + 1
+    }
+
+    private func trailOpacity(progress: Double) -> Double {
+        let fadeIn = min(max(progress / 0.12, 0), 1)
+        let fadeOut = min(max((1 - progress) / 0.48, 0), 1)
+        return fadeIn * fadeOut
+    }
+
+    private var dragTrailConfigs: [DragTrailConfig] {
+        [
+            DragTrailConfig(phaseOffset: 0.00, startX: 0.14, startY: 0.26, travelX: 0.12, travelY: 0.03, widthScale: 0.20, heightScale: 0.05, rotation: -22, maxOpacity: 0.42),
+            DragTrailConfig(phaseOffset: 0.24, startX: 0.08, startY: 0.42, travelX: 0.10, travelY: -0.01, widthScale: 0.24, heightScale: 0.055, rotation: -14, maxOpacity: 0.34),
+            DragTrailConfig(phaseOffset: 0.48, startX: 0.18, startY: 0.58, travelX: 0.14, travelY: -0.04, widthScale: 0.18, heightScale: 0.05, rotation: -28, maxOpacity: 0.28)
+        ]
+    }
+}
+
+private struct DragTrailConfig {
+    let phaseOffset: Double
+    let startX: Double
+    let startY: Double
+    let travelX: Double
+    let travelY: Double
+    let widthScale: Double
+    let heightScale: Double
+    let rotation: Double
+    let maxOpacity: Double
 }
 
 #Preview("Mascot Grid") {

--- a/PingIsland/UI/Views/DetachedIslandPanelView.swift
+++ b/PingIsland/UI/Views/DetachedIslandPanelView.swift
@@ -420,6 +420,7 @@ enum DetachedIslandContentModel {
 final class DetachedIslandInteractionModel: ObservableObject {
     @Published private(set) var bubbleState: DetachedIslandBubbleState = .hidden
     @Published private(set) var bubblePlacement: DetachedIslandBubblePlacement = .topLeft
+    @Published private(set) var isPetDragging = false
 
     var bubbleContentMode: DetachedIslandBubbleContentMode? {
         DetachedIslandBubbleContentMode(bubbleState: bubbleState)
@@ -472,6 +473,11 @@ final class DetachedIslandInteractionModel: ObservableObject {
 
     func resetForDragSuppression() {
         hidePinnedBubble()
+    }
+
+    func setPetDragging(_ isDragging: Bool) {
+        guard isPetDragging != isDragging else { return }
+        isPetDragging = isDragging
     }
 }
 
@@ -636,6 +642,7 @@ struct DetachedIslandPanelView: View {
             activeCount: activeCount,
             mascotKind: compactMascotKind,
             mascotStatus: compactMascotStatus,
+            isDragging: interactionModel.isPetDragging,
             onTap: onPetTap,
             onDragStarted: {
                 isPetDragging = true
@@ -680,6 +687,7 @@ private struct DetachedFloatingPetInteractionView: View {
     let activeCount: Int
     let mascotKind: MascotKind
     let mascotStatus: MascotStatus
+    let isDragging: Bool
     let onTap: () -> Void
     let onDragStarted: () -> Void
     let onDragChanged: (CGSize) -> Void
@@ -689,7 +697,8 @@ private struct DetachedFloatingPetInteractionView: View {
         ZStack(alignment: .bottomTrailing) {
             DetachedFloatingMascotView(
                 kind: mascotKind,
-                status: mascotStatus
+                status: mascotStatus,
+                isDragging: isDragging
             )
             .frame(
                 width: DetachedIslandPanelMetrics.petVisualFrame,
@@ -708,6 +717,9 @@ private struct DetachedFloatingPetInteractionView: View {
             width: DetachedIslandPanelMetrics.petHitFrame,
             height: DetachedIslandPanelMetrics.petHitFrame
         )
+        .rotationEffect(.degrees(isDragging ? -7 : 0))
+        .scaleEffect(isDragging ? 1.08 : 1)
+        .animation(.spring(response: 0.22, dampingFraction: 0.68), value: isDragging)
         .overlay {
             DetachedPetInteractionBridge(
                 size: CGSize(
@@ -834,6 +846,7 @@ private final class DetachedPetInteractionView: NSView {
 private struct DetachedFloatingMascotView: View {
     let kind: MascotKind
     let status: MascotStatus
+    let isDragging: Bool
 
     private var renderSize: CGFloat {
         DetachedIslandPanelMetrics.mascotDisplaySize * DetachedIslandPanelMetrics.mascotRenderScale
@@ -847,7 +860,8 @@ private struct DetachedFloatingMascotView: View {
         MascotView(
             kind: kind,
             status: status,
-            size: renderSize
+            size: renderSize,
+            isDragging: isDragging
         )
         .frame(width: renderSize, height: renderSize)
         .scaleEffect(displayScale)

--- a/PingIsland/UI/Window/DetachedIslandWindowController.swift
+++ b/PingIsland/UI/Window/DetachedIslandWindowController.swift
@@ -396,6 +396,7 @@ final class DetachedIslandWindowController: NSWindowController, NSWindowDelegate
         guard floatingDragStartOrigin == nil else { return }
         cancelInteractionActivation()
         interactionModel.resetForDragSuppression()
+        interactionModel.setPetDragging(true)
         hideBubbleRenderingImmediately()
         floatingDragStartOrigin = window?.frame.origin
     }
@@ -418,6 +419,7 @@ final class DetachedIslandWindowController: NSWindowController, NSWindowDelegate
 
     func endFloatingDrag() {
         floatingDragStartOrigin = nil
+        interactionModel.setPetDragging(false)
         if let currentPetAnchor {
             onPetAnchorChanged(currentPetAnchor)
         }
@@ -470,6 +472,10 @@ final class DetachedIslandWindowController: NSWindowController, NSWindowDelegate
         bubbleViewState.isBubbleVisible
     }
 
+    var isPetDraggingForTesting: Bool {
+        interactionModel.isPetDragging
+    }
+
     func applySessionSnapshotForTesting(_ sessions: [SessionState]) {
         sessionMonitor.instances = sessions
         handleManualAttentionChange()
@@ -492,6 +498,7 @@ final class DetachedIslandWindowController: NSWindowController, NSWindowDelegate
         outsideClickMonitor?.stop()
         outsideClickMonitor = nil
         floatingDragStartOrigin = nil
+        interactionModel.setPetDragging(false)
         window?.orderOut(nil)
     }
 

--- a/PingIslandTests/DetachedIslandWindowControllerTests.swift
+++ b/PingIslandTests/DetachedIslandWindowControllerTests.swift
@@ -188,6 +188,27 @@ final class DetachedIslandWindowControllerTests: XCTestCase {
         XCTAssertFalse(window.ignoresMouseEvents)
     }
 
+    func testFloatingDragUpdatesPetDraggingState() {
+        let viewModel = makeViewModel()
+        let sessionMonitor = SessionMonitor()
+        sessionMonitor.instances = []
+
+        let controller = DetachedIslandWindowController(
+            viewModel: viewModel,
+            sessionMonitor: sessionMonitor,
+            onClose: {}
+        )
+        defer { controller.dismiss() }
+
+        XCTAssertFalse(controller.isPetDraggingForTesting)
+
+        controller.beginFloatingDrag()
+        XCTAssertTrue(controller.isPetDraggingForTesting)
+
+        controller.endFloatingDrag()
+        XCTAssertFalse(controller.isPetDraggingForTesting)
+    }
+
     func testBeginFloatingDragPreservesPetAnchorWhenHoverBubbleIsVisible() throws {
         let viewModel = makeViewModel()
         let sessionMonitor = SessionMonitor()


### PR DESCRIPTION
## What changed
- add a dedicated dragging visual state for the floating pet so drag interactions feel intentional instead of looking like a static sprite being moved
- route the detached pet drag lifecycle through the shared interaction model so AppKit drag events and SwiftUI rendering stay in sync
- remove the extra bottom shadow and grounding mask so the dragged mascot stays visually light
- add a regression test for the detached window controller drag-state toggle

## Why it changed
The floating pet could be dragged around the screen, but there was almost no visual feedback that the mascot had entered a drag gesture. The earlier version of the fix also added grounding/shadow treatments that felt too heavy in practice.

## Impact
Dragging the floating mascot should now read more clearly while keeping the sprite clean and unobtrusive. The change is scoped to the detached floating-pet path.

## Validation
- `xcodebuild -project PingIsland.xcodeproj -scheme PingIsland -configuration Debug CODE_SIGNING_ALLOWED=NO build`

## Notes
- `PingIslandTests/DetachedIslandWindowControllerTests` was updated, but the targeted `xcodebuild test` flow previously compiled without actually launching `xctest` in this environment, so this PR is validated by build only.
