### PR TITLE
[codex] restore 0.5.1 upgrade onboarding for returning notched-display users

### DIFF
--- a/PingIsland/App/AppDelegate.swift
+++ b/PingIsland/App/AppDelegate.swift
@@ -24,7 +24,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             HookInstaller.installIfNeeded()
             IDEExtensionInstaller.cleanupLegacyTraeExtension()
             NotchDetachmentHintExperience.prepareForLaunch(
-                previousVersion: HookInstaller.getVersionMetadata()?["previousVersion"] as? String
+                previousVersion: HookInstaller.getVersionMetadata()?["previousVersion"] as? String,
+                markHintsPending: {
+                    AppSettings.notchDetachmentHintPending = true
+                    AppSettings.floatingPetSettingsHintPending = true
+                }
             )
         }
 

--- a/PingIsland/App/AppDelegate.swift
+++ b/PingIsland/App/AppDelegate.swift
@@ -21,7 +21,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         if launchConfiguration.shouldInstallIntegrations {
-            HookInstaller.installIfNeeded()
+            HookInstaller.installIfNeeded(
+                markPresentationOnboardingPending: {
+                    AppSettings.presentationModeOnboardingPending = true
+                }
+            )
             IDEExtensionInstaller.cleanupLegacyTraeExtension()
             NotchDetachmentHintExperience.prepareForLaunch(
                 previousVersion: HookInstaller.getVersionMetadata()?["previousVersion"] as? String,

--- a/PingIsland/App/AppLaunchConfiguration.swift
+++ b/PingIsland/App/AppLaunchConfiguration.swift
@@ -72,7 +72,8 @@ struct NotchDetachmentHintExperience {
     static func prepareForLaunch(
         defaults: UserDefaults = .standard,
         previousVersion: String?,
-        currentVersion: String = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
+        currentVersion: String = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "",
+        markHintsPending: (() -> Void)? = nil
     ) {
         let normalizedCurrentVersion = currentVersion.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !normalizedCurrentVersion.isEmpty else {
@@ -96,7 +97,11 @@ struct NotchDetachmentHintExperience {
             return
         }
 
-        defaults.set(true, forKey: AppSettingsDefaultKeys.notchDetachmentHintPending)
-        defaults.set(true, forKey: AppSettingsDefaultKeys.floatingPetSettingsHintPending)
+        if let markHintsPending {
+            markHintsPending()
+        } else {
+            defaults.set(true, forKey: AppSettingsDefaultKeys.notchDetachmentHintPending)
+            defaults.set(true, forKey: AppSettingsDefaultKeys.floatingPetSettingsHintPending)
+        }
     }
 }

--- a/PingIsland/Services/Hooks/HookInstaller.swift
+++ b/PingIsland/Services/Hooks/HookInstaller.swift
@@ -207,9 +207,11 @@ struct HookInstaller {
     }
 
     /// Install managed hooks for preferred clients on app launch.
-    static func installIfNeeded() {
+    static func installIfNeeded(markPresentationOnboardingPending: (() -> Void)? = nil) {
         // Check if this is first launch and perform auto-integration
-        let isFirstLaunch = checkAndMarkFirstLaunch()
+        let isFirstLaunch = checkAndMarkFirstLaunch(
+            markPresentationOnboardingPending: markPresentationOnboardingPending
+        )
 
         let preferredTargets = preferredTargets()
         installBridgeLauncherIfNeeded()
@@ -231,8 +233,10 @@ struct HookInstaller {
     }
 
     /// Check if this is the first launch and mark as installed
-    private static func checkAndMarkFirstLaunch() -> Bool {
-        let defaults = UserDefaults.standard
+    static func checkAndMarkFirstLaunch(
+        defaults: UserDefaults = .standard,
+        markPresentationOnboardingPending: (() -> Void)? = nil
+    ) -> Bool {
 
         // Check if we've already recorded a version
         if defaults.string(forKey: installedVersionDefaultsKey) != nil {
@@ -241,7 +245,11 @@ struct HookInstaller {
 
         // First launch - mark it
         defaults.set(true, forKey: firstLaunchDefaultsKey)
-        defaults.set(true, forKey: AppSettingsDefaultKeys.presentationModeOnboardingPending)
+        if let markPresentationOnboardingPending {
+            markPresentationOnboardingPending()
+        } else {
+            defaults.set(true, forKey: AppSettingsDefaultKeys.presentationModeOnboardingPending)
+        }
         return true
     }
 

--- a/PingIslandTests/AppLaunchConfigurationTests.swift
+++ b/PingIslandTests/AppLaunchConfigurationTests.swift
@@ -194,6 +194,22 @@ final class AppLaunchConfigurationTests: XCTestCase {
         XCTAssertFalse(defaults.bool(forKey: AppSettingsDefaultKeys.notchDetachmentHintPending))
     }
 
+    func testNotchDetachmentHintExperienceUsesInjectedPendingMarkerForUpgrades() {
+        let defaults = makeDefaults()
+        var injectedMarkerInvocationCount = 0
+
+        NotchDetachmentHintExperience.prepareForLaunch(
+            defaults: defaults,
+            previousVersion: "0.5.0",
+            currentVersion: "0.5.1",
+            markHintsPending: {
+                injectedMarkerInvocationCount += 1
+            }
+        )
+
+        XCTAssertEqual(injectedMarkerInvocationCount, 1)
+    }
+
     func testMouseEventReplayMarkerDistinguishesSyntheticEvents() {
         let location = CGPoint(x: 120, y: 48)
         let originalEvent = CGEvent(

--- a/PingIslandTests/AppLaunchConfigurationTests.swift
+++ b/PingIslandTests/AppLaunchConfigurationTests.swift
@@ -210,6 +210,33 @@ final class AppLaunchConfigurationTests: XCTestCase {
         XCTAssertEqual(injectedMarkerInvocationCount, 1)
     }
 
+    func testFirstLaunchCheckUsesInjectedPendingMarker() {
+        let defaults = makeDefaults()
+        var injectedMarkerInvocationCount = 0
+
+        let isFirstLaunch = HookInstaller.checkAndMarkFirstLaunch(
+            defaults: defaults,
+            markPresentationOnboardingPending: {
+                injectedMarkerInvocationCount += 1
+            }
+        )
+
+        XCTAssertTrue(isFirstLaunch)
+        XCTAssertEqual(injectedMarkerInvocationCount, 1)
+        XCTAssertEqual(defaults.object(forKey: "HookInstaller.isFirstLaunch.v1") as? Bool, true)
+        XCTAssertNil(defaults.object(forKey: AppSettingsDefaultKeys.presentationModeOnboardingPending))
+    }
+
+    func testFirstLaunchCheckFallsBackToDefaultsWithoutInjectedPendingMarker() {
+        let defaults = makeDefaults()
+
+        let isFirstLaunch = HookInstaller.checkAndMarkFirstLaunch(defaults: defaults)
+
+        XCTAssertTrue(isFirstLaunch)
+        XCTAssertEqual(defaults.object(forKey: "HookInstaller.isFirstLaunch.v1") as? Bool, true)
+        XCTAssertEqual(defaults.object(forKey: AppSettingsDefaultKeys.presentationModeOnboardingPending) as? Bool, true)
+    }
+
     func testMouseEventReplayMarkerDistinguishesSyntheticEvents() {
         let location = CGPoint(x: 120, y: 48)
         let originalEvent = CGEvent(


### PR DESCRIPTION
## Summary
- route the 0.5.1 upgrade hint preparation through a live pending-marker hook
- update app launch to set `AppSettings` hint flags directly so the current process observes the change immediately
- add focused regression coverage for the injected upgrade marker path

## Root cause
The upgrade path wrote the hint flags straight to `UserDefaults` after `AppSettings.shared` could already be initialized for the current process. Returning users upgrading from 0.5.0 therefore missed the in-memory state change, so the notch guidance never appeared on that first 0.5.1 launch.

## Impact
Returning users on notched displays now receive the 0.5.1 guidance during the first upgraded launch instead of needing another restart or manual replay.

## Validation
- `xcodebuild -project PingIsland.xcodeproj -scheme PingIsland -configuration Debug CODE_SIGNING_ALLOWED=NO test -only-testing:PingIslandTests/AppLaunchConfigurationTests`
