### PR TITLE
Fix Codex: filter background agent sessions and fix jump navigation blank page

### DIFF
--- a/PingIsland/Services/State/SessionStore.swift
+++ b/PingIsland/Services/State/SessionStore.swift
@@ -3971,6 +3971,13 @@ actor SessionStore {
 
     private func shouldIgnoreCodexHookEvent(_ event: HookEvent, existingSession: SessionState?) -> Bool {
         guard event.provider == .codex else { return false }
+
+        // Background Codex agents (ambient suggestions, state queries, safety filters)
+        // run with cwd="/". They are internal system processes, not user coding sessions.
+        if event.cwd == "/" {
+            return true
+        }
+
         guard event.clientInfo.sessionFilePath?.isEmpty != false else { return false }
         guard !event.expectsResponse else { return false }
         guard case .none = event.intervention else { return false }


### PR DESCRIPTION
## Summary

- **Filter Codex background agent sessions** (`cwd="/"`)：Codex 的 Ambient Suggestions 安全过滤 agent 每隔 ~6 秒触发一次 Stop hook（`cwd="/"`、`model=gpt-5.4-mini`、`bypassPermissions`），导致 UI 出现大量 `/ · /` 占位 session 噪音。现在在 `shouldIgnoreCodexHookEvent` 中直接过滤掉 `cwd="/"` 的 hook 事件。
- **Fix Codex jump navigation opening blank page**：从 Ping Island 点击跳转 Codex session 时，总是打开空白新页面而非已有会话。原因是 `activatePreferredAppNavigation` 在通过 `codex://threads/{threadId}` 深链接打开正确 thread 后，紧接着以 `activateAllWindows: true` 调用 `activateApplication`，触发 `reopenRunningApplication` → `NSWorkspace.openApplication(at:)`，导致 Electron 应用弹出新空白窗口覆盖在已导航的 thread 窗口之上。改为 `activateAllWindows: false` 只做 `app.activate()` 不创建新窗口。

## Test plan

- [ ] 启动 Codex App，确认 Island 不再出现 `/ · /` 的背景 agent session
- [ ] 在 Island 中点击 Codex session 跳转，确认直接打开对应 thread 而非空白页

🤖 Generated with [Claude Code](https://claude.com/claude-code)