### PR TITLE
fix: compare codex usage snapshots by event timestamp

### DIFF
--- a/PingIsland/Services/Usage/CodexUsage.swift
+++ b/PingIsland/Services/Usage/CodexUsage.swift
@@ -84,13 +84,21 @@ enum CodexUsageLoader {
             return lhs.modifiedAt > rhs.modifiedAt
         }
 
+        var bestSnapshot: CodexUsageSnapshot?
+        var bestCapturedAt: Date = .distantPast
+
         for candidate in sortedCandidates {
-            if let snapshot = loadLatestSnapshot(from: candidate.fileURL, modifiedAt: candidate.modifiedAt) {
-                return snapshot
+            guard let snapshot = loadLatestSnapshot(from: candidate.fileURL, modifiedAt: candidate.modifiedAt) else {
+                continue
+            }
+            let capturedAt = snapshot.capturedAt ?? candidate.modifiedAt
+            if capturedAt > bestCapturedAt {
+                bestSnapshot = snapshot
+                bestCapturedAt = capturedAt
             }
         }
 
-        return nil
+        return bestSnapshot
     }
 
     private nonisolated static func loadLatestSnapshot(from fileURL: URL, modifiedAt: Date) -> CodexUsageSnapshot? {


### PR DESCRIPTION
## Summary

`CodexUsageLoader.load()` was returning the first rollout file that had a valid `token_count` snapshot, using file modification time as a proxy for freshness. That breaks when a recently-touched session file carries old rate-limit data while another file has a newer snapshot.

The loader now compares snapshots by the `token_count` event's own `capturedAt` timestamp, picking the freshest one across candidate files.

## Before

- File A (`rollout-aaa.jsonl`): modified 2 min ago, last `token_count` → 45 min ago (80% used)
- File B (`rollout-bbb.jsonl`): modified 15 min ago, last `token_count` → 1 min ago (15% used)

Old code stopped at File A (first valid match by mtime) and showed stale 80%.

## After

Scans all candidate files, compares `capturedAt`, and picks File B (freshest token_count) → shows 15%.

## Validation

- `git diff --check`
- `CodexUsageLoaderTests` — 6/6 pass
- `UsageSummaryPresenterTests` — 10/10 pass
- `UsageSnapshotCacheStoreTests` — 2/2 pass