### PR TITLE
fix: improve Claude Code CLI session state detection

### DIFF
--- a/PingIsland/Services/Hooks/HookSocketServer.swift
+++ b/PingIsland/Services/Hooks/HookSocketServer.swift
@@ -636,8 +636,10 @@ private extension BridgeEnvelope {
         switch eventType {
         case "SessionEnd":
             return "ended"
-        case "SessionStart", "Stop", "SubagentStop":
+        case "SessionStart", "SubagentStop":
             return "waiting_for_input"
+        case "Stop":
+            return "idle"
         case "UserPromptSubmit", "PostToolUse":
             return "processing"
         case "PreToolUse":

--- a/PingIsland/Services/Session/SessionMonitor.swift
+++ b/PingIsland/Services/Session/SessionMonitor.swift
@@ -659,15 +659,47 @@ class SessionMonitor: ObservableObject {
         let primaryVisibleSessions = sessions.filter {
             !$0.shouldHideFromPrimaryUI && $0.shouldDisplaySubagent(in: visibilityMode)
         }
-        return primaryVisibleSessions.filter { candidate in
+        let dedupedSessions = deduplicateSameProjectClaudeSessions(from: primaryVisibleSessions)
+        return dedupedSessions.filter { candidate in
             guard shouldCheckDuplicateVisibility(for: candidate) else {
                 return true
             }
 
-            return !primaryVisibleSessions.contains { other in
+            return !dedupedSessions.contains { other in
                 candidate.shouldHideAsDuplicateCodexPlaceholder(comparedTo: other)
                     || candidate.shouldHideAsDuplicateOpenCodeChildSession(comparedTo: other)
             }
+        }
+    }
+
+    /// When Claude is resumed or restarted, concurrent hook events can create multiple
+    /// sessions for the same project before endOrphanedSessions has a chance to clean up.
+    /// Keep only the most recently active session per provider + cwd pair.
+    private func deduplicateSameProjectClaudeSessions(
+        from sessions: [SessionState]
+    ) -> [SessionState] {
+        var bestByKey: [String: SessionState] = [:]
+        var order: [String] = []
+
+        for session in sessions {
+            guard session.provider == .claude else { continue }
+            let cwd = session.cwd
+            guard !cwd.isEmpty else { continue }
+            let key = "\(session.provider.rawValue):\(cwd)"
+            if let existing = bestByKey[key] {
+                if session.lastActivity > existing.lastActivity {
+                    bestByKey[key] = session
+                }
+            } else {
+                bestByKey[key] = session
+                order.append(key)
+            }
+        }
+
+        var keep = Set(bestByKey.values.map(\.sessionId))
+        return sessions.filter { session in
+            guard session.provider == .claude, !session.cwd.isEmpty else { return true }
+            return keep.contains(session.sessionId)
         }
     }
 

--- a/PingIsland/Services/Session/SessionMonitor.swift
+++ b/PingIsland/Services/Session/SessionMonitor.swift
@@ -58,6 +58,7 @@ class SessionMonitor: ObservableObject {
                     await SessionStore.shared.process(
                         .pruneTimedOutExternalContinuations(now: Date())
                     )
+                    await SessionStore.shared.pruneOrphanedSessions()
                 }
             }
             .store(in: &cancellables)

--- a/PingIsland/Services/State/SessionStore.swift
+++ b/PingIsland/Services/State/SessionStore.swift
@@ -303,8 +303,10 @@ actor SessionStore {
         // race where a Stop event runs during a Notification's await, ends its own
         // fresh copy, and then the Notification resumes against an already-ended
         // session.
-        if sessions[sessionId] == nil {
+        let isNewSession = sessions[sessionId] == nil
+        if isNewSession {
             sessions[sessionId] = session
+            endOrphanedSessions(sameProviderAs: session, newSessionId: sessionId)
         }
 
         let tree = (event.pid != nil || event.tty != nil) ? ProcessTreeBuilder.shared.buildTree() : [:]
@@ -2107,6 +2109,30 @@ actor SessionStore {
             cancelPendingSync(sessionId: childSessionId)
             cancelPendingCodexPlaceholderPrune(sessionId: childSessionId)
             cancelPendingQoderConversationPoll(sessionId: childSessionId)
+        }
+    }
+
+    /// When a new session starts for a provider, end any active sessions from the same
+    /// provider + cwd that look orphaned (process died without sending Stop). This keeps
+    /// the primary list clean when the user quits and restarts Claude in the same project.
+    private func endOrphanedSessions(
+        sameProviderAs session: SessionState,
+        newSessionId: String
+    ) {
+        let provider = session.provider
+        let cwd = session.cwd
+        guard !cwd.isEmpty else { return }
+        guard provider == .claude else { return }
+        guard session.ingress != .nativeRuntime else { return }
+
+        for (existingId, var existing) in sessions {
+            guard existingId != newSessionId else { continue }
+            guard existing.provider == provider else { continue }
+            guard existing.cwd == cwd else { continue }
+            guard existing.phase != .ended else { continue }
+            guard !existing.needsManualAttention else { continue }
+            markSessionEnded(&existing)
+            sessions[existingId] = existing
         }
     }
 

--- a/PingIsland/Services/State/SessionStore.swift
+++ b/PingIsland/Services/State/SessionStore.swift
@@ -2169,6 +2169,29 @@ actor SessionStore {
         }
     }
 
+    /// Periodically check active Claude sessions whose bridge process has died without
+    /// sending a Stop event (crash, SIGKILL, terminal closed). End them so the bar
+    /// doesn't keep showing dead sessions as still working.
+    func pruneOrphanedSessions() {
+        for (sessionId, var session) in sessions {
+            guard session.provider == .claude else { continue }
+            guard session.ingress != .nativeRuntime else { continue }
+            guard session.phase != .ended else { continue }
+            guard !session.needsManualAttention else { continue }
+
+            guard let pid = session.pid, pid > 0 else { continue }
+
+            // Give the bridge a grace period — it may be restarting.
+            let idleSeconds = Date().timeIntervalSince(session.lastActivity)
+            guard idleSeconds >= 30 else { continue }
+
+            if Darwin.kill(pid_t(pid), 0) != 0 && errno == ESRCH {
+                markSessionEnded(&session)
+                sessions[sessionId] = session
+            }
+        }
+    }
+
     private func markSessionEnded(_ session: inout SessionState) {
         let wasAlreadyEnded = session.phase == .ended
         session.phase = .ended

--- a/PingIsland/Services/State/SessionStore.swift
+++ b/PingIsland/Services/State/SessionStore.swift
@@ -67,7 +67,6 @@ actor SessionStore {
     private let codexHookPlaceholderPruneDelayNs: UInt64 = 10_000_000_000
     private let codexAppServerPlaceholderPruneDelayNs: UInt64 = 60_000_000_000
     private let codexContinuationMergeWindow: TimeInterval = 10 * 60
-    private let apparentIdleProcessingGraceWindow: TimeInterval = 15
     private let qoderConversationPollIntervalNs: UInt64 = 250_000_000
     private let qoderConversationPollTimeoutNs: UInt64 = 120_000_000_000
     private let qoderSubagentAssociationWindow: TimeInterval = 2 * 60
@@ -379,7 +378,8 @@ actor SessionStore {
 
         let previousPendingHookResponse = pendingHookResponse(in: session)
 
-        if event.status == "ended", !shouldPreserveEndedStopForAnsweredQuestion {
+        if (event.status == "ended" || event.event == "Stop" || event.event == "SessionEnd"),
+           !shouldPreserveEndedStopForAnsweredQuestion {
             markSessionEnded(&session)
             cancelOrphanedPendingHookResponse(
                 previousPendingHookResponse,
@@ -1692,13 +1692,7 @@ actor SessionStore {
     ) -> Bool {
         guard session.phase.isActive else { return false }
         guard incomingPhase == .idle else { return false }
-
-        if sessionHasLiveExecutionEvidence(session) {
-            return true
-        }
-
-        guard let previousLastActivity else { return false }
-        return referenceDate.timeIntervalSince(previousLastActivity) < apparentIdleProcessingGraceWindow
+        return sessionHasLiveExecutionEvidence(session)
     }
 
     private func sessionHasLiveExecutionEvidence(_ session: SessionState) -> Bool {
@@ -2156,38 +2150,22 @@ actor SessionStore {
             guard session.phase != .ended else { continue }
             guard !session.needsManualAttention else { continue }
 
-            guard let pid = session.pid, pid > 0 else { continue }
-
-            // Give the bridge a grace period — it may be restarting.
             let idleSeconds = Date().timeIntervalSince(session.lastActivity)
             guard idleSeconds >= 30 else { continue }
 
-            if Darwin.kill(pid_t(pid), 0) != 0 && errno == ESRCH {
-                markSessionEnded(&session)
-                sessions[sessionId] = session
-            }
-        }
-    }
-
-    /// Periodically check active Claude sessions whose bridge process has died without
-    /// sending a Stop event (crash, SIGKILL, terminal closed). End them so the bar
-    /// doesn't keep showing dead sessions as still working.
-    func pruneOrphanedSessions() {
-        for (sessionId, var session) in sessions {
-            guard session.provider == .claude else { continue }
-            guard session.ingress != .nativeRuntime else { continue }
-            guard session.phase != .ended else { continue }
-            guard !session.needsManualAttention else { continue }
-
-            guard let pid = session.pid, pid > 0 else { continue }
-
-            // Give the bridge a grace period — it may be restarting.
-            let idleSeconds = Date().timeIntervalSince(session.lastActivity)
-            guard idleSeconds >= 30 else { continue }
-
-            if Darwin.kill(pid_t(pid), 0) != 0 && errno == ESRCH {
-                markSessionEnded(&session)
-                sessions[sessionId] = session
+            if let pid = session.pid, pid > 0 {
+                if Darwin.kill(pid_t(pid), 0) != 0 && errno == ESRCH {
+                    markSessionEnded(&session)
+                    sessions[sessionId] = session
+                }
+            } else if session.phase.isActive, !sessionHasLiveExecutionEvidence(session) {
+                // No PID available but session looks idle with no live evidence.
+                // Transition from processing/compacting to idle so it doesn't
+                // appear stuck as "working" indefinitely.
+                if session.phase.canTransition(to: .idle) {
+                    session.phase = .idle
+                    sessions[sessionId] = session
+                }
             }
         }
     }

--- a/PingIsland/Services/State/SessionStore.swift
+++ b/PingIsland/Services/State/SessionStore.swift
@@ -378,8 +378,7 @@ actor SessionStore {
 
         let previousPendingHookResponse = pendingHookResponse(in: session)
 
-        if (event.status == "ended" || event.event == "Stop" || event.event == "SessionEnd"),
-           !shouldPreserveEndedStopForAnsweredQuestion {
+        if event.status == "ended", !shouldPreserveEndedStopForAnsweredQuestion {
             markSessionEnded(&session)
             cancelOrphanedPendingHookResponse(
                 previousPendingHookResponse,

--- a/PingIsland/Services/State/SessionStore.swift
+++ b/PingIsland/Services/State/SessionStore.swift
@@ -2113,9 +2113,10 @@ actor SessionStore {
         }
     }
 
-    /// When a new session starts for a provider, end any active sessions from the same
-    /// provider + cwd that look orphaned (process died without sending Stop). This keeps
-    /// the primary list clean when the user quits and restarts Claude in the same project.
+    /// When a new session starts for a provider, archive any active sessions from the
+    /// same provider + cwd that look orphaned (process died without sending Stop).
+    /// This prevents duplicate-looking sessions in the expanded list when the user
+    /// quits and restarts Claude in the same project.
     private func endOrphanedSessions(
         sameProviderAs session: SessionState,
         newSessionId: String
@@ -2126,14 +2127,22 @@ actor SessionStore {
         guard provider == .claude else { return }
         guard session.ingress != .nativeRuntime else { return }
 
-        for (existingId, var existing) in sessions {
+        var idsToArchive: [String] = []
+        for (existingId, existing) in sessions {
             guard existingId != newSessionId else { continue }
             guard existing.provider == provider else { continue }
             guard existing.cwd == cwd else { continue }
             guard existing.phase != .ended else { continue }
             guard !existing.needsManualAttention else { continue }
-            markSessionEnded(&existing)
-            sessions[existingId] = existing
+            idsToArchive.append(existingId)
+        }
+
+        for id in idsToArchive {
+            sessions.removeValue(forKey: id)
+            clearCodexSessionAliases(for: id)
+            cancelPendingSync(sessionId: id)
+            cancelPendingCodexPlaceholderPrune(sessionId: id)
+            cancelPendingQoderConversationPoll(sessionId: id)
         }
     }
 

--- a/PingIsland/Services/State/SessionStore.swift
+++ b/PingIsland/Services/State/SessionStore.swift
@@ -2127,6 +2127,19 @@ actor SessionStore {
             guard existing.cwd == cwd else { continue }
             guard existing.phase != .ended else { continue }
             guard !existing.needsManualAttention else { continue }
+
+            // Don't archive a session that still has live execution evidence
+            // (running tools or thinking in progress) — it may be a legitimate
+            // concurrent instance, like a Qoder parent session with a child.
+            if sessionHasLiveExecutionEvidence(existing) { continue }
+
+            // Don't archive sessions whose process is still alive — two
+            // legitimate Claude instances can run in the same cwd concurrently.
+            if let pid = existing.pid, pid > 0,
+               Darwin.kill(pid_t(pid), 0) == 0 {
+                continue
+            }
+
             idsToArchive.append(existingId)
         }
 

--- a/PingIsland/Services/State/SessionStore.swift
+++ b/PingIsland/Services/State/SessionStore.swift
@@ -67,7 +67,7 @@ actor SessionStore {
     private let codexHookPlaceholderPruneDelayNs: UInt64 = 10_000_000_000
     private let codexAppServerPlaceholderPruneDelayNs: UInt64 = 60_000_000_000
     private let codexContinuationMergeWindow: TimeInterval = 10 * 60
-    private let apparentIdleProcessingGraceWindow: TimeInterval = 5 * 60
+    private let apparentIdleProcessingGraceWindow: TimeInterval = 15
     private let qoderConversationPollIntervalNs: UInt64 = 250_000_000
     private let qoderConversationPollTimeoutNs: UInt64 = 120_000_000_000
     private let qoderSubagentAssociationWindow: TimeInterval = 2 * 60

--- a/PingIsland/Services/State/SessionStore.swift
+++ b/PingIsland/Services/State/SessionStore.swift
@@ -8,6 +8,7 @@
 
 import AppKit
 import Combine
+import Darwin
 import Foundation
 import os.log
 
@@ -2133,6 +2134,29 @@ actor SessionStore {
             guard !existing.needsManualAttention else { continue }
             markSessionEnded(&existing)
             sessions[existingId] = existing
+        }
+    }
+
+    /// Periodically check active Claude sessions whose bridge process has died without
+    /// sending a Stop event (crash, SIGKILL, terminal closed). End them so the bar
+    /// doesn't keep showing dead sessions as still working.
+    func pruneOrphanedSessions() {
+        for (sessionId, var session) in sessions {
+            guard session.provider == .claude else { continue }
+            guard session.ingress != .nativeRuntime else { continue }
+            guard session.phase != .ended else { continue }
+            guard !session.needsManualAttention else { continue }
+
+            guard let pid = session.pid, pid > 0 else { continue }
+
+            // Give the bridge a grace period — it may be restarting.
+            let idleSeconds = Date().timeIntervalSince(session.lastActivity)
+            guard idleSeconds >= 30 else { continue }
+
+            if Darwin.kill(pid_t(pid), 0) != 0 && errno == ESRCH {
+                markSessionEnded(&session)
+                sessions[sessionId] = session
+            }
         }
     }
 

--- a/PingIslandTests/SessionStoreFileUpdateTests.swift
+++ b/PingIslandTests/SessionStoreFileUpdateTests.swift
@@ -240,9 +240,9 @@ final class SessionStoreFileUpdateTests: XCTestCase {
         await store.process(.sessionArchived(sessionId: sessionId))
     }
 
-    func testIdlePromptDoesNotDowngradeRecentProcessingSession() async throws {
+    func testIdlePromptTransitionsProcessingToIdleWhenNoLiveEvidence() async throws {
         let store = SessionStore.shared
-        let sessionId = "recent-processing-grace-\(UUID().uuidString)"
+        let sessionId = "recent-processing-idle-transition-\(UUID().uuidString)"
 
         await store.process(.hookReceived(
             HookEvent(
@@ -262,8 +262,6 @@ final class SessionStoreFileUpdateTests: XCTestCase {
             )
         ))
 
-        let previousLastActivity = await store.session(for: sessionId)?.lastActivity
-
         await store.process(.hookReceived(
             HookEvent(
                 sessionId: sessionId,
@@ -282,9 +280,11 @@ final class SessionStoreFileUpdateTests: XCTestCase {
             )
         ))
 
+        // When no tools are running and no thinking is in progress, an idle
+        // notification should transition the session from processing to idle
+        // immediately -- no grace window needed.
         let session = await store.session(for: sessionId)
-        XCTAssertEqual(session?.phase, .processing)
-        XCTAssertEqual(session?.lastActivity, previousLastActivity)
+        XCTAssertEqual(session?.phase, .idle)
 
         await store.process(.sessionArchived(sessionId: sessionId))
     }

--- a/Prototype/Sources/IslandBridge/main.swift
+++ b/Prototype/Sources/IslandBridge/main.swift
@@ -1000,7 +1000,7 @@ private enum RemoteBridgeMessageBuilder {
             event: envelope.eventType,
             status: mapStatus(eventType: envelope.eventType, status: envelope.status?.kind, notificationType: metadata["notification_type"]),
             provider: envelope.provider.rawValue,
-            pid: Int(metadata["pid"] ?? ""),
+            pid: Int(metadata["pid"] ?? "") ?? Int(getppid()) ?? Int(getppid()),
             tty: terminalContext.tty,
             tool: normalizedToolName(metadata["tool_name"] ?? envelope.title),
             toolInput: toolInput,


### PR DESCRIPTION
## Summary

Claude Code CLI state detection was unreliable compared to Codex Desktop. Codex maintains a persistent WebSocket — it disconnects, state updates immediately. Claude Code uses one-shot hook events with no persistent connection. Crashed or exited sessions hung in the bar showing "processing" indefinitely.

This PR adds multiple layers of detection, fixes Stop event mapping, and improves the working-to-idle transition.

**How to test**: run Claude Code, send "test", then end the task (Ctrl+C). Before this PR, the session stuck at "working." After this PR, it transitions to idle within a second or two.

## What changed

### 1. Stop event maps to idle (not waiting_for_input)

**File**: `HookSocketServer.swift:628-630`, `SessionStore.swift:379`

Claude Code sends `Stop` at the end of every turn. Previously it was mapped to `waiting_for_input` status, which `determinePhase()` turned into `.waitingForInput` — a "needs attention" state. The bar showed an exclamation/intervention indicator even though Claude was just idle.

Now `Stop` maps to `"idle"`, resulting in `.idle` phase. The bar transitions from "working" to idle immediately after each turn completes. `SessionEnd` still maps to `"ended"` for graceful exit.

### 2. Immediate idle transition when no live evidence

**File**: `SessionStore.swift:1689-1697`

Removed `apparentIdleProcessingGraceWindow`. Previously the phase would stick at `.processing` for up to 5 minutes even after all tools completed and Claude had already responded. Now `shouldPreserveActivePhaseDuringApparentIdle` only preserves `.processing` when there IS live execution evidence (tools running or thinking in progress). When all tools are done and the last chat item is an assistant response, transition to `.idle` happens immediately on the next relevant hook event.

### 3. PID-based orphaned session detection

**Files**: `SessionStore.swift:2142-2174`, `Prototype/Sources/IslandBridge/main.swift:1001`

Every 60 seconds, `pruneOrphanedSessions` checks whether the bridge process PID is still alive. If dead (Claude crashed, SIGKILL, terminal closed) and 30+ seconds idle, the session is ended.

The bridge binary now falls back to `getppid()` when hook metadata lacks a `pid` field. Claude Code hooks don't include `pid` in their payload — previously this silently skipped all Claude sessions in the PID check.

For sessions without a PID at all, if the phase is active with no live execution evidence and 30+ seconds idle, transition to `.idle` as a safety net.

### 4. Reactive cleanup on session restart

**File**: `SessionStore.swift:2120-2136`

When a new Claude session starts in the same cwd, `endOrphanedSessions` archives (removes) existing sessions that don't need manual attention. Two guards prevent false positives:
- Sessions with live execution evidence (running tools, thinking) are skipped — they may be legitimate concurrent instances
- Sessions whose PID is still alive are skipped — the process is genuinely running

### 5. Display-layer dedup

**File**: `SessionMonitor.swift:657-700`

When concurrent hook events on session resume create multiple sessions before `endOrphanedSessions` can fire, the display layer keeps only the most recently active session per provider + cwd pair. Acts as a safety net for edge cases.

## Why Codex was accurate and how Claude catches up

| | Codex Desktop | Claude Code CLI (before) | Claude Code CLI (after) |
|---|---|---|---|
| Connection | Persistent WebSocket | One-shot hook events | One-shot hook events |
| State updates | Real-time push | Per-event only | Per-event only |
| Turn complete -> idle | Immediate | Stuck at waiting_for_input | Stop -> idle immediately |
| Stop detection | WebSocket disconnect | No PID on session | getppid() + PID pruning |
| Duplicate prevention | Thread-level dedup | None | Reactive + PID + display |

## Validation

- Build: clean
- `ClaudeApprovalStateTests` — 6/6 pass
- `SessionStateTests` — all pass
- `QoderSubagentSessionTests` — all pass
- Manually tested with "send test then Ctrl+C" — session transitions to idle