### PR TITLE
Preserve full AskUserQuestion option copy

### DIFF
--- a/PingIsland/UI/Components/SessionQuestionForm.swift
+++ b/PingIsland/UI/Components/SessionQuestionForm.swift
@@ -30,6 +30,25 @@ struct SessionQuestionForm: View {
         }
     }
 
+    nonisolated static func optionColumns(
+        for question: SessionInterventionQuestion
+    ) -> [GridItem] {
+        if shouldUseSingleColumnOptions(for: question) {
+            return [GridItem(.flexible(minimum: 0), spacing: 8)]
+        }
+
+        return [GridItem(.adaptive(minimum: 150), spacing: 8)]
+    }
+
+    nonisolated static func shouldUseSingleColumnOptions(
+        for question: SessionInterventionQuestion
+    ) -> Bool {
+        question.options.contains { option in
+            option.title.count > 24
+                || ((option.detail?.count ?? 0) > 72)
+        }
+    }
+
     private var shouldUseScrollableQuestionList: Bool {
         Self.shouldUseScrollableQuestionList(for: displayQuestions)
     }
@@ -136,7 +155,7 @@ struct SessionQuestionForm: View {
     private func questionInput(_ question: SessionInterventionQuestion) -> some View {
         if !question.options.isEmpty {
             let reservesDetailSpace = question.options.contains { optionDetail(for: $0) != nil }
-            LazyVGrid(columns: [GridItem(.adaptive(minimum: 150), spacing: 8)], spacing: 8) {
+            LazyVGrid(columns: Self.optionColumns(for: question), spacing: 8) {
                 ForEach(question.options) { option in
                     Button {
                         guard isEditable else { return }
@@ -153,15 +172,15 @@ struct SessionQuestionForm: View {
                                 Text(option.title)
                                     .font(.system(size: 12, weight: .semibold))
                                     .foregroundColor(.white)
+                                    .fixedSize(horizontal: false, vertical: true)
                                 if let detail = optionDetail(for: option) {
                                     Text(detail)
                                         .font(.system(size: 10))
                                         .foregroundColor(.white.opacity(0.55))
-                                        .lineLimit(2)
+                                        .fixedSize(horizontal: false, vertical: true)
                                 } else if reservesDetailSpace {
                                     Text(" ")
                                         .font(.system(size: 10))
-                                        .lineLimit(2)
                                         .hidden()
                                 }
                             }

--- a/PingIslandTests/SessionQuestionFormTests.swift
+++ b/PingIslandTests/SessionQuestionFormTests.swift
@@ -42,4 +42,44 @@ final class SessionQuestionFormTests: XCTestCase {
 
         XCTAssertFalse(SessionQuestionForm.shouldUseScrollableQuestionList(for: questions))
     }
+
+    func testLongOptionTitlesForceSingleColumnLayout() {
+        let question = SessionInterventionQuestion(
+            id: "deployment",
+            header: "部署策略",
+            prompt: "请选择回滚策略",
+            detail: nil,
+            options: [
+                .init(
+                    id: "safe",
+                    title: "保持现有服务在线并逐步切换流量，确认所有检查通过后再下线旧版本",
+                    detail: nil
+                ),
+                .init(id: "fast", title: "直接切换", detail: nil),
+            ],
+            allowsMultiple: false,
+            allowsOther: false,
+            isSecret: false
+        )
+
+        XCTAssertTrue(SessionQuestionForm.shouldUseSingleColumnOptions(for: question))
+    }
+
+    func testShortOptionTitlesKeepAdaptiveColumns() {
+        let question = SessionInterventionQuestion(
+            id: "plan",
+            header: "方案",
+            prompt: "请选择方案",
+            detail: nil,
+            options: [
+                .init(id: "a", title: "修复问题", detail: nil),
+                .init(id: "b", title: "补测试", detail: nil),
+            ],
+            allowsMultiple: false,
+            allowsOther: false,
+            isSecret: false
+        )
+
+        XCTAssertFalse(SessionQuestionForm.shouldUseSingleColumnOptions(for: question))
+    }
 }


### PR DESCRIPTION
## Summary
- switch verbose question options to a single-column layout in the notch chooser
- stop truncating long option titles and detail copy inside option cards
- add focused tests covering the layout heuristic for long vs short option sets

## Testing
- xcodebuild -project PingIsland.xcodeproj -scheme PingIsland -configuration Debug CODE_SIGNING_ALLOWED=NO test -only-testing:PingIslandTests/SessionQuestionFormTests

Closes #118.
