### PR TITLE
Restore Codex SSH session status from remote bridge activity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ This file is a routing layer for coding agents working in this repo. Keep it sho
   - Terminal focus flows currently cover iTerm2, Ghostty, Terminal.app, tmux, and IDE-hosted terminals
 - Remote SSH forwarding and remote-host management: `PingIsland/Services/Remote/`
   - Remote hosts can bootstrap a bridge on the SSH target, rewrite remote hooks, install managed plugin-directory integrations such as Hermes under the remote home directory, and attach a bidirectional forwarding channel back into PingIsland
+  - The remote bridge also forwards Codex app-server thread activity from the SSH target's `~/.codex/state_*.sqlite` through the existing remote hook-event channel
 - Provider/client routing: bridge envelopes are normalized in `PingIsland/Services/Hooks/HookSocketServer.swift`, stored on `SessionState`, and launched via `PingIsland/Services/Window/SessionLauncher.swift`
 - Client profile registry: installable hook clients and runtime client branding / recognition are centralized in `PingIsland/Models/ClientProfile.swift`
 - VS Code-compatible IDE focus extension install / URI launch: `PingIsland/Services/Window/IDEExtensionInstaller.swift`, `PingIsland/Services/Window/TerminalSessionFocuser.swift`

--- a/Prototype/Sources/IslandBridge/main.swift
+++ b/Prototype/Sources/IslandBridge/main.swift
@@ -695,6 +695,8 @@ private final class RemoteAgentService: @unchecked Sendable {
     private var controlReadBuffer = Data()
     private var pendingRequests: [UUID: PendingRemoteBridgeRequest] = [:]
     private var queuedMessages: [Data] = []
+    private var codexStateSource: DispatchSourceTimer?
+    private var deliveredCodexThreadUpdates: [String: Int64] = [:]
     private let encoder = JSONEncoder()
     private let decoder = JSONDecoder()
 
@@ -728,6 +730,8 @@ private final class RemoteAgentService: @unchecked Sendable {
             self?.acceptControlConnection()
         }
         controlAcceptSource?.resume()
+
+        startCodexStatePolling()
     }
 
     private func makeListeningSocket(path: String) throws -> Int32 {
@@ -816,6 +820,33 @@ private final class RemoteAgentService: @unchecked Sendable {
         if payload.expectsResponse == false {
             close(clientSocket)
         }
+    }
+
+    private func startCodexStatePolling() {
+        let source = DispatchSource.makeTimerSource(queue: queue)
+        source.schedule(deadline: .now() + 1, repeating: 2)
+        source.setEventHandler { [weak self] in
+            self?.pollCodexState()
+        }
+        codexStateSource = source
+        source.resume()
+    }
+
+    private func pollCodexState() {
+        let cutoff = Int64(Date().timeIntervalSince1970 * 1000) - 15 * 60 * 1000
+        let codexHome = Self.homeDirectory.appendingPathComponent(".codex")
+        for thread in RemoteCodexStatePoller.readRecentThreads(codexHome: codexHome, updatedSinceMs: cutoff) {
+            guard thread.updatedAtMs > (deliveredCodexThreadUpdates[thread.id] ?? 0) else { continue }
+            deliveredCodexThreadUpdates[thread.id] = thread.updatedAtMs
+            enqueue(RemoteBridgeMessageBuilder.message(from: thread))
+        }
+    }
+
+    private nonisolated static var homeDirectory: URL {
+        if let home = ProcessInfo.processInfo.environment["HOME"], !home.isEmpty {
+            return URL(fileURLWithPath: home, isDirectory: true)
+        }
+        return FileManager.default.homeDirectoryForCurrentUser
     }
 
     private func acceptControlConnection() {
@@ -995,6 +1026,110 @@ private struct PendingRemoteBridgeRequest {
     let clientSocket: Int32
 }
 
+private struct RemoteCodexThread: Codable, Equatable {
+    let id: String
+    let cwd: String
+    let title: String?
+    let preview: String?
+    let rolloutPath: String?
+    let source: String?
+    let threadSource: String?
+    let updatedAtMs: Int64
+}
+
+private enum RemoteCodexStatePoller {
+    static func readRecentThreads(codexHome: URL, updatedSinceMs: Int64) -> [RemoteCodexThread] {
+        guard let stateURL = newestStateDatabase(in: codexHome) else { return [] }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["python3", "-c", pythonScript, stateURL.path, String(updatedSinceMs)]
+
+        let outputPipe = Pipe()
+        process.standardOutput = outputPipe
+        process.standardError = Pipe()
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return []
+        }
+
+        guard process.terminationStatus == 0 else { return [] }
+
+        let data = outputPipe.fileHandleForReading.readDataToEndOfFile()
+        return (try? JSONDecoder().decode([RemoteCodexThread].self, from: data)) ?? []
+    }
+
+    private static func newestStateDatabase(in codexHome: URL) -> URL? {
+        let contents = (try? FileManager.default.contentsOfDirectory(
+            at: codexHome,
+            includingPropertiesForKeys: nil
+        )) ?? []
+
+        return contents
+            .compactMap(StateDatabase.init(url:))
+            .max(by: { $0.version < $1.version })?
+            .url
+    }
+
+    private static let pythonScript = #"""
+import json
+import sqlite3
+import sys
+
+db_path = sys.argv[1]
+updated_since_ms = int(sys.argv[2])
+
+query = """
+SELECT
+  id,
+  cwd,
+  NULLIF(title, '') AS title,
+  NULLIF(preview, '') AS preview,
+  NULLIF(rollout_path, '') AS rolloutPath,
+  NULLIF(source, '') AS source,
+  NULLIF(thread_source, '') AS threadSource,
+  COALESCE(updated_at_ms, updated_at * 1000, created_at_ms, created_at * 1000) AS updatedAtMs
+FROM threads
+WHERE archived = 0
+  AND cwd != ''
+  AND COALESCE(NULLIF(preview, ''), NULLIF(title, '')) IS NOT NULL
+  AND COALESCE(updated_at_ms, updated_at * 1000, created_at_ms, created_at * 1000) >= ?
+ORDER BY updatedAtMs DESC
+LIMIT 12
+"""
+
+try:
+    con = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    con.row_factory = sqlite3.Row
+    rows = con.execute(query, (updated_since_ms,)).fetchall()
+    con.close()
+    print(json.dumps([dict(row) for row in rows], ensure_ascii=False))
+except Exception:
+    print("[]")
+"""#
+}
+
+private struct StateDatabase {
+    let url: URL
+    let version: Int
+
+    init?(url: URL) {
+        let name = url.lastPathComponent
+        guard name.hasPrefix("state_"), name.hasSuffix(".sqlite") else { return nil }
+
+        let versionText = name
+            .dropFirst("state_".count)
+            .dropLast(".sqlite".count)
+        guard let version = Int(versionText) else { return nil }
+
+        self.url = url
+        self.version = version
+    }
+}
+
 private struct RemoteHookClientInfoPayload: Codable {
     let kind: String
     let profileID: String?
@@ -1054,6 +1189,10 @@ private struct RemoteDecisionEnvelope: Codable {
 }
 
 private enum RemoteBridgeMessageBuilder {
+    static func message(from thread: RemoteCodexThread) -> RemoteHookEventMessage {
+        RemoteHookEventMessage(type: "hook_event", payload: payload(from: thread))
+    }
+
     static func payload(from envelope: BridgeEnvelope) -> RemoteHookEventPayload {
         let metadata = envelope.metadata
         let toolInput = decodeToolInput(from: metadata["tool_input_json"])
@@ -1070,7 +1209,7 @@ private enum RemoteBridgeMessageBuilder {
             event: envelope.eventType,
             status: mapStatus(eventType: envelope.eventType, status: envelope.status?.kind, notificationType: metadata["notification_type"]),
             provider: envelope.provider.rawValue,
-            pid: Int(metadata["pid"] ?? "") ?? Int(getppid()) ?? Int(getppid()),
+            pid: Int(metadata["pid"] ?? "") ?? Int(getppid()),
             tty: terminalContext.tty,
             tool: normalizedToolName(metadata["tool_name"] ?? envelope.title),
             toolInput: toolInput,
@@ -1100,6 +1239,46 @@ private enum RemoteBridgeMessageBuilder {
                 tmuxSessionIdentifier: terminalContext.tmuxSession,
                 tmuxPaneIdentifier: terminalContext.tmuxPane,
                 processName: firstNonEmpty(metadata["source_process_name"], metadata["process_name"])
+            )
+        )
+    }
+
+    private static func payload(from thread: RemoteCodexThread) -> RemoteHookEventPayload {
+        let message = firstNonEmpty(thread.preview, thread.title)
+        return RemoteHookEventPayload(
+            requestID: UUID(),
+            sessionID: thread.id,
+            cwd: thread.cwd,
+            event: "RemoteCodexThreadUpdated",
+            status: "processing",
+            provider: AgentProvider.codex.rawValue,
+            pid: nil,
+            tty: nil,
+            tool: nil,
+            toolInput: nil,
+            toolUseID: nil,
+            notificationType: nil,
+            message: message,
+            expectsResponse: false,
+            clientInfo: RemoteHookClientInfoPayload(
+                kind: "codexCLI",
+                profileID: "codex-cli",
+                name: "Codex CLI",
+                bundleIdentifier: nil,
+                launchURL: nil,
+                origin: "cli",
+                originator: "Codex App",
+                threadSource: firstNonEmpty(thread.threadSource, thread.source, "app-server"),
+                transport: "ssh",
+                remoteHost: ProcessInfo.processInfo.hostName,
+                sessionFilePath: thread.rolloutPath,
+                terminalBundleIdentifier: nil,
+                terminalProgram: nil,
+                terminalSessionIdentifier: nil,
+                iTermSessionIdentifier: nil,
+                tmuxSessionIdentifier: nil,
+                tmuxPaneIdentifier: nil,
+                processName: "codex app-server"
             )
         )
     }

--- a/Prototype/Tests/IslandTests/IslandBridgeE2ETests.swift
+++ b/Prototype/Tests/IslandTests/IslandBridgeE2ETests.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import IslandShared
 @testable import IslandApp
@@ -266,4 +267,181 @@ func remoteAgentFailsOpenWhenNoControlClientIsAttached() async throws {
     #expect(response.decision == nil)
     #expect(response.updatedInput == nil)
     #expect(response.reason == nil)
+}
+
+@Test
+func remoteAgentForwardsCodexAppServerStateUpdates() async throws {
+    try await withTemporaryDirectory { directory in
+        let executable = try TestRuntime.executableURL(named: "PingIslandBridge")
+        let codexHome = directory.appending(path: ".codex")
+        try FileManager.default.createDirectory(at: codexHome, withIntermediateDirectories: true)
+        try createCodexStateDatabase(
+            at: codexHome.appending(path: "state_5.sqlite"),
+            updatedAtMs: Int64(Date().timeIntervalSince1970 * 1000)
+        )
+
+        let socketID = UUID().uuidString.prefix(8)
+        let hookSocketPath = "/tmp/pi-\(socketID)-h.sock"
+        let controlSocketPath = "/tmp/pi-\(socketID)-c.sock"
+        let service = try RunningProcess(
+            executableURL: executable,
+            arguments: [
+                "--mode", "remote-agent-service",
+                "--hook-socket", hookSocketPath,
+                "--control-socket", controlSocketPath
+            ],
+            environment: ["HOME": directory.path()]
+        )
+        defer {
+            service.terminate()
+            _ = service.waitForExit()
+            try? FileManager.default.removeItem(atPath: hookSocketPath)
+            try? FileManager.default.removeItem(atPath: controlSocketPath)
+        }
+
+        try await waitUntil(description: "remote agent service should create control socket") {
+            FileManager.default.fileExists(atPath: controlSocketPath)
+        }
+
+        let event = try await readRemoteHookEvent(
+            controlSocketPath: controlSocketPath,
+            matching: { $0.payload.sessionID == "remote-codex-thread" }
+        )
+
+        #expect(event.payload.provider == "codex")
+        #expect(event.payload.cwd == "/work/project")
+        #expect(event.payload.status == "processing")
+        #expect(event.payload.message == "Remote Codex is editing files")
+        #expect(event.payload.clientInfo.kind == "codexCLI")
+        #expect(event.payload.clientInfo.transport == "ssh")
+        #expect(event.payload.clientInfo.sessionFilePath == "/home/dev/.codex/sessions/rollout.jsonl")
+    }
+}
+
+private func createCodexStateDatabase(at url: URL, updatedAtMs: Int64) throws {
+    try runPython(
+        """
+        import sqlite3
+        con = sqlite3.connect(r'\(url.path())')
+        con.execute('''
+          CREATE TABLE threads (
+            id TEXT PRIMARY KEY,
+            rollout_path TEXT,
+            created_at INTEGER,
+            updated_at INTEGER,
+            source TEXT,
+            model_provider TEXT,
+            cwd TEXT,
+            title TEXT,
+            archived INTEGER,
+            created_at_ms INTEGER,
+            updated_at_ms INTEGER,
+            thread_source TEXT,
+            preview TEXT
+          )
+        ''')
+        con.execute("INSERT INTO threads VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", (
+          'remote-codex-thread',
+          '/home/dev/.codex/sessions/rollout.jsonl',
+          1,
+          1,
+          'vscode',
+          'codex',
+          '/work/project',
+          'Remote Codex',
+          0,
+          \(updatedAtMs),
+          \(updatedAtMs),
+          'vscode',
+          'Remote Codex is editing files'
+        ))
+        con.commit()
+        con.close()
+        """
+    )
+}
+
+private func readRemoteHookEvent(
+    controlSocketPath: String,
+    matching predicate: @escaping (TestRemoteHookEventMessage) -> Bool
+) async throws -> TestRemoteHookEventMessage {
+    let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+    guard fd >= 0 else { throw POSIXError(.EIO) }
+    defer { close(fd) }
+    _ = fcntl(fd, F_SETFL, fcntl(fd, F_GETFL, 0) | O_NONBLOCK)
+
+    var address = sockaddr_un()
+    address.sun_family = sa_family_t(AF_UNIX)
+    let utf8 = controlSocketPath.utf8CString.map(UInt8.init(bitPattern:))
+    guard utf8.count <= MemoryLayout.size(ofValue: address.sun_path) else {
+        throw POSIXError(.ENAMETOOLONG)
+    }
+    withUnsafeMutableBytes(of: &address.sun_path) { buffer in
+        buffer.copyBytes(from: utf8)
+    }
+    let connectResult = withUnsafePointer(to: &address) {
+        $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+            connect(fd, $0, socklen_t(MemoryLayout<sockaddr_un>.size))
+        }
+    }
+    guard connectResult == 0 else { throw POSIXError(.ECONNREFUSED) }
+
+    var buffer = Data()
+    var bytes = [UInt8](repeating: 0, count: 4096)
+    let decoder = JSONDecoder()
+    let deadline = ContinuousClock().now + .seconds(4)
+    while ContinuousClock().now < deadline {
+        let count = read(fd, &bytes, bytes.count)
+        if count > 0 {
+            buffer.append(bytes, count: count)
+            while let newline = buffer.firstRange(of: Data([0x0A])) {
+                let line = buffer.subdata(in: 0..<newline.lowerBound)
+                buffer.removeSubrange(0...newline.lowerBound)
+                if let event = try? decoder.decode(TestRemoteHookEventMessage.self, from: line),
+                   predicate(event) {
+                    return event
+                }
+            }
+        } else {
+            try await Task.sleep(for: .milliseconds(25))
+        }
+    }
+
+    throw TestSupportError.timedOut("remote Codex hook event")
+}
+
+private struct TestRemoteHookEventMessage: Decodable {
+    let type: String
+    let payload: TestRemoteHookEventPayload
+}
+
+private struct TestRemoteHookEventPayload: Decodable {
+    let sessionID: String
+    let cwd: String
+    let status: String
+    let provider: String
+    let message: String?
+    let clientInfo: TestRemoteHookClientInfoPayload
+}
+
+private struct TestRemoteHookClientInfoPayload: Decodable {
+    let kind: String
+    let transport: String?
+    let sessionFilePath: String?
+}
+
+private func runPython(_ script: String) throws {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+    process.arguments = ["python3", "-c", script]
+    let stderr = Pipe()
+    process.standardError = stderr
+    try process.run()
+    process.waitUntilExit()
+    guard process.terminationStatus == 0 else {
+        let message = String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        throw NSError(domain: "IslandBridgeE2ETests", code: Int(process.terminationStatus), userInfo: [
+            NSLocalizedDescriptionKey: message
+        ])
+    }
 }


### PR DESCRIPTION
## Summary

This PR restores live status visibility for Codex sessions that are running on a remote machine over SSH.

The issue was that Codex could already run remotely through the new SSH workflow, and Ping Island already had a remote bridge channel, but Codex app-server activity on the SSH target never became a session update in the local app. So after connecting to a remote host, the work was happening on the server, but the Island stayed quiet.

The fix keeps the change at the right layer: the remote `PingIslandBridge` now observes recent Codex thread activity from the remote `~/.codex/state_*.sqlite` database and forwards it through the existing remote hook event channel. The local app can then reuse the normal `HookEvent -> SessionStore -> UI` path without new UI-specific branching.

## What Changed

- Added remote Codex state polling inside `remote-agent-service`.
- Emits `RemoteCodexThreadUpdated` events for active remote Codex threads.
- Preserves useful remote session metadata, including:
  - provider: `codex`
  - transport: `ssh`
  - remote host
  - remote cwd
  - rollout/session file path
  - Codex app-server origin details
- Added an end-to-end bridge test that starts the remote agent service, creates a synthetic Codex state database, and verifies the forwarded hook event.
- Updated agent routing notes to document that remote Codex app-server state is forwarded from the SSH target.

## Notes

This intentionally avoids adding special Codex SSH handling in the app UI or `SessionStore`. The remote bridge turns remote Codex activity into the same kind of session event the app already understands, which keeps the implementation smaller and easier to maintain.

## Verification

- `swift test --package-path Prototype`
- `xcodebuild -project PingIsland.xcodeproj -scheme PingIsland -configuration Debug CODE_SIGNING_ALLOWED=NO test -only-testing:PingIslandTests`
- `xcodebuild -project PingIsland.xcodeproj -scheme PingIsland -configuration Debug CODE_SIGN_IDENTITY=- test`
- Manual remote SSH validation with the updated bridge installed on the remote host; Ping Island showed the remote Codex session as running.