### PR TITLE
[codex] Preserve ask-user answers during hover input

### DIFF
--- a/PingIsland/Core/NotchViewModel.swift
+++ b/PingIsland/Core/NotchViewModel.swift
@@ -51,6 +51,7 @@ class NotchViewModel: ObservableObject {
     @Published private(set) var isFullscreenBrowserHiddenActive = false
     @Published private(set) var isIdleAutoHiddenActive = false
     @Published private(set) var isSettingsPopoverPresented = false
+    @Published private(set) var isInlineTextInputActive = false
 
     // MARK: - Geometry
 
@@ -117,6 +118,22 @@ class NotchViewModel: ObservableObject {
         let systemWidth = ceil(deviceNotchRect.width)
         guard systemWidth > 0 else { return defaultClosedWidth }
         return max(defaultClosedWidth, systemWidth + physicalNotchContentAllowance)
+    }
+
+    static func shouldAutoCollapseHoverPreview(
+        isHovering: Bool,
+        status: NotchStatus,
+        openReason: NotchOpenReason,
+        isSettingsPopoverPresented: Bool,
+        isInlineTextInputActive: Bool,
+        autoCollapseOnLeave: Bool
+    ) -> Bool {
+        !isHovering
+            && status == .opened
+            && openReason == .hover
+            && !isSettingsPopoverPresented
+            && !isInlineTextInputActive
+            && autoCollapseOnLeave
     }
 
     private var narrowedClosedWidth: CGFloat {
@@ -531,11 +548,14 @@ class NotchViewModel: ObservableObject {
         hoverTimer?.cancel()
         hoverTimer = nil
 
-        if !newHovering,
-           status == .opened,
-           openReason == .hover,
-           !isSettingsPopoverPresented,
-           AppSettings.autoCollapseOnLeave {
+        if Self.shouldAutoCollapseHoverPreview(
+            isHovering: newHovering,
+            status: status,
+            openReason: openReason,
+            isSettingsPopoverPresented: isSettingsPopoverPresented,
+            isInlineTextInputActive: isInlineTextInputActive,
+            autoCollapseOnLeave: AppSettings.autoCollapseOnLeave
+        ) {
             notchClose()
         }
 
@@ -802,6 +822,7 @@ class NotchViewModel: ObservableObject {
         currentChatSession = nil
         contentType = .instances
         openedMeasuredHeight = nil
+        isInlineTextInputActive = false
     }
 
     func beginDetachedPresentation(contentType: NotchContentType, playSound: Bool = true) {
@@ -859,6 +880,11 @@ class NotchViewModel: ObservableObject {
 
     func setSettingsPopoverPresented(_ isPresented: Bool) {
         isSettingsPopoverPresented = isPresented
+    }
+
+    func setInlineTextInputActive(_ isActive: Bool) {
+        guard isInlineTextInputActive != isActive else { return }
+        isInlineTextInputActive = isActive
     }
 
     func showChat(for session: SessionState) {

--- a/PingIsland/UI/Components/SessionQuestionForm.swift
+++ b/PingIsland/UI/Components/SessionQuestionForm.swift
@@ -4,6 +4,7 @@ struct SessionQuestionForm: View {
     let intervention: SessionIntervention
     let submitLabel: String?
     let onSubmit: ([String: [String]]) -> Void
+    var onInteractionStateChanged: (Bool) -> Void = { _ in }
     var secondaryActionTitle: String? = nil
     var onSecondaryAction: (() -> Void)? = nil
     var isEditable: Bool = true
@@ -12,7 +13,7 @@ struct SessionQuestionForm: View {
     @State private var answers: [String: [String]] = [:]
     @State private var otherAnswers: [String: String] = [:]
     @State private var measuredQuestionContentHeight: CGFloat = 0
-    @FocusState private var focusedCustomQuestionID: String?
+    @FocusState private var focusedQuestionID: String?
 
     private var displayQuestions: [SessionInterventionQuestion] {
         intervention.resolvedQuestions
@@ -109,6 +110,38 @@ struct SessionQuestionForm: View {
         return laterQuestions.first?.id
     }
 
+    nonisolated static func finalAnswers(
+        for question: SessionInterventionQuestion,
+        answers: [String: [String]],
+        otherAnswers: [String: String]
+    ) -> [String] {
+        var current = answers[question.id, default: []]
+        let other = otherAnswers[question.id]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if !other.isEmpty {
+            if question.allowsMultiple {
+                current.append(other)
+            } else {
+                current = [other]
+            }
+        }
+        return current.filter { !$0.isEmpty }
+    }
+
+    nonisolated static func protectsDraftInteraction(
+        questions: [SessionInterventionQuestion],
+        answers: [String: [String]],
+        otherAnswers: [String: String],
+        focusedQuestionID: String?
+    ) -> Bool {
+        focusedQuestionID != nil || questions.contains { question in
+            !finalAnswers(
+                for: question,
+                answers: answers,
+                otherAnswers: otherAnswers
+            ).isEmpty
+        }
+    }
+
     private var questionListMaximumHeight: CGFloat {
         Self.questionListMaximumHeight(for: settings.maxPanelHeight)
     }
@@ -136,6 +169,7 @@ struct SessionQuestionForm: View {
         submitLabel: String? = nil,
         initialAnswers: [String: [String]] = [:],
         onSubmit: @escaping ([String: [String]]) -> Void,
+        onInteractionStateChanged: @escaping (Bool) -> Void = { _ in },
         secondaryActionTitle: String? = nil,
         onSecondaryAction: (() -> Void)? = nil,
         isEditable: Bool = true
@@ -143,6 +177,7 @@ struct SessionQuestionForm: View {
         self.intervention = intervention
         self.submitLabel = submitLabel
         self.onSubmit = onSubmit
+        self.onInteractionStateChanged = onInteractionStateChanged
         self.secondaryActionTitle = secondaryActionTitle
         self.onSecondaryAction = onSecondaryAction
         self.isEditable = isEditable
@@ -168,7 +203,7 @@ struct SessionQuestionForm: View {
             HStack(spacing: 8) {
                 if let submitLabel {
                     Button {
-                        onSubmit(submissionPayload())
+                        submitCurrentAnswers()
                     }
                     label: {
                         Text(appLocalized: submitLabel)
@@ -189,6 +224,13 @@ struct SessionQuestionForm: View {
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+        .onAppear(perform: notifyInteractionState)
+        .onChange(of: answers) { _, _ in notifyInteractionState() }
+        .onChange(of: otherAnswers) { _, _ in notifyInteractionState() }
+        .onChange(of: focusedQuestionID) { _, _ in notifyInteractionState() }
+        .onDisappear {
+            onInteractionStateChanged(false)
+        }
     }
 
     @ViewBuilder
@@ -338,6 +380,11 @@ struct SessionQuestionForm: View {
                 set: { answers[question.id] = normalizedAnswers(from: $0) }
             ))
             .textFieldStyle(.plain)
+            .focused($focusedQuestionID, equals: question.id)
+            .submitLabel(.send)
+            .onSubmit {
+                submitCurrentAnswers()
+            }
             .padding(10)
             .disabled(!isEditable)
             .overlay(
@@ -350,6 +397,11 @@ struct SessionQuestionForm: View {
                 set: { answers[question.id] = normalizedAnswers(from: $0) }
             ))
             .textFieldStyle(.plain)
+            .focused($focusedQuestionID, equals: question.id)
+            .submitLabel(.send)
+            .onSubmit {
+                submitCurrentAnswers()
+            }
             .padding(10)
             .disabled(!isEditable)
             .overlay(
@@ -360,7 +412,7 @@ struct SessionQuestionForm: View {
     }
 
     private func customAnswerField(for question: SessionInterventionQuestion) -> some View {
-        let isFocused = focusedCustomQuestionID == question.id
+        let isFocused = focusedQuestionID == question.id
 
         return HStack(spacing: 8) {
             Image(systemName: "text.cursor")
@@ -373,7 +425,11 @@ struct SessionQuestionForm: View {
                 set: { setCustomAnswer($0, for: question) }
             ), prompt: Text(appLocalized: "Type Something ..."))
             .textFieldStyle(.plain)
-            .focused($focusedCustomQuestionID, equals: question.id)
+            .focused($focusedQuestionID, equals: question.id)
+            .submitLabel(.send)
+            .onSubmit {
+                submitCurrentAnswers()
+            }
         }
         .padding(10)
         .disabled(!isEditable)
@@ -398,6 +454,15 @@ struct SessionQuestionForm: View {
 
     private var canSubmit: Bool {
         !displayQuestions.contains { finalAnswers(for: $0).isEmpty }
+    }
+
+    private var protectsDraftInteraction: Bool {
+        Self.protectsDraftInteraction(
+            questions: displayQuestions,
+            answers: answers,
+            otherAnswers: otherAnswers,
+            focusedQuestionID: focusedQuestionID
+        )
     }
 
     private func isSelected(_ title: String, for question: SessionInterventionQuestion) -> Bool {
@@ -456,16 +521,11 @@ struct SessionQuestionForm: View {
     }
 
     private func finalAnswers(for question: SessionInterventionQuestion) -> [String] {
-        var current = answers[question.id, default: []]
-        let other = otherAnswers[question.id]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        if !other.isEmpty {
-            if question.allowsMultiple {
-                current.append(other)
-            } else {
-                current = [other]
-            }
-        }
-        return current.filter { !$0.isEmpty }
+        Self.finalAnswers(
+            for: question,
+            answers: answers,
+            otherAnswers: otherAnswers
+        )
     }
 
     private func submissionPayload() -> [String: [String]] {
@@ -475,6 +535,16 @@ struct SessionQuestionForm: View {
                 partial[question.id] = resolved
             }
         }
+    }
+
+    private func submitCurrentAnswers() {
+        guard canSubmit && isEditable else { return }
+        onInteractionStateChanged(false)
+        onSubmit(submissionPayload())
+    }
+
+    private func notifyInteractionState() {
+        onInteractionStateChanged(protectsDraftInteraction && isEditable)
     }
 
     private func normalizedAnswers(from value: String) -> [String] {

--- a/PingIsland/UI/Views/ChatView.swift
+++ b/PingIsland/UI/Views/ChatView.swift
@@ -574,6 +574,7 @@ struct ChatView: View {
                         intervention: intervention,
                         initialAnswers: intervention.submittedAnswers,
                         onSubmit: { _ in },
+                        onInteractionStateChanged: { viewModel.setInlineTextInputActive($0) },
                         secondaryActionTitle: AppLocalization.format("打开 %@", session.interactionDisplayName),
                         onSecondaryAction: { openClientApplication() },
                         isEditable: false
@@ -626,6 +627,7 @@ struct ChatView: View {
                     onSubmit: { payload in
                         sessionMonitor.answerIntervention(sessionId: sessionId, answers: payload)
                     },
+                    onInteractionStateChanged: { viewModel.setInlineTextInputActive($0) },
                     secondaryActionTitle: secondaryActionTitle,
                     onSecondaryAction: onSecondaryAction
                 )

--- a/PingIsland/UI/Views/CodexSessionView.swift
+++ b/PingIsland/UI/Views/CodexSessionView.swift
@@ -194,6 +194,7 @@ struct CodexSessionView: View {
                         sessionMonitor.answerIntervention(sessionId: session.sessionId, answers: payload)
                         viewModel.exitChat()
                     },
+                    onInteractionStateChanged: { viewModel.setInlineTextInputActive($0) },
                     secondaryActionTitle: secondaryActionTitle,
                     onSecondaryAction: {
                         if intervention.supportsInlineResponse && session.clientInfo.prefersAnsweredQuestionFollowupAction {

--- a/PingIsland/UI/Views/IslandOpenedContentView.swift
+++ b/PingIsland/UI/Views/IslandOpenedContentView.swift
@@ -49,13 +49,15 @@ struct IslandOpenedContentView: View {
             SessionHoverDashboardView(
                 sessions: hoverPreviewSessions,
                 sessionMonitor: sessionMonitor,
-                density: surface == .floating ? .detachedCompact : .regular
+                density: surface == .floating ? .detachedCompact : .regular,
+                onQuestionInteractionStateChanged: { viewModel.setInlineTextInputActive($0) }
             )
         case .attentionNotification(let session):
             SessionAttentionNotificationView(
                 session: liveSession(for: session),
                 sessionMonitor: sessionMonitor,
                 density: surface == .floating ? .detachedCompact : .regular,
+                onQuestionInteractionStateChanged: { viewModel.setInlineTextInputActive($0) },
                 onActionCompleted: onAttentionActionCompleted
             )
         case .completionNotification(let notification):

--- a/PingIsland/UI/Views/SessionHoverPreviewView.swift
+++ b/PingIsland/UI/Views/SessionHoverPreviewView.swift
@@ -100,6 +100,7 @@ struct SessionHoverDashboardView: View {
     let sessions: [SessionState]
     let sessionMonitor: SessionMonitor
     var density: HoverPreviewDensity = .regular
+    var onQuestionInteractionStateChanged: (Bool) -> Void = { _ in }
 
     private var displayedSessions: [SessionState] {
         Array(sessions.prefix(3))
@@ -120,7 +121,8 @@ struct SessionHoverDashboardView: View {
                             sessionMonitor: sessionMonitor,
                             opensOnTap: false,
                             isHighlighted: isHighlighted,
-                            density: density
+                            density: density,
+                            onQuestionInteractionStateChanged: onQuestionInteractionStateChanged
                         )
                     } else {
                         SessionHoverCompactRow(
@@ -157,6 +159,7 @@ struct SessionAttentionNotificationView: View {
     let sessionMonitor: SessionMonitor
     var density: HoverPreviewDensity = .regular
     var onHoverChanged: (Bool) -> Void = { _ in }
+    var onQuestionInteractionStateChanged: (Bool) -> Void = { _ in }
     var onActionCompleted: () -> Void = {}
 
     var body: some View {
@@ -168,6 +171,7 @@ struct SessionAttentionNotificationView: View {
                     opensOnTap: false,
                     isHighlighted: session.needsApprovalResponse,
                     density: density,
+                    onQuestionInteractionStateChanged: onQuestionInteractionStateChanged,
                     onActionCompleted: onActionCompleted
                 )
             }
@@ -305,6 +309,7 @@ struct HoverSessionCard: View {
     var opensOnTap: Bool = true
     var isHighlighted = false
     var density: HoverPreviewDensity = .regular
+    var onQuestionInteractionStateChanged: (Bool) -> Void = { _ in }
     var onActionCompleted: () -> Void = {}
     @State private var isHovered = false
 
@@ -329,6 +334,7 @@ struct HoverSessionCard: View {
                     session: session,
                     intervention: intervention,
                     sessionMonitor: sessionMonitor,
+                    onQuestionInteractionStateChanged: onQuestionInteractionStateChanged,
                     onActionCompleted: onActionCompleted
                 )
             } else {
@@ -509,6 +515,7 @@ private struct HoverQuestionInterventionCard: View {
     let session: SessionState
     let intervention: SessionIntervention
     let sessionMonitor: SessionMonitor
+    var onQuestionInteractionStateChanged: (Bool) -> Void = { _ in }
     let onActionCompleted: () -> Void
 
     var body: some View {
@@ -533,6 +540,7 @@ private struct HoverQuestionInterventionCard: View {
                         intervention: intervention,
                         initialAnswers: intervention.submittedAnswers,
                         onSubmit: { _ in },
+                        onInteractionStateChanged: onQuestionInteractionStateChanged,
                         secondaryActionTitle: AppLocalization.format("打开 %@", session.interactionDisplayName),
                         onSecondaryAction: {
                             Task {
@@ -573,6 +581,7 @@ private struct HoverQuestionInterventionCard: View {
                         sessionMonitor.answerIntervention(sessionId: session.sessionId, answers: payload)
                         onActionCompleted()
                     },
+                    onInteractionStateChanged: onQuestionInteractionStateChanged,
                     secondaryActionTitle: secondaryActionTitle,
                     onSecondaryAction: secondaryActionTitle == nil ? nil : {
                         Task {

--- a/PingIslandTests/NotchViewModelTests.swift
+++ b/PingIslandTests/NotchViewModelTests.swift
@@ -63,6 +63,44 @@ final class NotchViewModelTests: XCTestCase {
         }
     }
 
+    func testHoverAutoCollapseWaitsWhileInlineTextInputIsActive() async {
+        await MainActor.run {
+            XCTAssertFalse(
+                NotchViewModel.shouldAutoCollapseHoverPreview(
+                    isHovering: false,
+                    status: .opened,
+                    openReason: .hover,
+                    isSettingsPopoverPresented: false,
+                    isInlineTextInputActive: true,
+                    autoCollapseOnLeave: true
+                )
+            )
+
+            XCTAssertTrue(
+                NotchViewModel.shouldAutoCollapseHoverPreview(
+                    isHovering: false,
+                    status: .opened,
+                    openReason: .hover,
+                    isSettingsPopoverPresented: false,
+                    isInlineTextInputActive: false,
+                    autoCollapseOnLeave: true
+                )
+            )
+        }
+    }
+
+    func testClosingNotchClearsInlineTextInputState() async {
+        await MainActor.run {
+            let viewModel = makeViewModel()
+
+            viewModel.setInlineTextInputActive(true)
+            viewModel.notchOpen(reason: .hover)
+            viewModel.notchClose()
+
+            XCTAssertFalse(viewModel.isInlineTextInputActive)
+        }
+    }
+
     func testPresentSessionListClearsSavedChatAndOpensManualList() async {
         await MainActor.run {
             let viewModel = makeViewModel()

--- a/PingIslandTests/SessionQuestionFormTests.swift
+++ b/PingIslandTests/SessionQuestionFormTests.swift
@@ -166,7 +166,49 @@ final class SessionQuestionFormTests: XCTestCase {
         )
     }
 
-    private func makeQuestion(id: String) -> SessionInterventionQuestion {
+    func testCustomAnswerProtectsDraftInteraction() {
+        let question = makeQuestion(id: "scope", allowsOther: true)
+
+        XCTAssertTrue(
+            SessionQuestionForm.protectsDraftInteraction(
+                questions: [question],
+                answers: [:],
+                otherAnswers: ["scope": "Please keep my draft"],
+                focusedQuestionID: nil
+            )
+        )
+    }
+
+    func testFocusedEmptyAnswerProtectsDraftInteraction() {
+        let question = makeQuestion(id: "scope", allowsOther: true)
+
+        XCTAssertTrue(
+            SessionQuestionForm.protectsDraftInteraction(
+                questions: [question],
+                answers: [:],
+                otherAnswers: [:],
+                focusedQuestionID: "scope"
+            )
+        )
+    }
+
+    func testCustomAnswerReplacesSingleChoiceOptionInSubmission() {
+        let question = makeQuestion(id: "scope", allowsOther: true)
+
+        XCTAssertEqual(
+            SessionQuestionForm.finalAnswers(
+                for: question,
+                answers: ["scope": ["Use the selected option"]],
+                otherAnswers: ["scope": "Use the custom draft"]
+            ),
+            ["Use the custom draft"]
+        )
+    }
+
+    private func makeQuestion(
+        id: String,
+        allowsOther: Bool = false
+    ) -> SessionInterventionQuestion {
         SessionInterventionQuestion(
             id: id,
             header: id,
@@ -177,7 +219,7 @@ final class SessionQuestionFormTests: XCTestCase {
                 .init(id: "\(id)-no", title: "否", detail: nil),
             ],
             allowsMultiple: false,
-            allowsOther: false,
+            allowsOther: allowsOther,
             isSecret: false
         )
     }

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
   <a href="#buddy-detach">Buddy Detach</a> •
   <a href="#supported-tools">Supported Tools</a> •
   <a href="#build-from-source">Build</a> •
+  <a href="#contributors">Contributors</a> •
   <a href="docs/privacy-policy.md">Privacy</a><br>
   English | <a href="README.zh-CN.md">简体中文</a>
 </p>
@@ -306,6 +307,12 @@ Implementation details worth knowing:
 - macOS 14.0 or later
 - Best experience on MacBooks with a notch, but external displays are supported too
 - Install whichever CLI or desktop clients you want Ping Island to monitor
+
+## Contributors
+
+Thanks to everyone who has helped shape Ping Island through code, issues, ideas, testing, docs, design feedback, and release validation.
+
+See the full contributor history on the [GitHub contributors graph](https://github.com/erha19/ping-island/graphs/contributors).
 
 ## Acknowledgments
 


### PR DESCRIPTION
## Summary

- Keep question hover panels open while an inline answer field is focused or has an unsent draft.
- Make Return submit question answers through the same path as the submit button.
- Cover the draft-protection and hover auto-collapse behavior with focused tests.

Fixes #153

## Validation

- `xcodebuild -project PingIsland.xcodeproj -scheme PingIsland -configuration Debug CODE_SIGNING_ALLOWED=NO test -only-testing:PingIslandTests/SessionQuestionFormTests -only-testing:PingIslandTests/NotchViewModelTests`
- `git diff --check`
