### PR TITLE
Add Claude Desktop local-agent session monitoring with turn completion detection

### DIFF
--- a/PingIsland/Models/ClientProfile.swift
+++ b/PingIsland/Models/ClientProfile.swift
@@ -1204,6 +1204,21 @@ enum ClientProfileRegistry {
             bundleIdentifiers: ["com.openai.codex"]
         ),
         SessionClientProfile(
+            id: "claude-desktop",
+            provider: .claude,
+            family: .claudeHooks,
+            kind: .custom,
+            displayName: "Claude Desktop",
+            assistantLabelMode: .badgeLabel,
+            brand: .claude,
+            defaultBundleIdentifier: "com.anthropic.claudefordesktop",
+            defaultOrigin: "desktop",
+            recognizedKinds: ["claude-desktop", "claude_desktop", "claude desktop"],
+            exactAliases: ["claude-desktop", "claude desktop"],
+            keywordAliases: ["claude desktop"],
+            bundleIdentifiers: ["com.anthropic.claudefordesktop"]
+        ),
+        SessionClientProfile(
             id: "codex-cli",
             provider: .codex,
             family: .codexHooks,

--- a/PingIsland/Models/SessionEvent.swift
+++ b/PingIsland/Models/SessionEvent.swift
@@ -87,6 +87,9 @@ enum SessionEvent: Sendable {
     /// A new Claude Desktop local-agent session was discovered via file monitoring
     case desktopSessionDiscovered(ClaudeDesktopSessionInfo)
 
+    /// A Claude Desktop AI turn completed (detected via `type:"result"` in audit.jsonl)
+    case desktopTurnCompleted(sessionId: String)
+
     // MARK: - Session Lifecycle
 
     /// Session has ended
@@ -719,6 +722,8 @@ extension SessionEvent: CustomStringConvertible {
             return "agentFileUpdated(session: \(sessionId.prefix(8)), task: \(taskToolId.prefix(12)), tools: \(tools.count))"
         case .desktopSessionDiscovered(let info):
             return "desktopSessionDiscovered(session: \(info.sessionId.prefix(8)))"
+        case .desktopTurnCompleted(let sessionId):
+            return "desktopTurnCompleted(session: \(sessionId.prefix(8)))"
         }
     }
 }
@@ -774,6 +779,8 @@ extension SessionEvent {
             return "toolCompleted"
         case .desktopSessionDiscovered:
             return "desktopSessionDiscovered"
+        case .desktopTurnCompleted:
+            return "desktopTurnCompleted"
         }
     }
 
@@ -806,6 +813,8 @@ extension SessionEvent {
             return String(payload.sessionId.prefix(8))
         case .desktopSessionDiscovered(let info):
             return String(info.sessionId.prefix(8))
+        case .desktopTurnCompleted(let sessionId):
+            return String(sessionId.prefix(8))
         case .pruneTimedOutExternalContinuations:
             return nil
         }

--- a/PingIsland/Models/SessionEvent.swift
+++ b/PingIsland/Models/SessionEvent.swift
@@ -82,6 +82,11 @@ enum SessionEvent: Sendable {
     /// User issued /clear command - reset UI state while keeping session alive
     case clearDetected(sessionId: String)
 
+    // MARK: - Desktop App Monitor Events
+
+    /// A new Claude Desktop local-agent session was discovered via file monitoring
+    case desktopSessionDiscovered(ClaudeDesktopSessionInfo)
+
     // MARK: - Session Lifecycle
 
     /// Session has ended
@@ -109,6 +114,15 @@ struct FileUpdatePayload: Sendable {
     let completedToolIds: Set<String>
     let toolResults: [String: ConversationParser.ToolResult]
     let structuredResults: [String: ToolResultData]
+}
+
+/// Info about a Claude Desktop local-agent session discovered via file monitoring
+struct ClaudeDesktopSessionInfo: Sendable {
+    let sessionId: String
+    let cwd: String
+    let title: String?
+    let createdAt: Date
+    let auditFilePath: String
 }
 
 /// Result of a tool completion detected from JSONL
@@ -703,6 +717,8 @@ extension SessionEvent: CustomStringConvertible {
             return "subagentStopped(session: \(sessionId.prefix(8)), task: \(taskToolId.prefix(12)))"
         case .agentFileUpdated(let sessionId, let taskToolId, let tools):
             return "agentFileUpdated(session: \(sessionId.prefix(8)), task: \(taskToolId.prefix(12)), tools: \(tools.count))"
+        case .desktopSessionDiscovered(let info):
+            return "desktopSessionDiscovered(session: \(info.sessionId.prefix(8)))"
         }
     }
 }
