### PR TITLE
[codex] Fix universal PingIslandBridge packaging

### DIFF
--- a/PingIsland.xcodeproj/project.pbxproj
+++ b/PingIsland.xcodeproj/project.pbxproj
@@ -285,7 +285,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/zsh;
-			shellScript = "set -euo pipefail\n\nPACKAGE_PATH=\"$SRCROOT/Prototype\"\nPRODUCT_NAME=\"PingIslandBridge\"\nBUILD_CONFIGURATION=$(echo \"$CONFIGURATION\" | tr '[:upper:]' '[:lower:]')\nSCRATCH_PATH=\"$DERIVED_FILE_DIR/PingIslandBridge-build\"\nAPP_BRIDGE_PATH=\"$TARGET_BUILD_DIR/$EXECUTABLE_FOLDER_PATH/$PRODUCT_NAME\"\n\nxcrun swift build \\\n  --package-path \"$PACKAGE_PATH\" \\\n  --product \"$PRODUCT_NAME\" \\\n  --configuration \"$BUILD_CONFIGURATION\" \\\n  --scratch-path \"$SCRATCH_PATH\"\n\nBRIDGE_PATH=$(find \"$SCRATCH_PATH\" -type f -path \"*/$BUILD_CONFIGURATION/$PRODUCT_NAME\" | head -n 1)\nif [ -z \"$BRIDGE_PATH\" ] || [ ! -x \"$BRIDGE_PATH\" ]; then\n  echo \"error: Failed to build $PRODUCT_NAME\" >&2\n  exit 1\nfi\n\ncp \"$BRIDGE_PATH\" \"$APP_BRIDGE_PATH\"\nchmod 755 \"$APP_BRIDGE_PATH\"\n\nif [[ \"${CODE_SIGNING_ALLOWED:-NO}\" == \"YES\" && -n \"${EXPANDED_CODE_SIGN_IDENTITY:-}\" ]]; then\n  codesign_args=(\n    --force\n    --sign \"$EXPANDED_CODE_SIGN_IDENTITY\"\n    --timestamp\n  )\n\n  if [[ \"${ENABLE_HARDENED_RUNTIME:-NO}\" == \"YES\" ]]; then\n    codesign_args+=(--options runtime)\n  fi\n\n  if [[ -n \"${OTHER_CODE_SIGN_FLAGS:-}\" ]]; then\n    codesign_args+=(${=OTHER_CODE_SIGN_FLAGS})\n  fi\n\n  codesign_args+=(\"$APP_BRIDGE_PATH\")\n  /usr/bin/codesign \"${codesign_args[@]}\"\nfi\n";
+			shellScript = "\"$SRCROOT/scripts/embed-ping-island-bridge.sh\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/scripts/embed-ping-island-bridge.sh
+++ b/scripts/embed-ping-island-bridge.sh
@@ -1,0 +1,83 @@
+#!/bin/zsh
+
+set -euo pipefail
+
+PACKAGE_PATH="${PING_ISLAND_BRIDGE_PACKAGE_PATH:-$SRCROOT/Prototype}"
+PRODUCT_NAME="${PING_ISLAND_BRIDGE_PRODUCT_NAME:-PingIslandBridge}"
+BUILD_CONFIGURATION=$(echo "${CONFIGURATION:-Debug}" | tr '[:upper:]' '[:lower:]')
+SCRATCH_BASE="${DERIVED_FILE_DIR:?DERIVED_FILE_DIR is required}/PingIslandBridge-build"
+APP_BRIDGE_PATH="${TARGET_BUILD_DIR:?TARGET_BUILD_DIR is required}/${EXECUTABLE_FOLDER_PATH:?EXECUTABLE_FOLDER_PATH is required}/$PRODUCT_NAME"
+DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-14.0}"
+
+archs=()
+for arch in ${(s: :)${ARCHS:-arm64 x86_64}}; do
+  case "$arch" in
+    arm64|x86_64)
+      if (( ${archs[(Ie)$arch]} == 0 )); then
+        archs+=("$arch")
+      fi
+      ;;
+  esac
+done
+
+if (( ${#archs[@]} == 0 )); then
+  echo "error: No supported architectures found in ARCHS='${ARCHS:-}'" >&2
+  exit 1
+fi
+
+rm -rf "$SCRATCH_BASE"
+mkdir -p "$(dirname "$APP_BRIDGE_PATH")"
+
+bridge_slices=()
+for arch in "${archs[@]}"; do
+  arch_scratch_path="$SCRATCH_BASE/$arch"
+  xcrun swift build \
+    --package-path "$PACKAGE_PATH" \
+    --product "$PRODUCT_NAME" \
+    --configuration "$BUILD_CONFIGURATION" \
+    --scratch-path "$arch_scratch_path" \
+    --triple "$arch-apple-macosx$DEPLOYMENT_TARGET"
+
+  bridge_path=$(find "$arch_scratch_path" -type f -path "*/$BUILD_CONFIGURATION/$PRODUCT_NAME" | head -n 1)
+  if [[ -z "$bridge_path" || ! -x "$bridge_path" ]]; then
+    echo "error: Failed to build $PRODUCT_NAME for $arch" >&2
+    exit 1
+  fi
+
+  bridge_slices+=("$bridge_path")
+done
+
+if (( ${#bridge_slices[@]} == 1 )); then
+  cp "${bridge_slices[1]}" "$APP_BRIDGE_PATH"
+else
+  xcrun lipo -create "${bridge_slices[@]}" -output "$APP_BRIDGE_PATH"
+fi
+
+chmod 755 "$APP_BRIDGE_PATH"
+
+actual_archs=$(xcrun lipo -archs "$APP_BRIDGE_PATH")
+for arch in "${archs[@]}"; do
+  if [[ " $actual_archs " != *" $arch "* ]]; then
+    echo "error: $PRODUCT_NAME is missing $arch slice; found: $actual_archs" >&2
+    exit 1
+  fi
+done
+
+if [[ "${CODE_SIGNING_ALLOWED:-NO}" == "YES" && -n "${EXPANDED_CODE_SIGN_IDENTITY:-}" ]]; then
+  codesign_args=(
+    --force
+    --sign "$EXPANDED_CODE_SIGN_IDENTITY"
+    --timestamp
+  )
+
+  if [[ "${ENABLE_HARDENED_RUNTIME:-NO}" == "YES" ]]; then
+    codesign_args+=(--options runtime)
+  fi
+
+  if [[ -n "${OTHER_CODE_SIGN_FLAGS:-}" ]]; then
+    codesign_args+=(${=OTHER_CODE_SIGN_FLAGS})
+  fi
+
+  codesign_args+=("$APP_BRIDGE_PATH")
+  /usr/bin/codesign "${codesign_args[@]}"
+fi


### PR DESCRIPTION
## Summary

- Fixes #129 by building the embedded macOS `PingIslandBridge` for each supported Xcode `ARCHS` slice instead of only the host architecture.
- Moves the Xcode embed phase into `scripts/embed-ping-island-bridge.sh` so the build logic is reviewable and reusable.
- Uses `lipo` to merge multi-arch bridge slices, validates the resulting binary, and preserves the existing post-build code signing path.

## Validation

- `scripts/embed-ping-island-bridge.sh` with `ARCHS='arm64 x86_64'` produced `x86_64 arm64` slices.
- `xcodebuild -project PingIsland.xcodeproj -scheme PingIsland -configuration Release -destination 'generic/platform=macOS' CODE_SIGNING_ALLOWED=NO build`
- `swift test --package-path Prototype`

## Notes

The Release build also confirmed the packaged app's `Contents/MacOS/PingIslandBridge` is a Mach-O universal binary containing both `x86_64` and `arm64` slices.
