### PR TITLE
[codex] Keep long session details responsive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,7 @@ This file is a routing layer for coding agents working in this repo. Keep it sho
 - If you change tmux or terminal focusing, trace through `Services/Tmux`, `Services/Window`, and `TerminalVisibilityDetector`.
 - If you change IDE terminal jump behavior, inspect both `TerminalSessionFocuser` and `IDEExtensionInstaller`, plus the integration settings UI so install state and URI schemes stay aligned.
 - If you change Codex behavior, verify both the monitor layer under `PingIsland/Services/Codex/` and the UI under `PingIsland/UI/Views/CodexSessionView.swift`.
+  - Long Codex/subagent prompts, results, tool details, and transcript rows must keep full data in `SessionStore` / snapshots and apply bounded display text only at SwiftUI rendering boundaries. Prefer `SessionTextSanitizer.boundedDisplayText` for inline `Text` / Markdown content, add or preserve tests for truncation behavior, and avoid passing unbounded transcripts directly into expanded Island detail views.
 - If you change app updates or release notes, trace through `PingIsland/Services/Update/`, `PingIsland/Info.plist`, the settings UI, and `scripts/create-release.sh` so appcast assets, runtime config, and update messaging stay aligned.
 - If you change Sparkle configuration keys or hosting assumptions, update `Config/App.xcconfig`, `Config/LocalSecrets.example.xcconfig`, `scripts/generate-keys.sh`, and `docs/sparkle-release.md` together.
 - If you change App Store distribution behavior, keep the `PingIslandAppStore` target isolated from the regular `PingIsland` Developer ID/Sparkle lane, and update `docs/mac-app-store-submission.md` plus `scripts/build-app-store.sh` together.
@@ -156,6 +157,7 @@ This file is a routing layer for coding agents working in this repo. Keep it sho
   - SwiftUI view-local `@State`
   - shared `ObservableObject` state
   - actor-owned `SessionStore` state
+- Keep localization lookups at UI or other actor-appropriate boundaries. `AppLocalization.string` is main-actor isolated on CI toolchains, so nonisolated utilities such as sanitizers, parsers, stores, and model helpers should expose localization keys or plain data instead of calling localization APIs directly.
 - When adding bundled assets or fonts, make sure app startup initializes them.
 - Keep this file high-signal. If a section becomes long, move the durable detail into a dedicated markdown doc and link it here.
 

--- a/PingIsland/Resources/en.lproj/Localizable.strings
+++ b/PingIsland/Resources/en.lproj/Localizable.strings
@@ -341,6 +341,7 @@
 "Latest thread result" = "Latest thread result";
 "Session result" = "Session result";
 "No thread details yet. Once Codex responds, the latest result will show here." = "No thread details yet. Once Codex responds, the latest result will show here.";
+"Showing a shortened preview to keep Ping Island responsive. Open the client to view the full content." = "Showing a shortened preview to keep Ping Island responsive. Open the client to view the full content.";
 "Open Claude Code in tmux to enable messaging" = "Open Claude Code in tmux to enable messaging";
 "Processing" = "Processing";
 "Working" = "Working";

--- a/PingIsland/Resources/zh-Hans.lproj/Localizable.strings
+++ b/PingIsland/Resources/zh-Hans.lproj/Localizable.strings
@@ -336,6 +336,7 @@
 "Latest thread result" = "最新线程结果";
 "Session result" = "会话结果";
 "No thread details yet. Once Codex responds, the latest result will show here." = "暂时还没有线程详情。等 Codex 回复后，最新结果会显示在这里。";
+"Showing a shortened preview to keep Ping Island responsive. Open the client to view the full content." = "为保持 Ping Island 流畅，已显示精简预览。请打开客户端查看完整内容。";
 "Open Claude Code in tmux to enable messaging" = "在 tmux 中打开 Claude Code 以启用发消息";
 "Processing" = "处理中";
 "Working" = "工作中";

--- a/PingIsland/UI/Views/ChatView.swift
+++ b/PingIsland/UI/Views/ChatView.swift
@@ -1063,6 +1063,10 @@ struct ToolCallView: View {
         tool.name == "Edit" || isExpanded
     }
 
