### PR TITLE
Use documented OpenCode config path

### DIFF
--- a/PingIsland/Models/ClientProfile.swift
+++ b/PingIsland/Models/ClientProfile.swift
@@ -809,7 +809,7 @@ enum ClientProfileRegistry {
             localAppBundleIdentifiers: ["ai.opencode.desktop"],
             iconSymbolName: "waveform.path.ecg.text",
             configurationRelativePath: ".config/opencode/plugins/ping-island.js",
-            activationConfigurationRelativePath: ".config/opencode/config.json",
+            activationConfigurationRelativePath: ".config/opencode/opencode.json",
             bridgeSource: "claude",
             bridgeExtraArguments: [
                 "--client-kind", "opencode",

--- a/PingIsland/Models/SessionState.swift
+++ b/PingIsland/Models/SessionState.swift
@@ -407,7 +407,91 @@ struct SessionState: Equatable, Identifiable, Sendable {
             return true
         }
 
+        if isLikelyCodexAuxiliaryThreadForUI {
+            return true
+        }
+
         return isLikelyEmptyCodexPlaceholderForUI
+    }
+
+    /// Codex may write helper threads for app-side suggestions or selection filters into the
+    /// same rollout/app-server surfaces as user sessions. Hide those JSON-only helper threads
+    /// from the primary list while keeping real JSON user prompts visible.
+    private nonisolated var isLikelyCodexAuxiliaryThreadForUI: Bool {
+        guard provider == .codex else { return false }
+        guard intervention == nil else { return false }
+        guard !hasSpecificCodexSessionName else { return false }
+        guard codexParentThreadId?.isEmpty != false else { return false }
+        guard codexSubagentDepth == nil else { return false }
+        guard codexSubagentNickname?.isEmpty != false else { return false }
+        guard codexSubagentRole?.isEmpty != false else { return false }
+        guard !chatItems.contains(where: Self.isToolCallItem(_:)) else { return false }
+
+        let visibleTexts = codexAuxiliaryCandidateTexts
+        guard !visibleTexts.isEmpty else { return false }
+        guard visibleTexts.contains(where: Self.isCodexAuxiliaryJSONText(_:)) else { return false }
+
+        return visibleTexts.allSatisfy { text in
+            Self.isCodexAuxiliaryJSONText(text) || Self.isLikelyGenericCodexProgressText(text)
+        }
+    }
+
+    private nonisolated var hasSpecificCodexSessionName: Bool {
+        guard let sessionName = SessionTextSanitizer.sanitizedDisplayText(sessionName) else {
+            return false
+        }
+
+        let normalizedName = Self.normalizedCodexAuxiliaryComparisonText(sessionName)
+        let normalizedProject = Self.normalizedCodexAuxiliaryComparisonText(projectName)
+        let genericNames: Set<String> = [
+            "codex",
+            "codex session",
+            "new session",
+            "untitled"
+        ]
+
+        if normalizedName == normalizedProject || genericNames.contains(normalizedName) {
+            return false
+        }
+
+        return true
+    }
+
+    private nonisolated var codexAuxiliaryCandidateTexts: [String] {
+        var texts: [String] = [
+            SessionTextSanitizer.sanitizedDisplayText(previewText),
+            compactHookMessage,
+            SessionTextSanitizer.sanitizedDisplayText(conversationInfo.summary),
+            SessionTextSanitizer.sanitizedDisplayText(conversationInfo.firstUserMessage),
+            SessionTextSanitizer.sanitizedDisplayText(conversationInfo.lastMessage)
+        ].compactMap { $0 }
+
+        for item in chatItems {
+            switch item.type {
+            case .user(let text), .assistant(let text), .thinking(let text):
+                if let sanitized = SessionTextSanitizer.sanitizedDisplayText(text) {
+                    texts.append(sanitized)
+                }
+            case .toolCall, .interrupted:
+                continue
+            }
+        }
+
+        var seen: Set<String> = []
+        return texts.filter { seen.insert($0).inserted }
+    }
+
+    private nonisolated static func isToolCallItem(_ item: ChatHistoryItem) -> Bool {
+        if case .toolCall = item.type {
+            return true
+        }
+        return false
+    }
+
+    private nonisolated static func normalizedCodexAuxiliaryComparisonText(_ text: String) -> String {
+        text.trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
     }
 
     /// Codex placeholder sessions can be created before a richer thread record is available.
@@ -622,6 +706,27 @@ struct SessionState: Equatable, Identifiable, Sendable {
             "压缩上下文"
         ]
         return containsMatches.contains { normalized.contains($0) }
+    }
+
+    private nonisolated static func isCodexAuxiliaryJSONText(_ text: String) -> Bool {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.hasPrefix("{"), trimmed.hasSuffix("}") else { return false }
+        guard let data = trimmed.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return false
+        }
+
+        let keys = Set(object.keys)
+        if keys == ["suggestions"], object["suggestions"] is [Any] {
+            return true
+        }
+
+        let includeExcludeKeys: Set<String> = ["include", "exclude"]
+        if !keys.isEmpty, keys.isSubset(of: includeExcludeKeys) {
+            return keys.allSatisfy { key in object[key] is [Any] }
+        }
+
+        return false
     }
 
     private nonisolated static func isLikelyGenericHookProgressText(_ text: String) -> Bool {

--- a/PingIsland/Services/Hooks/HookInstaller.swift
+++ b/PingIsland/Services/Hooks/HookInstaller.swift
@@ -640,14 +640,15 @@ struct HookInstaller {
     }
 
     private static func isManagedPluginEnabled(_ profile: ManagedHookClientProfile) -> Bool {
-        guard let url = profile.activationConfigurationURL,
-              let data = try? Data(contentsOf: url) else {
-            return false
+        managedPluginActivationConfigurationURLs(for: profile).contains { url in
+            guard let data = try? Data(contentsOf: url) else {
+                return false
+            }
+            return isManagedPluginEnabled(
+                existingData: data,
+                pluginURL: profile.primaryConfigurationURL
+            )
         }
-        return isManagedPluginEnabled(
-            existingData: data,
-            pluginURL: profile.primaryConfigurationURL
-        )
     }
 
     private static func setInternalHookEnabled(_ enabled: Bool, for profile: ManagedHookClientProfile, customConfigURL: URL? = nil) {
@@ -675,21 +676,47 @@ struct HookInstaller {
         customConfigURL: URL? = nil,
         pluginURL: URL? = nil
     ) {
-        let url = customConfigURL ?? profile.activationConfigurationURL
         let pluginURL = pluginURL ?? profile.primaryConfigurationURL
-        guard let url else {
+        let urls = managedPluginActivationConfigurationURLs(
+            for: profile,
+            customConfigURL: customConfigURL
+        )
+        guard !urls.isEmpty else {
             return
         }
 
-        let existingData = try? Data(contentsOf: url)
-        let data = updatedConfigurationData(
-            existingData: existingData,
-            profile: profile,
-            customCommand: "",
-            installing: enabled,
-            pluginURL: pluginURL
-        )
-        writeData(data, to: url)
+        let targetURLs = enabled ? [urls[0]] : urls
+        for url in targetURLs {
+            let existingData = try? Data(contentsOf: url)
+            let data = updatedConfigurationData(
+                existingData: existingData,
+                profile: profile,
+                customCommand: "",
+                installing: enabled,
+                pluginURL: pluginURL
+            )
+            writeData(data, to: url)
+        }
+    }
+
+    private static func managedPluginActivationConfigurationURLs(
+        for profile: ManagedHookClientProfile,
+        customConfigURL: URL? = nil
+    ) -> [URL] {
+        guard let primaryURL = customConfigURL ?? profile.activationConfigurationURL else {
+            return []
+        }
+
+        guard profile.id == "opencode-hooks" else {
+            return [primaryURL]
+        }
+
+        // OpenCode 1.14 still reads legacy config.json, but current docs name opencode.json as the global config.
+        let legacyURL = primaryURL.deletingLastPathComponent().appendingPathComponent("config.json")
+        if legacyURL.standardizedFileURL == primaryURL.standardizedFileURL {
+            return [primaryURL]
+        }
+        return [primaryURL, legacyURL]
     }
 
     private static func removeLegacyTraeHooks() {
@@ -2983,9 +3010,9 @@ struct HookInstaller {
         switch profile.installationKind {
         case .pluginFile:
             if baseDirectory.lastPathComponent == "plugins" {
-                return baseDirectory.deletingLastPathComponent().appendingPathComponent("config.json")
+                return baseDirectory.deletingLastPathComponent().appendingPathComponent("opencode.json")
             }
-            return baseDirectory.appendingPathComponent("config.json")
+            return baseDirectory.appendingPathComponent("opencode.json")
         case .jsonHooks, .pluginDirectory:
             return nil
         case .hookDirectory:
@@ -3005,7 +3032,7 @@ struct HookInstaller {
     private static func customActivationConfigurationURL(for profile: ManagedHookClientProfile, installedURL: URL) -> URL? {
         switch profile.installationKind {
         case .pluginFile:
-            return installedURL.deletingLastPathComponent().deletingLastPathComponent().appendingPathComponent("config.json")
+            return installedURL.deletingLastPathComponent().deletingLastPathComponent().appendingPathComponent("opencode.json")
         case .jsonHooks, .pluginDirectory:
             return nil
         case .hookDirectory:

--- a/PingIslandTests/OpenCodeIntegrationTests.swift
+++ b/PingIslandTests/OpenCodeIntegrationTests.swift
@@ -182,7 +182,7 @@ final class OpenCodeIntegrationTests: XCTestCase {
         XCTAssertEqual(profile?.brand, .opencode)
         XCTAssertEqual(profile?.localAppBundleIdentifiers, ["ai.opencode.desktop"])
         XCTAssertEqual(profile?.primaryConfigurationURL.path, NSHomeDirectory() + "/.config/opencode/plugins/ping-island.js")
-        XCTAssertEqual(profile?.activationConfigurationURL?.path, NSHomeDirectory() + "/.config/opencode/config.json")
+        XCTAssertEqual(profile?.activationConfigurationURL?.path, NSHomeDirectory() + "/.config/opencode/opencode.json")
         XCTAssertTrue(profile?.reinstallDescriptionFormat.contains("插件文件") == true)
     }
 

--- a/PingIslandTests/SessionStateTests.swift
+++ b/PingIslandTests/SessionStateTests.swift
@@ -403,6 +403,130 @@ final class SessionStateTests: XCTestCase {
         XCTAssertFalse(session.shouldHideFromPrimaryUI)
     }
 
+    func testCodexAuxiliaryExcludeThreadHidesFromPrimaryUI() {
+        let message = #"{"exclude":[]}"#
+        let session = SessionState(
+            sessionId: "codex-exclude-helper",
+            cwd: "/",
+            provider: .codex,
+            clientInfo: .codexApp(threadId: "codex-exclude-helper"),
+            previewText: message,
+            chatItems: [
+                ChatHistoryItem(id: "user-1", type: .user(message), timestamp: Date())
+            ],
+            conversationInfo: ConversationInfo(
+                summary: message,
+                lastMessage: message,
+                lastMessageRole: "user",
+                lastToolName: nil,
+                firstUserMessage: message,
+                lastUserMessageDate: Date()
+            )
+        )
+
+        XCTAssertTrue(session.shouldHideFromPrimaryUI)
+    }
+
+    func testCodexAuxiliarySuggestionsThreadHidesFromPrimaryUI() {
+        let message = #"{"suggestions":[{"title":"Add investor appendix slides","prompt":"Add the three investor appendix slides."}]}"#
+        let session = SessionState(
+            sessionId: "codex-suggestions-helper",
+            cwd: "/tmp/vestibular_ppt_market",
+            provider: .codex,
+            clientInfo: .codexApp(threadId: "codex-suggestions-helper"),
+            previewText: message,
+            chatItems: [
+                ChatHistoryItem(id: "user-1", type: .user(message), timestamp: Date())
+            ],
+            conversationInfo: ConversationInfo(
+                summary: message,
+                lastMessage: message,
+                lastMessageRole: "user",
+                lastToolName: nil,
+                firstUserMessage: message,
+                lastUserMessageDate: Date()
+            )
+        )
+
+        XCTAssertTrue(session.shouldHideFromPrimaryUI)
+    }
+
+    func testCodexAuxiliarySuggestionsThreadWithGenericSessionNameHidesFromPrimaryUI() {
+        let message = #"{"suggestions":[{"title":"Add investor appendix slides","prompt":"Add the three investor appendix slides."}]}"#
+        let session = SessionState(
+            sessionId: "codex-named-suggestions-helper",
+            cwd: "/tmp/vestibular_ppt_market",
+            projectName: "vestibular_ppt_market",
+            provider: .codex,
+            clientInfo: .codexApp(threadId: "codex-named-suggestions-helper"),
+            sessionName: "vestibular_ppt_market",
+            previewText: message,
+            chatItems: [
+                ChatHistoryItem(id: "user-1", type: .user(message), timestamp: Date())
+            ],
+            conversationInfo: ConversationInfo(
+                summary: message,
+                lastMessage: message,
+                lastMessageRole: "user",
+                lastToolName: nil,
+                firstUserMessage: message,
+                lastUserMessageDate: Date()
+            )
+        )
+
+        XCTAssertTrue(session.shouldHideFromPrimaryUI)
+    }
+
+    func testCodexNormalJSONPromptStaysVisibleInPrimaryUI() {
+        let message = #"{"task":"update release notes","exclude":[]}"#
+        let session = SessionState(
+            sessionId: "codex-json-user-task",
+            cwd: "/tmp/project",
+            provider: .codex,
+            clientInfo: .codexApp(threadId: "codex-json-user-task"),
+            previewText: message,
+            chatItems: [
+                ChatHistoryItem(id: "user-1", type: .user(message), timestamp: Date())
+            ],
+            conversationInfo: ConversationInfo(
+                summary: message,
+                lastMessage: message,
+                lastMessageRole: "user",
+                lastToolName: nil,
+                firstUserMessage: message,
+                lastUserMessageDate: Date()
+            )
+        )
+
+        XCTAssertFalse(session.shouldHideFromPrimaryUI)
+    }
+
+    func testCodexAuxiliaryJSONWithSpecificSessionNameStaysVisibleInPrimaryUI() {
+        let message = #"{"suggestions":[{"title":"Add investor appendix slides","prompt":"Add the three investor appendix slides."}]}"#
+        let session = SessionState(
+            sessionId: "codex-named-user-task",
+            cwd: "/tmp/vestibular_ppt_market",
+            projectName: "vestibular_ppt_market",
+            provider: .codex,
+            clientInfo: .codexApp(threadId: "codex-named-user-task"),
+            sessionName: "Investor appendix work",
+            previewText: message,
+            chatItems: [
+                ChatHistoryItem(id: "user-1", type: .user(message), timestamp: Date())
+            ],
+            conversationInfo: ConversationInfo(
+                summary: message,
+                lastMessage: message,
+                lastMessageRole: "user",
+                lastToolName: nil,
+                firstUserMessage: message,
+                lastUserMessageDate: Date()
+            )
+        )
+
+        XCTAssertFalse(session.shouldHideFromPrimaryUI)
+    }
+
     func testEndedSessionShowsArchiveActionAfterTenMinutes() {
         let session = SessionState(
             sessionId: "ended-archive-eligible",

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ Implementation details worth knowing:
 - Codex sessions can come from hook events or the live `codex app-server` websocket monitor.
 - Gemini CLI hooks are installed into `~/.gemini/settings.json`; tool matchers use Gemini's regex-based hook matcher syntax.
 - Qwen Code hooks are installed into `~/.qwen/settings.json`; the bridge follows the official event names and uses `Stop` / `SessionEnd` / `Notification` messages to surface popup-ready summaries in Island.
-- OpenCode is wired through a generated plugin file under `~/.config/opencode/plugins/`.
+- OpenCode is wired through a generated plugin file under `~/.config/opencode/plugins/` and enabled from the documented global config at `~/.config/opencode/opencode.json`; legacy `config.json` entries are still recognized for cleanup.
 - Remote SSH hosts can bootstrap `PingIslandBridge`, rewrite remote Claude-compatible hooks to target that bridge, and forward remote events back into the local Ping Island UI.
 - Focus routing spans iTerm2, Ghostty, Terminal.app, tmux, and VS Code-compatible IDE extensions.
 


### PR DESCRIPTION
## Summary
- Switched OpenCode activation from `config.json` to `opencode.json`, matching the current docs
- Disable still cleans up both paths so existing installs don't accumulate stale entries
- Updated integration test assertion and README

## Why
OpenCode docs (https://opencode.ai/docs/config/) define the config at `~/.config/opencode/opencode.json`. We were still writing to the legacy `config.json`.

## Validation
- `git diff --check`
- OpenCode integration tests pass