### PR TITLE
fix: keep Codex Stop events as waiting_for_input

### DIFF
--- a/PingIsland/Services/Hooks/HookSocketServer.swift
+++ b/PingIsland/Services/Hooks/HookSocketServer.swift
@@ -582,7 +582,7 @@ private extension BridgeEnvelope {
             sessionId: sessionId,
             cwd: resolvedCWD,
             event: eventType,
-            status: Self.mapStatus(eventType: eventType, status: status?.kind, notificationType: metadata["notification_type"]),
+            status: Self.mapStatus(eventType: eventType, status: status?.kind, notificationType: metadata["notification_type"], provider: provider),
             provider: provider.sessionProvider,
             clientInfo: Self.makeClientInfo(
                 provider: provider,
@@ -613,7 +613,8 @@ private extension BridgeEnvelope {
     private static func mapStatus(
         eventType: String,
         status: BridgeStatusKind?,
-        notificationType: String?
+        notificationType: String?,
+        provider: BridgeProvider = .claude
     ) -> String {
         if eventType == "Notification", notificationType == "idle_prompt" {
             return "waiting_for_input"
@@ -646,7 +647,7 @@ private extension BridgeEnvelope {
         case "SessionStart", "SubagentStop":
             return "waiting_for_input"
         case "Stop":
-            return "idle"
+            return provider == .codex ? "waiting_for_input" : "idle"
         case "UserPromptSubmit", "PostToolUse":
             return "processing"
         case "PreToolUse":


### PR DESCRIPTION
PR #149 mapped `Stop` events to `"idle"` for all providers, but Codex Desktop also sends `Stop` hooks (every ~6s for background agents, per #175). This was forcing Codex sessions to show as idle even while Codex was actively running.

Claude Code keeps the `idle` mapping (Stop = end of turn = idle). Codex reverts to `waiting_for_input` (the original behavior).