### PR TITLE
Fix Codex PermissionRequest hook stalls with no Island approval UI

### DIFF
--- a/Prototype/Sources/IslandShared/HookPayloadMapper.swift
+++ b/Prototype/Sources/IslandShared/HookPayloadMapper.swift
@@ -258,7 +258,11 @@ public enum HookPayloadMapper {
             if hasAnsweredQuestionPayload(payload) {
                 return answeredQuestionStatus(eventType: eventType)
             }
-            return mapStatusString(text)
+            return normalizedInteractiveStatus(
+                mapStatusString(text),
+                eventType: eventType,
+                intervention: intervention
+            )
         }
         if isGeminiHookClient(clientKind) {
             return geminiStatus(eventType: eventType, payload: payload)
@@ -306,6 +310,57 @@ public enum HookPayloadMapper {
             return SessionStatus(kind: .thinking)
         }
         return SessionStatus(kind: .active)
+    }
+
+    private static func normalizedInteractiveStatus(
+        _ explicitStatus: SessionStatus,
+        eventType: String,
+        intervention: InterventionRequest?
+    ) -> SessionStatus {
+        let loweredEvent = eventType.lowercased()
+
+        if let intervention {
+            switch intervention.kind {
+            case .approval:
+                if shouldPreferApprovalStatus(for: explicitStatus.kind) {
+                    return SessionStatus(kind: .waitingForApproval, detail: explicitStatus.detail)
+                }
+            case .question:
+                if shouldPreferQuestionStatus(for: explicitStatus.kind) {
+                    return SessionStatus(kind: .waitingForInput, detail: explicitStatus.detail)
+                }
+            }
+        }
+
+        if (loweredEvent.contains("permission") || loweredEvent.contains("approval")),
+           shouldPreferApprovalStatus(for: explicitStatus.kind) {
+            return SessionStatus(kind: .waitingForApproval, detail: explicitStatus.detail)
+        }
+
+        if (loweredEvent.contains("question") || loweredEvent.contains("userinput")),
+           shouldPreferQuestionStatus(for: explicitStatus.kind) {
+            return SessionStatus(kind: .waitingForInput, detail: explicitStatus.detail)
+        }
+
+        return explicitStatus
+    }
+
+    private static func shouldPreferApprovalStatus(for kind: SessionStatusKind) -> Bool {
+        switch kind {
+        case .idle, .active, .thinking, .runningTool:
+            return true
+        default:
+            return false
+        }
+    }
+
+    private static func shouldPreferQuestionStatus(for kind: SessionStatusKind) -> Bool {
+        switch kind {
+        case .idle, .active, .thinking, .runningTool:
+            return true
+        default:
+            return false
+        }
     }
 
     private static func detectExpectsResponse(

--- a/Prototype/Tests/IslandTests/HookPayloadMapperTests.swift
+++ b/Prototype/Tests/IslandTests/HookPayloadMapperTests.swift
@@ -28,6 +28,32 @@ func mapsApprovalEventFromClaudePayload() throws {
 }
 
 @Test
+func codexPermissionRequestKeepsApprovalStatusWhenPayloadStatusIsPending() throws {
+    let payload = """
+    {
+      "hook_event_name": "PermissionRequest",
+      "tool_name": "Bash",
+      "status": "pending",
+      "reason": "Needs approval to continue",
+      "session_id": "codex-permission-1"
+    }
+    """.data(using: .utf8)!
+
+    let envelope = HookPayloadMapper.makeEnvelope(
+        source: .codex,
+        arguments: ["island-bridge", "--source", "codex"],
+        environment: ["TERM_PROGRAM": "codex", "PWD": "/tmp/demo"],
+        stdinData: payload
+    )
+
+    #expect(envelope.provider == .codex)
+    #expect(envelope.eventType == "PermissionRequest")
+    #expect(envelope.intervention?.kind == .approval)
+    #expect(envelope.status?.kind == .waitingForApproval)
+    #expect(envelope.expectsResponse)
+}
+
+@Test
 func mapsGhosttyTerminalContextFromEnvironment() throws {
     let payload = """
     {


### PR DESCRIPTION
## Summary

This fixes issue #110, where Codex CLI could block in the `PermissionRequest` hook while Ping Island showed no approval prompt.

## Root Cause

The bridge mapper was treating any explicit payload `status` string as authoritative.
For Codex CLI `0.124.0`, `PermissionRequest` can carry a generic status such as `pending`.

That produced a bad split-brain state:

- the hook still counted as `expectsResponse`, so Ping Island kept the hook socket open and Codex waited
- but the mapped session status was downgraded to `.active` instead of `.waitingForApproval`
- so the session never surfaced an approval UI inside Ping Island

In practice that meant: CLI blocked, Island looked idle.

## Fix

This PR keeps the raw status detail for diagnostics, but changes the state mapping so interactive semantics win over ambiguous generic statuses:

- `PermissionRequest` / approval events now stay in `waitingForApproval` when the explicit status is an active-like value such as `pending`
- question-style events similarly prefer `waitingForInput` over ambiguous active-like statuses
- terminal/non-interactive events still keep their explicit status mapping behavior

## Why this approach

I did not remove explicit payload status handling entirely.
That would throw away useful diagnostics and broaden the behavior change to unrelated events.
The narrower fix is to override only the ambiguous active-like states when the event semantics clearly describe an approval or question interaction.

## Validation

- `swift test --package-path Prototype --filter HookPayloadMapperTests`
- `xcodebuild -project PingIsland.xcodeproj -scheme PingIsland -configuration Debug build`

## Tests added

- Codex `PermissionRequest` with `status = pending` still maps to `waitingForApproval`

Closes #110.