+    private var truncationNotice: String {
+        AppLocalization.string(SessionDetailDisplayStrings.truncationNoticeKey)
+    }
+
     private var agentDescription: String? {
         guard tool.name == "AgentOutputTool",
               let agentId = tool.input["agentId"],
@@ -1070,6 +1074,14 @@ struct ToolCallView: View {
             return nil
         }
         return sessionDescriptions[agentId]
+    }
+
+    private func boundedInlineDetail(_ text: String) -> String {
+        SessionTextSanitizer.boundedDisplayText(
+            text,
+            maxCharacters: 300,
+            truncationNotice: truncationNotice
+        ) ?? text
     }
 
     var body: some View {
@@ -1084,7 +1096,7 @@ struct ToolCallView: View {
                     .fixedSize()
 
                 if tool.name == "Task" && !tool.subagentTools.isEmpty {
-                    let taskDesc = tool.input["description"] ?? AppLocalization.string("Running agent...")
+                    let taskDesc = boundedInlineDetail(tool.input["description"] ?? AppLocalization.string("Running agent..."))
                     Text(verbatim: AppLocalization.format("%@ (%lld tools)", taskDesc, tool.subagentTools.count))
                         .font(.system(size: 11))
                         .foregroundColor(textColor.opacity(0.7))
@@ -1092,7 +1104,8 @@ struct ToolCallView: View {
                         .truncationMode(.tail)
                 } else if tool.name == "AgentOutputTool", let desc = agentDescription {
                     let blocking = tool.input["block"] == "true"
-                    Text(blocking ? "Waiting: \(desc)" : desc)
+                    let detail = boundedInlineDetail(desc)
+                    Text(blocking ? "Waiting: \(detail)" : detail)
                         .font(.system(size: 11))
                         .foregroundColor(textColor.opacity(0.7))
                         .lineLimit(1)

--- a/PingIsland/UI/Views/CodexSessionView.swift
+++ b/PingIsland/UI/Views/CodexSessionView.swift
@@ -6,6 +6,15 @@ struct CodexSessionView: View {
     @ObservedObject var viewModel: NotchViewModel
     @State private var isHeaderHovered = false
 
+    private enum DisplayLimits {
+        static let titleCharacters = 300
+        static let summaryPreviewCharacters = 1_200
+    }
+
+    private var truncationNotice: String {
+        AppLocalization.string(SessionDetailDisplayStrings.truncationNoticeKey)
+    }
+
     var body: some View {
         ScrollView(.vertical, showsIndicators: false) {
             VStack(alignment: .leading, spacing: 16) {
@@ -62,9 +71,14 @@ struct CodexSessionView: View {
 
     private var summaryCard: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text(session.displayTitle)
+            Text(SessionTextSanitizer.boundedDisplayText(
+                session.displayTitle,
+                maxCharacters: DisplayLimits.titleCharacters,
+                truncationNotice: truncationNotice
+            ) ?? session.displayTitle)
                 .font(.system(size: 16, weight: .semibold))
                 .foregroundColor(.white)
+                .lineLimit(2)
 
             HStack(spacing: 8) {
                 providerBadge
@@ -93,14 +107,22 @@ struct CodexSessionView: View {
                     .lineLimit(1)
             }
 
-            if let subagentLabel = session.codexSubagentLabel {
+            if let subagentLabel = SessionTextSanitizer.boundedDisplayText(
+                session.codexSubagentLabel,
+                maxCharacters: DisplayLimits.titleCharacters,
+                truncationNotice: truncationNotice
+            ) {
                 Text(subagentLabel)
                     .font(.system(size: 11, weight: .medium, design: .monospaced))
                     .foregroundColor(.white.opacity(0.55))
                     .lineLimit(1)
             }
 
-            if let preview = session.previewText ?? session.lastMessage {
+            if let preview = SessionTextSanitizer.boundedDisplayText(
+                session.previewText ?? session.lastMessage,
+                maxCharacters: DisplayLimits.summaryPreviewCharacters,
+                truncationNotice: truncationNotice
+            ) {
                 Text(preview)
                     .font(.system(size: 13))
                     .foregroundColor(.white.opacity(0.72))
@@ -288,6 +310,11 @@ struct CodexThreadInspectorView: View {
     @State private var loadError: String?
     @FocusState private var isFollowUpFocused: Bool
 
+    private enum DisplayLimits {
+        static let primaryResultCharacters = 8_000
+        static let historyRowCharacters = 2_000
+    }
+
     private var canSendFollowUp: Bool {
         guard mode == .chat else { return false }
         guard session.phase != .ended else { return false }
@@ -302,8 +329,13 @@ struct CodexThreadInspectorView: View {
     }
 
     private var primaryResultText: String? {
-        session.codexSubagentSummaryText(
-            for: snapshot?.displayResultText ?? session.previewText ?? session.lastMessage
+        let bounded = SessionTextSanitizer.boundedDisplayText(
+            snapshot?.displayResultText ?? session.previewText ?? session.lastMessage,
+            maxCharacters: DisplayLimits.primaryResultCharacters,
+            truncationNotice: truncationNotice
+        )
+        return session.codexSubagentSummaryText(
+            for: bounded
         )
     }
 
@@ -322,6 +354,10 @@ struct CodexThreadInspectorView: View {
 
     private var bodyFontSize: CGFloat {
         CGFloat(settings.contentFontSize)
+    }
+
+    private var truncationNotice: String {
+        AppLocalization.string(SessionDetailDisplayStrings.truncationNoticeKey)
     }
 
     var body: some View {
@@ -466,14 +502,22 @@ struct CodexThreadInspectorView: View {
     private func rowContent(for item: ChatHistoryItem) -> (prefix: String, prefixColor: Color, text: String, textColor: Color) {
         switch item.type {
         case .user(let text):
-            return ("你", .white.opacity(0.72), text, .white.opacity(0.72))
+            return ("你", .white.opacity(0.72), boundedHistoryText(text), .white.opacity(0.72))
         case .assistant(let text):
-            return ("答", .white, text, .white.opacity(0.82))
+            return ("答", .white, boundedHistoryText(text), .white.opacity(0.82))
         case .thinking(let text):
-            return ("注", TerminalColors.blue.opacity(0.9), text, .white.opacity(0.58))
+            return ("注", TerminalColors.blue.opacity(0.9), boundedHistoryText(text), .white.opacity(0.58))
         case .toolCall, .interrupted:
             return ("", .clear, "", .clear)
         }
+    }
+
+    private func boundedHistoryText(_ text: String) -> String {
+        SessionTextSanitizer.boundedDisplayText(
+            text,
+            maxCharacters: DisplayLimits.historyRowCharacters,
+            truncationNotice: truncationNotice
+        ) ?? ""
     }
 
     @MainActor

--- a/PingIsland/Utilities/SessionTextSanitizer.swift
+++ b/PingIsland/Utilities/SessionTextSanitizer.swift
@@ -45,4 +45,33 @@ enum SessionTextSanitizer {
 
         return cleaned.isEmpty ? nil : cleaned
     }
+
+    static func boundedDisplayText(
+        _ text: String?,
+        maxCharacters: Int,
+        truncationNotice: String
+    ) -> String? {
+        guard let text else { return nil }
+        guard !text.isEmpty else { return nil }
+        guard maxCharacters > 0 else { return truncationNotice }
+
+        guard let cutoff = text.index(
+            text.startIndex,
+            offsetBy: maxCharacters,
+            limitedBy: text.endIndex
+        ) else {
+            return text
+        }
+
+        guard cutoff < text.endIndex else {
+            return text
+        }
+
+        let prefix = text[..<cutoff].trimmingCharacters(in: .whitespacesAndNewlines)
+        return "\(prefix)\n\n\(truncationNotice)"
+    }
+}
+
+enum SessionDetailDisplayStrings {
+    static let truncationNoticeKey = "Showing a shortened preview to keep Ping Island responsive. Open the client to view the full content."
 }

--- a/PingIslandTests/SessionStateTests.swift
+++ b/PingIslandTests/SessionStateTests.swift
@@ -185,6 +185,27 @@ final class SessionStateTests: XCTestCase {
         XCTAssertEqual(session.queueSortActivityDate, now)
     }
 
+    func testBoundedDisplayTextKeepsShortTextUnchanged() {
+        XCTAssertEqual(
+            SessionTextSanitizer.boundedDisplayText(
+                "short detail",
+                maxCharacters: 20,
+                truncationNotice: "[truncated]"
+            ),
+            "short detail"
+        )
+    }
+
+    func testBoundedDisplayTextTruncatesLongTextWithNotice() {
+        let result = SessionTextSanitizer.boundedDisplayText(
+            "abcdefghijklmnopqrstuvwxyz",
+            maxCharacters: 8,
+            truncationNotice: "[truncated]"
+        )
+
+        XCTAssertEqual(result, "abcdefgh\n\n[truncated]")
+    }
+
     func testIdleQueueSortActivityDateStillUsesLastUserMessageDateWhenPresent() {
         let now = Date()
         let lastUserMessageDate = now.addingTimeInterval(-60)


### PR DESCRIPTION
## Summary

Fixes #193.

- Add a shared bounded-display helper so very large strings are not handed directly to expanded Island rendering.
- Cap Codex detail titles, previews, primary result Markdown, and recent history rows while keeping the full session snapshot/transcript data intact.
- Cap Claude/Task subagent inline descriptions in the chat detail view so long subagent input text cannot make the Option+J panel stall while laying out a single row.
- Add focused unit coverage for the bounded text helper.

## Root Cause

Option+J opens the expanded detail UI, which could pass long subagent prompts or responses directly into SwiftUI Text and Markdown rendering. Extremely large strings made the main-thread layout/Markdown path expensive, causing the visible freeze and abnormal CPU/energy use reported in issue 193.

## Validation

- `xcodebuild -project PingIsland.xcodeproj -scheme PingIsland -configuration Debug CODE_SIGNING_ALLOWED=NO test -only-testing:PingIslandTests/SessionStateTests`

## Notes

The fix intentionally truncates only the rendered inline preview. The underlying session state, Codex snapshot, and transcript data remain complete so future flows can still access the full content.