### PR TITLE
fix: remove parentThreadId guard from Codex auxiliary filter

### DIFF
--- a/PingIsland/Models/SessionState.swift
+++ b/PingIsland/Models/SessionState.swift
@@ -421,10 +421,13 @@ struct SessionState: Equatable, Identifiable, Sendable {
         guard provider == .codex else { return false }
         guard intervention == nil else { return false }
         guard !hasSpecificCodexSessionName else { return false }
-        guard codexParentThreadId?.isEmpty != false else { return false }
-        guard codexSubagentDepth == nil else { return false }
-        guard codexSubagentNickname?.isEmpty != false else { return false }
-        guard codexSubagentRole?.isEmpty != false else { return false }
+        // Real subagent threads have parent ID AND subagent metadata.
+        // Suggestions threads have parent ID but no subagent metadata.
+        let isRealSubagent = codexParentThreadId?.isEmpty == false
+            && (codexSubagentDepth != nil
+                || codexSubagentNickname?.isEmpty == false
+                || codexSubagentRole?.isEmpty == false)
+        if isRealSubagent { return false }
         guard !chatItems.contains(where: Self.isToolCallItem(_:)) else { return false }
 
         let visibleTexts = codexAuxiliaryCandidateTexts


### PR DESCRIPTION
Codex Desktop suggestions threads have `codexParentThreadId` set because they are child threads of the main session. The parent thread ID guard in `isLikelyCodexAuxiliaryThreadForUI` was skipping ALL child threads, including suggestions-only JSON threads that should be hidden.

Real subagent threads are still kept visible by the existing `codexSubagentDepth` / `codexSubagentNickname` / `codexSubagentRole` guards.

Fixes the issue where `{"suggestions":[...]}` sessions appear in the session list.