@@ -756,6 +772,8 @@ extension SessionEvent {
             return "historyLoaded"
         case .toolCompleted:
             return "toolCompleted"
+        case .desktopSessionDiscovered:
+            return "desktopSessionDiscovered"
         }
     }
 
@@ -786,6 +804,8 @@ extension SessionEvent {
             return String(sessionId.prefix(8))
         case .fileUpdated(let payload):
             return String(payload.sessionId.prefix(8))
+        case .desktopSessionDiscovered(let info):
+            return String(info.sessionId.prefix(8))
         case .pruneTimedOutExternalContinuations:
             return nil
         }

--- a/PingIsland/Models/SessionProvider.swift
+++ b/PingIsland/Models/SessionProvider.swift
@@ -25,6 +25,7 @@ enum SessionIngress: String, Equatable, Sendable {
     case remoteBridge
     case codexAppServer
     case nativeRuntime
+    case desktopAppMonitor
 }
 
 enum SessionClientKind: String, Codable, Equatable, Sendable {

--- a/PingIsland/Services/Session/ClaudeDesktopWatcher.swift
+++ b/PingIsland/Services/Session/ClaudeDesktopWatcher.swift
@@ -1,0 +1,224 @@
+//
+//  ClaudeDesktopWatcher.swift
+//  PingIsland
+//
+//  Monitors ~/Library/Application Support/Claude/local-agent-mode-sessions/
+//  for Claude Desktop local-agent sessions. Pipes each session's audit.jsonl
+//  through ConversationParser → SessionStore (notify-only, no hook responses).
+//
+
+import Foundation
+import os.log
+
+private let logger = Logger(subsystem: "com.wudanwu.pingisland", category: "ClaudeDesktop")
+
+actor ClaudeDesktopWatcher {
+    static let shared = ClaudeDesktopWatcher()
+
+    private var discoveryTask: Task<Void, Never>?
+    private var sessionTasks: [String: Task<Void, Never>] = [:]
+    private var knownLocalSessionIds: Set<String> = []
+
+    private init() {}
+
+    // MARK: - Lifecycle
+
+    func start() {
+        guard discoveryTask == nil else { return }
+        logger.info("Starting Claude Desktop watcher")
+        discoveryTask = Task { [weak self] in
+            await self?.runDiscoveryLoop()
+        }
+    }
+
+    func stop() {
+        discoveryTask?.cancel()
+        discoveryTask = nil
+        for task in sessionTasks.values { task.cancel() }
+        sessionTasks.removeAll()
+        knownLocalSessionIds.removeAll()
+        logger.info("Stopped Claude Desktop watcher")
+    }
+
+    // MARK: - Discovery Loop
+
+    private func runDiscoveryLoop() async {
+        while !Task.isCancelled {
+            await scanForNewSessions()
+            do {
+                try await Task.sleep(for: .seconds(2))
+            } catch {
+                break
+            }
+        }
+    }
+
+    private func scanForNewSessions() async {
+        let sessionsRoot = Self.sessionsRootURL()
+        guard FileManager.default.fileExists(atPath: sessionsRoot.path) else { return }
+
+        guard let orgDirs = try? FileManager.default.contentsOfDirectory(
+            at: sessionsRoot,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        ) else { return }
+
+        for orgDir in orgDirs where orgDir.hasDirectoryPath {
+            guard let userDirs = try? FileManager.default.contentsOfDirectory(
+                at: orgDir,
+                includingPropertiesForKeys: nil,
+                options: [.skipsHiddenFiles]
+            ) else { continue }
+
+            for userDir in userDirs where userDir.hasDirectoryPath {
+                await scanUserDirectory(userDir)
+            }
+        }
+    }
+
+    private func scanUserDirectory(_ userDir: URL) async {
+        guard let entries = try? FileManager.default.contentsOfDirectory(
+            at: userDir,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        ) else { return }
+
+        for entry in entries {
+            let name = entry.lastPathComponent
+            guard name.hasPrefix("local_"), name.hasSuffix(".json") else { continue }
+            let localSessionId = name.dropLast(5).description // strip .json
+
+            guard !knownLocalSessionIds.contains(localSessionId) else { continue }
+
+            await registerSession(metadataURL: entry, localSessionId: localSessionId)
+        }
+    }
+
+    // MARK: - Session Registration
+
+    private func registerSession(metadataURL: URL, localSessionId: String) async {
+        guard let metadata = Self.readMetadata(at: metadataURL) else { return }
+        guard !metadata.isArchived else { return }
+
+        let sessionDir = metadataURL.deletingPathExtension()
+        let auditPath = sessionDir.appendingPathComponent("audit.jsonl").path
+        guard FileManager.default.fileExists(atPath: auditPath) else { return }
+
+        knownLocalSessionIds.insert(localSessionId)
+        logger.info("Discovered Claude Desktop session \(metadata.cliSessionId.prefix(8), privacy: .public)")
+
+        let info = ClaudeDesktopSessionInfo(
+            sessionId: metadata.cliSessionId,
+            cwd: metadata.cwd,
+            title: metadata.title,
+            createdAt: metadata.createdAt,
+            auditFilePath: auditPath
+        )
+        await SessionStore.shared.process(.desktopSessionDiscovered(info))
+        await ConversationParser.shared.resetState(for: metadata.cliSessionId)
+
+        let sessionId = metadata.cliSessionId
+        let cwd = metadata.cwd
+        let task = Task {
+            await self.runPollingLoop(
+                sessionId: sessionId,
+                cwd: cwd,
+                auditFilePath: auditPath,
+                metadataURL: metadataURL,
+                localSessionId: localSessionId
+            )
+        }
+        sessionTasks[localSessionId] = task
+    }
+
+    // MARK: - Polling Loop
+
+    private func runPollingLoop(
+        sessionId: String,
+        cwd: String,
+        auditFilePath: String,
+        metadataURL: URL,
+        localSessionId: String
+    ) async {
+        while !Task.isCancelled {
+            let result = await ConversationParser.shared.parseIncremental(
+                sessionId: sessionId,
+                cwd: cwd,
+                explicitFilePath: auditFilePath
+            )
+
+            if result.clearDetected {
+                await SessionStore.shared.process(.clearDetected(sessionId: sessionId))
+            }
+
+            if !result.newMessages.isEmpty || result.clearDetected {
+                let payload = FileUpdatePayload(
+                    sessionId: sessionId,
+                    cwd: cwd,
+                    messages: result.newMessages,
+                    isIncremental: !result.clearDetected,
+                    completedToolIds: result.completedToolIds,
+                    toolResults: result.toolResults,
+                    structuredResults: result.structuredResults
+                )
+                await SessionStore.shared.process(.fileUpdated(payload))
+            }
+
+            // Check if session was archived so we can end it and stop polling
+            if let metadata = Self.readMetadata(at: metadataURL), metadata.isArchived {
+                logger.info("Claude Desktop session archived \(sessionId.prefix(8), privacy: .public)")
+                await SessionStore.shared.process(.sessionEnded(sessionId: sessionId))
+                break
+            }
+
+            do {
+                try await Task.sleep(for: .milliseconds(750))
+            } catch {
+                break
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    nonisolated static func sessionsRootURL() -> URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support/Claude/local-agent-mode-sessions")
+    }
+
+    nonisolated static func readMetadata(at url: URL) -> ClaudeDesktopSessionMetadata? {
+        guard let data = try? Data(contentsOf: url),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+
+        guard let cliSessionId = json["cliSessionId"] as? String,
+              let localSessionId = json["sessionId"] as? String
+        else { return nil }
+
+        let cwd = (json["cwd"] as? String) ?? FileManager.default.homeDirectoryForCurrentUser.path
+        let title = json["title"] as? String
+        let isArchived = json["isArchived"] as? Bool ?? false
+        let createdAtMs = json["createdAt"] as? TimeInterval ?? 0
+        let createdAt = Date(timeIntervalSince1970: createdAtMs / 1000)
+
+        return ClaudeDesktopSessionMetadata(
+            localSessionId: localSessionId,
+            cliSessionId: cliSessionId,
+            cwd: cwd,
+            title: title,
+            isArchived: isArchived,
+            createdAt: createdAt
+        )
+    }
+}
+
+// MARK: - Supporting Types
+
+struct ClaudeDesktopSessionMetadata: Sendable {
+    let localSessionId: String
+    let cliSessionId: String
+    let cwd: String
+    let title: String?
+    let isArchived: Bool
+    let createdAt: Date
+}

--- a/PingIsland/Services/Session/ClaudeDesktopWatcher.swift
+++ b/PingIsland/Services/Session/ClaudeDesktopWatcher.swift
@@ -12,12 +12,16 @@ import os.log
 
 private let logger = Logger(subsystem: "com.wudanwu.pingisland", category: "ClaudeDesktop")
 
+/// Sessions idle for longer than this threshold are skipped on startup.
+private let activeWindowSeconds: TimeInterval = 4 * 60 * 60  // 4 hours
+
 actor ClaudeDesktopWatcher {
     static let shared = ClaudeDesktopWatcher()
 
     private var discoveryTask: Task<Void, Never>?
     private var sessionTasks: [String: Task<Void, Never>] = [:]
     private var knownLocalSessionIds: Set<String> = []
+    private var sessionFileSizes: [String: UInt64] = [:]  // localSessionId → last known file size
 
     private init() {}
 
@@ -26,8 +30,8 @@ actor ClaudeDesktopWatcher {
     func start() {
         guard discoveryTask == nil else { return }
         logger.info("Starting Claude Desktop watcher")
-        discoveryTask = Task { [weak self] in
-            await self?.runDiscoveryLoop()
+        discoveryTask = Task {
+            await self.runDiscoveryLoop()
         }
     }
 
@@ -37,6 +41,7 @@ actor ClaudeDesktopWatcher {
         for task in sessionTasks.values { task.cancel() }
         sessionTasks.removeAll()
         knownLocalSessionIds.removeAll()
+        sessionFileSizes.removeAll()
         logger.info("Stopped Claude Desktop watcher")
     }
 
@@ -86,7 +91,7 @@ actor ClaudeDesktopWatcher {
         for entry in entries {
             let name = entry.lastPathComponent
             guard name.hasPrefix("local_"), name.hasSuffix(".json") else { continue }
-            let localSessionId = name.dropLast(5).description // strip .json
+            let localSessionId = String(name.dropLast(5)) // strip .json
 
             guard !knownLocalSessionIds.contains(localSessionId) else { continue }
 
@@ -100,12 +105,25 @@ actor ClaudeDesktopWatcher {
         guard let metadata = Self.readMetadata(at: metadataURL) else { return }
         guard !metadata.isArchived else { return }
 
+        // Skip sessions that have been idle longer than the active window.
+        // This prevents loading dozens of historical sessions on startup.
+        let idleSeconds = Date().timeIntervalSince(metadata.lastActivityAt)
+        guard idleSeconds < activeWindowSeconds else {
+            logger.debug(
+                "Skipping stale Claude Desktop session \(metadata.cliSessionId.prefix(8), privacy: .public) idle=\(Int(idleSeconds))s"
+            )
+            knownLocalSessionIds.insert(localSessionId)
+            return
+        }
+
         let sessionDir = metadataURL.deletingPathExtension()
         let auditPath = sessionDir.appendingPathComponent("audit.jsonl").path
         guard FileManager.default.fileExists(atPath: auditPath) else { return }
 
         knownLocalSessionIds.insert(localSessionId)
-        logger.info("Discovered Claude Desktop session \(metadata.cliSessionId.prefix(8), privacy: .public)")
+        logger.info(
+            "Registering Claude Desktop session \(metadata.cliSessionId.prefix(8), privacy: .public) idle=\(Int(idleSeconds))s"
+        )
 
         let info = ClaudeDesktopSessionInfo(
             sessionId: metadata.cliSessionId,
@@ -115,7 +133,18 @@ actor ClaudeDesktopWatcher {
             auditFilePath: auditPath
         )
         await SessionStore.shared.process(.desktopSessionDiscovered(info))
+
+        // Advance ConversationParser's internal offset to end-of-file without emitting
+        // events, so we only pick up content written after Ping Island started watching.
         await ConversationParser.shared.resetState(for: metadata.cliSessionId)
+        _ = await ConversationParser.shared.parseIncremental(
+            sessionId: metadata.cliSessionId,
+            cwd: metadata.cwd,
+            explicitFilePath: auditPath
+        )
+
+        // Record current file size so the polling loop can skip unchanged files.
+        sessionFileSizes[localSessionId] = Self.fileSize(at: auditPath)
 
         let sessionId = metadata.cliSessionId
         let cwd = metadata.cwd
@@ -141,30 +170,37 @@ actor ClaudeDesktopWatcher {
         localSessionId: String
     ) async {
         while !Task.isCancelled {
-            let result = await ConversationParser.shared.parseIncremental(
-                sessionId: sessionId,
-                cwd: cwd,
-                explicitFilePath: auditFilePath
-            )
+            let currentSize = Self.fileSize(at: auditFilePath)
+            let lastSize = sessionFileSizes[localSessionId] ?? 0
 
-            if result.clearDetected {
-                await SessionStore.shared.process(.clearDetected(sessionId: sessionId))
-            }
+            if currentSize > lastSize {
+                sessionFileSizes[localSessionId] = currentSize
 
-            if !result.newMessages.isEmpty || result.clearDetected {
-                let payload = FileUpdatePayload(
+                let result = await ConversationParser.shared.parseIncremental(
                     sessionId: sessionId,
                     cwd: cwd,
-                    messages: result.newMessages,
-                    isIncremental: !result.clearDetected,
-                    completedToolIds: result.completedToolIds,
-                    toolResults: result.toolResults,
-                    structuredResults: result.structuredResults
+                    explicitFilePath: auditFilePath
                 )
-                await SessionStore.shared.process(.fileUpdated(payload))
+
+                if result.clearDetected {
+                    await SessionStore.shared.process(.clearDetected(sessionId: sessionId))
+                }
+
+                if !result.newMessages.isEmpty || result.clearDetected {
+                    let payload = FileUpdatePayload(
+                        sessionId: sessionId,
+                        cwd: cwd,
+                        messages: result.newMessages,
+                        isIncremental: !result.clearDetected,
+                        completedToolIds: result.completedToolIds,
+                        toolResults: result.toolResults,
+                        structuredResults: result.structuredResults
+                    )
+                    await SessionStore.shared.process(.fileUpdated(payload))
+                }
             }
 
-            // Check if session was archived so we can end it and stop polling
+            // End the session when Claude Desktop archives it
             if let metadata = Self.readMetadata(at: metadataURL), metadata.isArchived {
                 logger.info("Claude Desktop session archived \(sessionId.prefix(8), privacy: .public)")
                 await SessionStore.shared.process(.sessionEnded(sessionId: sessionId))
@@ -180,6 +216,11 @@ actor ClaudeDesktopWatcher {
     }
 
     // MARK: - Helpers
+
+    nonisolated static func fileSize(at path: String) -> UInt64 {
+        let attrs = try? FileManager.default.attributesOfItem(atPath: path)
+        return (attrs?[.size] as? UInt64) ?? 0
+    }
 
     nonisolated static func sessionsRootURL() -> URL {
         FileManager.default.homeDirectoryForCurrentUser
@@ -200,6 +241,8 @@ actor ClaudeDesktopWatcher {
         let isArchived = json["isArchived"] as? Bool ?? false
         let createdAtMs = json["createdAt"] as? TimeInterval ?? 0
         let createdAt = Date(timeIntervalSince1970: createdAtMs / 1000)
+        let lastActivityAtMs = json["lastActivityAt"] as? TimeInterval ?? createdAtMs
+        let lastActivityAt = Date(timeIntervalSince1970: lastActivityAtMs / 1000)
 
         return ClaudeDesktopSessionMetadata(
             localSessionId: localSessionId,
@@ -207,7 +250,8 @@ actor ClaudeDesktopWatcher {
             cwd: cwd,
             title: title,
             isArchived: isArchived,
-            createdAt: createdAt
+            createdAt: createdAt,
+            lastActivityAt: lastActivityAt
         )
     }
 }
@@ -221,4 +265,5 @@ struct ClaudeDesktopSessionMetadata: Sendable {
     let title: String?
     let isArchived: Bool
     let createdAt: Date
+    let lastActivityAt: Date
 }

--- a/PingIsland/Services/Session/ClaudeDesktopWatcher.swift
+++ b/PingIsland/Services/Session/ClaudeDesktopWatcher.swift
@@ -22,6 +22,7 @@ actor ClaudeDesktopWatcher {
     private var sessionTasks: [String: Task<Void, Never>] = [:]
     private var knownLocalSessionIds: Set<String> = []
     private var sessionFileSizes: [String: UInt64] = [:]  // localSessionId → last known file size
+    private var resultScanOffsets: [String: UInt64] = [:]  // localSessionId → byte offset up to which result entries have been scanned
 
     private init() {}
 
@@ -42,6 +43,7 @@ actor ClaudeDesktopWatcher {
         sessionTasks.removeAll()
         knownLocalSessionIds.removeAll()
         sessionFileSizes.removeAll()
+        resultScanOffsets.removeAll()
         logger.info("Stopped Claude Desktop watcher")
     }
 
@@ -144,7 +146,10 @@ actor ClaudeDesktopWatcher {
         )
 
         // Record current file size so the polling loop can skip unchanged files.
-        sessionFileSizes[localSessionId] = Self.fileSize(at: auditPath)
+        let currentSize = Self.fileSize(at: auditPath)
+        sessionFileSizes[localSessionId] = currentSize
+        // Start result scanning from EOF — don't treat historical result entries as new completions.
+        resultScanOffsets[localSessionId] = currentSize
 
         let sessionId = metadata.cliSessionId
         let cwd = metadata.cwd
@@ -175,6 +180,22 @@ actor ClaudeDesktopWatcher {
 
             if currentSize > lastSize {
                 sessionFileSizes[localSessionId] = currentSize
+
+                // Scan new bytes for type:"result" entries (signals AI turn completion).
+                let scanFrom = resultScanOffsets[localSessionId] ?? lastSize
+                if currentSize > scanFrom,
+                   let turnCompleted = Self.scanForResultEntry(
+                       filePath: auditFilePath, from: scanFrom, to: currentSize
+                   )
+                {
+                    resultScanOffsets[localSessionId] = currentSize
+                    logger.info(
+                        "Turn completed session=\(sessionId.prefix(8), privacy: .public) isError=\(turnCompleted.isError) turns=\(turnCompleted.numTurns)"
+                    )
+                    await SessionStore.shared.process(.desktopTurnCompleted(sessionId: sessionId))
+                } else {
+                    resultScanOffsets[localSessionId] = currentSize
+                }
 
                 let result = await ConversationParser.shared.parseIncremental(
                     sessionId: sessionId,
@@ -216,6 +237,38 @@ actor ClaudeDesktopWatcher {
     }
 
     // MARK: - Helpers
+
+    struct ResultEntry {
+        let isError: Bool
+        let numTurns: Int
+    }
+
+    /// Reads bytes [from, to) from the file and scans for the first `type:"result"` JSONL entry.
+    nonisolated static func scanForResultEntry(filePath: String, from: UInt64, to: UInt64) -> ResultEntry? {
+        guard to > from,
+              let fh = FileHandle(forReadingAtPath: filePath)
+        else { return nil }
+        defer { try? fh.close() }
+        do {
+            try fh.seek(toOffset: from)
+            let length = Int(to - from)
+            guard let data = try fh.read(upToCount: length),
+                  let text = String(data: data, encoding: .utf8)
+            else { return nil }
+            for line in text.components(separatedBy: "\n") {
+                let trimmed = line.trimmingCharacters(in: .whitespaces)
+                guard !trimmed.isEmpty,
+                      let lineData = trimmed.data(using: .utf8),
+                      let json = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
+                      json["type"] as? String == "result"
+                else { continue }
+                let isError = json["is_error"] as? Bool ?? false
+                let numTurns = json["num_turns"] as? Int ?? 1
+                return ResultEntry(isError: isError, numTurns: numTurns)
+            }
+        } catch {}
+        return nil
+    }
 
     nonisolated static func fileSize(at path: String) -> UInt64 {
         let attrs = try? FileManager.default.attributesOfItem(atPath: path)

--- a/PingIsland/Services/Session/SessionMonitor.swift
+++ b/PingIsland/Services/Session/SessionMonitor.swift
@@ -122,6 +122,10 @@ class SessionMonitor: ObservableObject {
         }
 
         Task {
+            await ClaudeDesktopWatcher.shared.start()
+        }
+
+        Task {
             await runtimeCoordinator.start()
         }
         RemoteConnectorManager.shared.start(
@@ -244,6 +248,9 @@ class SessionMonitor: ObservableObject {
         RemoteConnectorManager.shared.stop()
         Task {
             await CodexAppServerMonitor.shared.stop()
+        }
+        Task {
+            await ClaudeDesktopWatcher.shared.stop()
         }
         Task {
             await runtimeCoordinator.stop()

--- a/PingIsland/Services/State/SessionStore.swift
+++ b/PingIsland/Services/State/SessionStore.swift
@@ -158,6 +158,9 @@ actor SessionStore {
         case .desktopSessionDiscovered(let info):
             processDesktopSessionDiscovered(info)
 
+        case .desktopTurnCompleted(let sessionId):
+            processDesktopTurnCompleted(sessionId: sessionId)
+
         case .sessionEnded(let sessionId):
             await processSessionEnd(sessionId: sessionId)
 
@@ -316,6 +319,18 @@ actor SessionStore {
             createdAt: info.createdAt
         )
         sessions[info.sessionId] = session
+    }
+
+    private func processDesktopTurnCompleted(sessionId: String) {
+        guard var session = sessions[sessionId] else { return }
+        let oldPhase = session.phase
+        if session.phase.canTransition(to: .waitingForInput) {
+            session.phase = .waitingForInput
+            sessions[sessionId] = session
+            Self.logger.info(
+                "Desktop turn completed session=\(sessionId.prefix(8), privacy: .public) phase=\(oldPhase.description, privacy: .public)→waitingForInput"
+            )
+        }
     }
 
     private func processHookEvent(_ event: HookEvent) async {

--- a/PingIsland/Services/State/SessionStore.swift
+++ b/PingIsland/Services/State/SessionStore.swift
@@ -155,6 +155,9 @@ actor SessionStore {
         case .clearDetected(let sessionId):
             await processClearDetected(sessionId: sessionId)
 
+        case .desktopSessionDiscovered(let info):
+            processDesktopSessionDiscovered(info)
+
         case .sessionEnded(let sessionId):
             await processSessionEnd(sessionId: sessionId)
 
@@ -283,6 +286,36 @@ actor SessionStore {
         )
 
         sessions[handle.sessionID] = session
+    }
+
+    private func processDesktopSessionDiscovered(_ info: ClaudeDesktopSessionInfo) {
+        guard sessions[info.sessionId] == nil else { return }
+
+        let clientInfo = SessionClientInfo(
+            kind: .custom,
+            profileID: "claude-desktop",
+            name: "Claude Desktop",
+            bundleIdentifier: "com.anthropic.claudefordesktop",
+            origin: "desktop",
+            sessionFilePath: info.auditFilePath
+        )
+        let projectName = info.title
+            ?? Self.projectName(for: info.cwd, fallback: "Claude Desktop")
+        let session = SessionState(
+            sessionId: info.sessionId,
+            cwd: info.cwd,
+            projectName: projectName,
+            provider: .claude,
+            clientInfo: clientInfo,
+            ingress: .desktopAppMonitor,
+            sessionName: nil,
+            pid: nil,
+            tty: nil,
+            isInTmux: false,
+            phase: .idle,
+            createdAt: info.createdAt
+        )
+        sessions[info.sessionId] = session
     }
 
     private func processHookEvent(_ event: HookEvent) async {
@@ -976,7 +1009,7 @@ actor SessionStore {
                 )
             case .hookBridge:
                 HookSocketServer.shared.cancelPendingPermission(toolUseId: toolUseId)
-            case .codexAppServer, .nativeRuntime:
+            case .codexAppServer, .nativeRuntime, .desktopAppMonitor:
                 break
             }
         }
@@ -4111,7 +4144,7 @@ actor SessionStore {
             return codexHookPlaceholderPruneDelayNs
         case .codexAppServer:
             return codexAppServerPlaceholderPruneDelayNs
-        case .nativeRuntime:
+        case .nativeRuntime, .desktopAppMonitor:
             return codexAppServerPlaceholderPruneDelayNs
         }
     }


### PR DESCRIPTION
## Summary

- **监控 Claude Desktop 本地 agent 会话**：轮询 `~/Library/Application Support/Claude/local-agent-mode-sessions/` 目录，发现新会话后通过 `ConversationParser` 增量解析 `audit.jsonl`，将会话注入 `SessionStore`。支持多 org/user 目录结构，跳过超过 4 小时无活动的历史会话。
- **修复 ClaudeDesktopWatcher 重复解析**：之前每次轮询都调用 `parseIncremental`，即使文件未变化。改为记录上次文件大小，只在 `audit.jsonl` 增长时才触发解析。
- **检测 AI turn 完成**：通过扫描 `audit.jsonl` 新增字节中的 `type:"result"` 条目（每个 AI turn 结束时写入，包含 `is_error`、`num_turns` 字段）来触发 turn 完成通知，将 session phase 从 `processing` 转为 `waitingForInput`。使用独立的 `resultScanOffsets` 字节偏移避免重复计算。

## Test plan

- [ ] 启动 Claude Desktop 并发起一次 local-agent 会话，确认 Island 能显示该 session
- [ ] AI 完成回复后，确认 Island 显示 session 进入等待输入状态并触发完成通知
- [ ] 重启 Island，确认历史 session 不重复触发通知（从 EOF 开始扫描）
- [ ] Claude Desktop 归档 session 后，确认 Island 中对应 session 结束

🤖 Generated with [Claude Code](https://claude.com/claude-code)