### PR TITLE
[codex] Fix Hermes plugin manifest name

### DIFF
--- a/PingIsland/Services/Hooks/HookInstaller.swift
+++ b/PingIsland/Services/Hooks/HookInstaller.swift
@@ -1836,7 +1836,7 @@ struct HookInstaller {
 
         let pluginYAML = """
         # \(marker)
-        name: ping-island
+        name: ping_island
         version: 1.0.0
         description: Forward Hermes Agent plugin hooks to Ping Island
         provides_hooks:

--- a/PingIslandTests/HermesIntegrationTests.swift
+++ b/PingIslandTests/HermesIntegrationTests.swift
@@ -20,7 +20,7 @@ final class HermesIntegrationTests: XCTestCase {
         let pluginYAML = try XCTUnwrap(files["plugin.yaml"])
         let pluginSource = try XCTUnwrap(files["__init__.py"])
 
-        XCTAssertTrue(pluginYAML.contains("name: ping-island"))
+        XCTAssertTrue(pluginYAML.contains("name: ping_island"))
         XCTAssertTrue(pluginYAML.contains("provides_hooks:"))
         XCTAssertTrue(pluginYAML.contains("- on_session_finalize"))
         XCTAssertTrue(pluginYAML.contains("- on_session_reset"))

--- a/PingIslandTests/RemoteHookConfigurationTests.swift
+++ b/PingIslandTests/RemoteHookConfigurationTests.swift
@@ -136,7 +136,7 @@ final class RemoteHookConfigurationTests: XCTestCase {
         let files = HookInstaller.managedPluginDirectoryFiles(for: profile)
 
         XCTAssertEqual(Set(files.keys), ["plugin.yaml", "__init__.py"])
-        XCTAssertTrue(files["plugin.yaml"]?.contains("name: ping-island") == true)
+        XCTAssertTrue(files["plugin.yaml"]?.contains("name: ping_island") == true)
         XCTAssertTrue(files["__init__.py"]?.contains("ctx.register_hook(\"pre_llm_call\"") == true)
     }
 


### PR DESCRIPTION
## Summary

- Change the generated Hermes `plugin.yaml` manifest name from `ping-island` to `ping_island` so it matches the managed plugin directory.
- Update local and remote Hermes plugin-generation tests to lock the directory/manifest identity contract.

Fixes #130.

## Validation

- `xcodebuild -project PingIsland.xcodeproj -scheme PingIsland -configuration Debug CODE_SIGNING_ALLOWED=NO test -only-testing:PingIslandTests/HermesIntegrationTests -only-testing:PingIslandTests/RemoteHookConfigurationTests`
