### PR TITLE
Recover docked notch hover/click input after long runtime

### DIFF
--- a/PingIsland/Events/EventMonitor.swift
+++ b/PingIsland/Events/EventMonitor.swift
@@ -7,6 +7,11 @@
 
 import AppKit
 
+protocol EventMonitoring: AnyObject {
+    func start()
+    func stop()
+}
+
 enum MouseEventReplay {
     private static let marker: Int64 = 0x50494E47
 
@@ -81,7 +86,7 @@ enum MouseEventReplay {
     }
 }
 
-class EventMonitor {
+final class EventMonitor: EventMonitoring {
     private var globalMonitor: Any?
     private var localMonitor: Any?
     private let mask: NSEvent.EventTypeMask

--- a/PingIsland/Events/EventMonitors.swift
+++ b/PingIsland/Events/EventMonitors.swift
@@ -8,7 +8,8 @@
 import AppKit
 import Combine
 
-class EventMonitors {
+@MainActor
+final class EventMonitors {
     static let shared = EventMonitors()
 
     let mouseLocation = CurrentValueSubject<CGPoint, Never>(.zero)
@@ -16,42 +17,107 @@ class EventMonitors {
     let mouseDragged = PassthroughSubject<NSEvent, Never>()
     let mouseUp = PassthroughSubject<NSEvent, Never>()
 
-    private var mouseMoveMonitor: EventMonitor?
-    private var mouseDownMonitor: EventMonitor?
-    private var mouseDraggedMonitor: EventMonitor?
-    private var mouseUpMonitor: EventMonitor?
+    private var mouseMoveMonitor: EventMonitoring?
+    private var mouseDownMonitor: EventMonitoring?
+    private var mouseDraggedMonitor: EventMonitoring?
+    private var mouseUpMonitor: EventMonitoring?
+    private let notificationCenter: NotificationCenter
+    private let workspaceNotificationCenter: NotificationCenter
+    private let currentMouseLocation: () -> CGPoint
+    private let monitorFactory: (NSEvent.EventTypeMask, @escaping (NSEvent) -> Void) -> EventMonitoring
+    private var cancellables = Set<AnyCancellable>()
 
-    private init() {
+    convenience private init() {
+        self.init(
+            notificationCenter: .default,
+            workspaceNotificationCenter: NSWorkspace.shared.notificationCenter,
+            currentMouseLocation: { NSEvent.mouseLocation },
+            monitorFactory: { mask, handler in
+                EventMonitor(mask: mask, handler: handler)
+            }
+        )
+    }
+
+    init(
+        notificationCenter: NotificationCenter,
+        workspaceNotificationCenter: NotificationCenter,
+        currentMouseLocation: @escaping () -> CGPoint,
+        monitorFactory: @escaping (NSEvent.EventTypeMask, @escaping (NSEvent) -> Void) -> EventMonitoring
+    ) {
+        self.notificationCenter = notificationCenter
+        self.workspaceNotificationCenter = workspaceNotificationCenter
+        self.currentMouseLocation = currentMouseLocation
+        self.monitorFactory = monitorFactory
+
+        observeLifecycle()
+        restartMonitoring()
+    }
+
+    private func observeLifecycle() {
+        notificationCenter.publisher(for: NSApplication.didBecomeActiveNotification)
+            .sink { [weak self] _ in
+                self?.restartMonitoring()
+            }
+            .store(in: &cancellables)
+
+        notificationCenter.publisher(for: NSApplication.didChangeScreenParametersNotification)
+            .sink { [weak self] _ in
+                self?.restartMonitoring()
+            }
+            .store(in: &cancellables)
+
+        workspaceNotificationCenter.publisher(for: NSWorkspace.didWakeNotification)
+            .sink { [weak self] _ in
+                self?.restartMonitoring()
+            }
+            .store(in: &cancellables)
+
+        workspaceNotificationCenter.publisher(for: NSWorkspace.sessionDidBecomeActiveNotification)
+            .sink { [weak self] _ in
+                self?.restartMonitoring()
+            }
+            .store(in: &cancellables)
+    }
+
+    func restartMonitoring() {
+        stopMonitoring()
         setupMonitors()
+        mouseLocation.send(currentMouseLocation())
     }
 
     private func setupMonitors() {
-        mouseMoveMonitor = EventMonitor(mask: .mouseMoved) { [weak self] _ in
-            self?.mouseLocation.send(NSEvent.mouseLocation)
+        mouseMoveMonitor = monitorFactory(.mouseMoved) { [weak self] _ in
+            guard let self else { return }
+            self.mouseLocation.send(self.currentMouseLocation())
         }
         mouseMoveMonitor?.start()
 
-        mouseDownMonitor = EventMonitor(mask: .leftMouseDown) { [weak self] event in
+        mouseDownMonitor = monitorFactory(.leftMouseDown) { [weak self] event in
             self?.mouseDown.send(event)
         }
         mouseDownMonitor?.start()
 
-        mouseDraggedMonitor = EventMonitor(mask: .leftMouseDragged) { [weak self] event in
-            self?.mouseLocation.send(NSEvent.mouseLocation)
-            self?.mouseDragged.send(event)
+        mouseDraggedMonitor = monitorFactory(.leftMouseDragged) { [weak self] event in
+            guard let self else { return }
+            self.mouseLocation.send(self.currentMouseLocation())
+            self.mouseDragged.send(event)
         }
         mouseDraggedMonitor?.start()
 
-        mouseUpMonitor = EventMonitor(mask: .leftMouseUp) { [weak self] event in
+        mouseUpMonitor = monitorFactory(.leftMouseUp) { [weak self] event in
             self?.mouseUp.send(event)
         }
         mouseUpMonitor?.start()
     }
 
-    deinit {
+    private func stopMonitoring() {
         mouseMoveMonitor?.stop()
+        mouseMoveMonitor = nil
         mouseDownMonitor?.stop()
+        mouseDownMonitor = nil
         mouseDraggedMonitor?.stop()
+        mouseDraggedMonitor = nil
         mouseUpMonitor?.stop()
+        mouseUpMonitor = nil
     }
 }

--- a/PingIslandTests/NotchViewModelTests.swift
+++ b/PingIslandTests/NotchViewModelTests.swift
@@ -1,3 +1,5 @@
+import AppKit
+import Combine
 import CoreGraphics
 import XCTest
 @testable import Ping_Island
@@ -566,6 +568,57 @@ final class NotchViewModelTests: XCTestCase {
         }
     }
 
+    func testEventMonitorsRebuildAllMonitorsOnWakeNotification() async {
+        await MainActor.run {
+            let notificationCenter = NotificationCenter()
+            let workspaceNotificationCenter = NotificationCenter()
+            let recorder = MonitorRecorder()
+
+            let monitors = EventMonitors(
+                notificationCenter: notificationCenter,
+                workspaceNotificationCenter: workspaceNotificationCenter,
+                currentMouseLocation: { CGPoint(x: 40, y: 24) },
+                monitorFactory: recorder.makeMonitor(mask:handler:)
+            )
+
+            XCTAssertEqual(recorder.createdMasks, [.mouseMoved, .leftMouseDown, .leftMouseDragged, .leftMouseUp])
+            XCTAssertEqual(recorder.startedMasks, [.mouseMoved, .leftMouseDown, .leftMouseDragged, .leftMouseUp])
+
+            workspaceNotificationCenter.post(name: NSWorkspace.didWakeNotification, object: nil)
+
+            XCTAssertEqual(
+                recorder.createdMasks,
+                [.mouseMoved, .leftMouseDown, .leftMouseDragged, .leftMouseUp, .mouseMoved, .leftMouseDown, .leftMouseDragged, .leftMouseUp]
+            )
+            XCTAssertEqual(recorder.stopCallCount, 4)
+            XCTAssertEqual(monitors.mouseLocation.value, CGPoint(x: 40, y: 24))
+        }
+    }
+
+    func testEventMonitorsRebuildAllMonitorsOnAppActivation() async {
+        await MainActor.run {
+            let notificationCenter = NotificationCenter()
+            let workspaceNotificationCenter = NotificationCenter()
+            let recorder = MonitorRecorder()
+
+            let monitors = EventMonitors(
+                notificationCenter: notificationCenter,
+                workspaceNotificationCenter: workspaceNotificationCenter,
+                currentMouseLocation: { .zero },
+                monitorFactory: recorder.makeMonitor(mask:handler:)
+            )
+
+            notificationCenter.post(name: NSApplication.didBecomeActiveNotification, object: nil)
+
+            XCTAssertEqual(recorder.stopCallCount, 4)
+            XCTAssertEqual(
+                recorder.startedMasks,
+                [.mouseMoved, .leftMouseDown, .leftMouseDragged, .leftMouseUp, .mouseMoved, .leftMouseDown, .leftMouseDragged, .leftMouseUp]
+            )
+            XCTAssertEqual(monitors.mouseLocation.value, .zero)
+        }
+    }
+
     @MainActor
     private func makeViewModel() -> NotchViewModel {
         NotchViewModel(
@@ -584,5 +637,55 @@ final class NotchViewModelTests: XCTestCase {
             sessionId: id,
             cwd: "/tmp/\(id)"
         )
+    }
+}
+
+private final class MonitorRecorder {
+    private(set) var createdMasks: [NSEvent.EventTypeMask] = []
+    private(set) var startedMasks: [NSEvent.EventTypeMask] = []
+    private(set) var stopCallCount = 0
+
+    func makeMonitor(
+        mask: NSEvent.EventTypeMask,
+        handler: @escaping (NSEvent) -> Void
+    ) -> EventMonitoring {
+        createdMasks.append(mask)
+        return FakeEventMonitor(
+            mask: mask,
+            startHook: { [weak self] mask in
+                self?.startedMasks.append(mask)
+            },
+            stopHook: { [weak self] in
+                self?.stopCallCount += 1
+            },
+            handler: handler
+        )
+    }
+}
+
+private final class FakeEventMonitor: EventMonitoring {
+    private let mask: NSEvent.EventTypeMask
+    private let startHook: (NSEvent.EventTypeMask) -> Void
+    private let stopHook: () -> Void
+    let handler: (NSEvent) -> Void
+
+    init(
+        mask: NSEvent.EventTypeMask,
+        startHook: @escaping (NSEvent.EventTypeMask) -> Void,
+        stopHook: @escaping () -> Void,
+        handler: @escaping (NSEvent) -> Void
+    ) {
+        self.mask = mask
+        self.startHook = startHook
+        self.stopHook = stopHook
+        self.handler = handler
+    }
+
+    func start() {
+        startHook(mask)
+    }
+
+    func stop() {
+        stopHook()
     }
 }


### PR DESCRIPTION
## Summary

This fixes a docked-notch failure mode where the Island can stay visible after long runtime lifecycle transitions, but stop reacting to both hover and click while closed.

## Root Cause

The closed docked notch intentionally sets `ignoresMouseEvents = true`, so reopening it depends entirely on the global/local `NSEvent` monitors in `EventMonitors`.

Those monitors were only registered once at startup. After long-running lifecycle transitions such as:

- wake from sleep
- app becoming active again
- user session reactivation
- screen parameter changes

there was no recovery path to rebuild the monitor chain. If the monitor registration went stale, the closed notch had no fallback input path, so it looked present but became non-interactive.

## Fix

This PR keeps the existing pass-through closed-notch design and hardens the monitor lifecycle instead of changing hit testing:

- make `EventMonitors` main-actor bound because it owns AppKit event plumbing
- add a lightweight `EventMonitoring` abstraction so the lifecycle behavior is testable
- rebuild the mouse monitors on wake, app activation, session reactivation, and screen-parameter changes
- immediately republish the current mouse location after each rebuild so hover state can recover without waiting on a stale edge

## Why this approach

I did not switch the closed notch to direct mouse capture.
That would change the click-through model around the menu bar/system notch area and is a materially broader behavioral change.
Rebuilding the monitor chain is the narrower fix for the failure mode we have today.

## Validation

- `xcodebuild -project PingIsland.xcodeproj -scheme PingIsland -configuration Debug build`
- `xcodebuild -project PingIsland.xcodeproj -scheme PingIsland -configuration Debug CODE_SIGNING_ALLOWED=NO test -only-testing:PingIslandTests/NotchViewModelTests`

## Tests added

- wake notification rebuilds all notch event monitors
- app activation rebuilds all notch event monitors
