### PR TITLE
Fix concurrent Claude AskUserQuestion handling

### DIFF
--- a/PingIsland/Models/SessionState.swift
+++ b/PingIsland/Models/SessionState.swift
@@ -52,6 +52,7 @@ struct SessionState: Equatable, Identifiable, Sendable {
     var previewText: String?
     var latestHookMessage: String?
     var intervention: SessionIntervention?
+    var pendingInterventions: [SessionIntervention]
     var codexParentThreadId: String?
     var codexSubagentDepth: Int?
     var codexSubagentNickname: String?
@@ -123,6 +124,7 @@ struct SessionState: Equatable, Identifiable, Sendable {
         previewText: String? = nil,
         latestHookMessage: String? = nil,
         intervention: SessionIntervention? = nil,
+        pendingInterventions: [SessionIntervention] = [],
         codexParentThreadId: String? = nil,
         codexSubagentDepth: Int? = nil,
         codexSubagentNickname: String? = nil,
@@ -157,6 +159,7 @@ struct SessionState: Equatable, Identifiable, Sendable {
         self.previewText = previewText
         self.latestHookMessage = latestHookMessage
         self.intervention = intervention
+        self.pendingInterventions = pendingInterventions
         self.codexParentThreadId = codexParentThreadId
         self.codexSubagentDepth = codexSubagentDepth
         self.codexSubagentNickname = codexSubagentNickname

--- a/PingIsland/Services/State/SessionStore.swift
+++ b/PingIsland/Services/State/SessionStore.swift
@@ -583,7 +583,9 @@ actor SessionStore {
         }
 
         if let intervention {
-            if session.clientInfo.brand == .qoder, intervention.kind == .question {
+            if shouldQueuePendingQuestionIntervention(intervention, in: session) {
+                enqueuePendingQuestionIntervention(intervention, in: &session)
+            } else if session.clientInfo.brand == .qoder, intervention.kind == .question {
                 session.intervention = mergedQoderQuestionIntervention(
                     current: session.intervention,
                     proposed: intervention
@@ -612,7 +614,7 @@ actor SessionStore {
         } else if shouldPreserveQoderCLIQuestionIntervention {
             session.phase = .waitingForInput
         } else if shouldClearCurrentIntervention {
-            session.intervention = nil
+            clearCurrentIntervention(in: &session, nextPhase: session.phase)
         }
 
         if event.event == "PermissionRequest", let toolUseId = event.toolUseId {
@@ -1138,6 +1140,105 @@ actor SessionStore {
         }
     }
 
+    private nonisolated func shouldQueuePendingQuestionIntervention(
+        _ intervention: SessionIntervention,
+        in session: SessionState
+    ) -> Bool {
+        intervention.kind == .question
+            && intervention.supportsInlineResponse
+            && session.clientInfo.kind == .claudeCode
+    }
+
+    private func enqueuePendingQuestionIntervention(
+        _ intervention: SessionIntervention,
+        in session: inout SessionState
+    ) {
+        if let current = session.intervention,
+           shouldQueuePendingQuestionIntervention(current, in: session),
+           !session.pendingInterventions.contains(where: { interventionsMatch($0, current) }) {
+            session.pendingInterventions.insert(current, at: 0)
+        }
+
+        if let index = session.pendingInterventions.firstIndex(where: { interventionsMatch($0, intervention) }) {
+            session.pendingInterventions[index] = intervention
+        } else {
+            session.pendingInterventions.append(intervention)
+        }
+
+        if let current = session.intervention,
+           shouldQueuePendingQuestionIntervention(current, in: session),
+           interventionsMatch(current, intervention) {
+            session.intervention = intervention
+            return
+        }
+
+        if let current = session.intervention,
+           shouldQueuePendingQuestionIntervention(current, in: session),
+           session.pendingInterventions.contains(where: { interventionsMatch($0, current) }) {
+            return
+        }
+
+        session.intervention = session.pendingInterventions.first
+    }
+
+    private func clearCurrentIntervention(
+        in session: inout SessionState,
+        nextPhase: SessionPhase
+    ) {
+        if let intervention = session.intervention {
+            removePendingIntervention(intervention, from: &session)
+        }
+
+        if let nextIntervention = session.pendingInterventions.first {
+            session.intervention = nextIntervention
+            if nextIntervention.kind == .question {
+                session.phase = .waitingForInput
+            }
+            return
+        }
+
+        session.intervention = nil
+        if session.phase.canTransition(to: nextPhase) || session.phase == nextPhase {
+            session.phase = nextPhase
+        }
+    }
+
+    private func removePendingIntervention(
+        _ intervention: SessionIntervention,
+        from session: inout SessionState
+    ) {
+        session.pendingInterventions.removeAll { queued in
+            interventionsMatch(queued, intervention)
+        }
+    }
+
+    private nonisolated func interventionsMatch(
+        _ lhs: SessionIntervention,
+        _ rhs: SessionIntervention
+    ) -> Bool {
+        if lhs.id == rhs.id {
+            return true
+        }
+
+        let lhsToolUseIds = Set(pendingHookResponseToolUseIdCandidates(for: lhs))
+        guard !lhsToolUseIds.isEmpty else { return false }
+        let rhsToolUseIds = Set(pendingHookResponseToolUseIdCandidates(for: rhs))
+        return !lhsToolUseIds.isDisjoint(with: rhsToolUseIds)
+    }
+
+    private nonisolated func pendingHookResponseToolUseIdCandidates(for intervention: SessionIntervention) -> [String] {
+        [
+            intervention.metadata["originalToolUseId"],
+            intervention.metadata["toolUseId"],
+            intervention.metadata["tool_use_id"],
+            intervention.id
+        ].compactMap { value -> String? in
+            guard let value else { return nil }
+            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        }
+    }
+
     private func pendingHookResponse(in session: SessionState) -> PendingHookResponse? {
         if let activePermission = session.activePermission,
            !activePermission.toolUseId.isEmpty {
@@ -1161,19 +1262,8 @@ actor SessionStore {
         )
     }
 
-    private func pendingHookResponseToolUseId(for intervention: SessionIntervention) -> String? {
-        [
-            intervention.metadata["originalToolUseId"],
-            intervention.metadata["toolUseId"],
-            intervention.metadata["tool_use_id"],
-            intervention.id
-        ]
-        .compactMap { value -> String? in
-            guard let value else { return nil }
-            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-            return trimmed.isEmpty ? nil : trimmed
-        }
-        .first
+    private nonisolated func pendingHookResponseToolUseId(for intervention: SessionIntervention) -> String? {
+        pendingHookResponseToolUseIdCandidates(for: intervention).first
     }
 
     private func cancelOrphanedPendingHookResponse(
@@ -1210,10 +1300,19 @@ actor SessionStore {
         guard let intervention = session.intervention,
               intervention.kind == pending.kind,
               intervention.supportsInlineResponse else {
-            return false
+            return session.pendingInterventions.contains { intervention in
+                intervention.kind == pending.kind
+                    && intervention.supportsInlineResponse
+                    && intervention.matchesResolvedToolUseId(pending.toolUseId)
+            }
         }
 
         return intervention.matchesResolvedToolUseId(pending.toolUseId)
+            || session.pendingInterventions.contains { intervention in
+                intervention.kind == pending.kind
+                    && intervention.supportsInlineResponse
+                    && intervention.matchesResolvedToolUseId(pending.toolUseId)
+            }
     }
 
     private func processSubagentTracking(event: HookEvent, session: inout SessionState) {
@@ -1617,16 +1716,14 @@ actor SessionStore {
         guard var session = sessions[sessionId] else { return }
         if let intervention = session.intervention,
            shouldAwaitExternalContinuationAfterResolving(intervention, in: session) {
+            removePendingIntervention(intervention, from: &session)
             session.intervention = intervention.markingAwaitingExternalContinuation(
                 actorName: session.interactionDisplayName,
                 selectedAnswers: submittedAnswers
             )
             session.phase = .waitingForInput
         } else {
-            session.intervention = nil
-            if session.phase.canTransition(to: nextPhase) || session.phase == nextPhase {
-                session.phase = nextPhase
-            }
+            clearCurrentIntervention(in: &session, nextPhase: nextPhase)
         }
         session.lastActivity = Date()
         sessions[sessionId] = session
@@ -2383,6 +2480,7 @@ actor SessionStore {
         let wasAlreadyEnded = session.phase == .ended
         session.phase = .ended
         session.intervention = nil
+        session.pendingInterventions.removeAll()
         session.autoApprovePermissions = false
         if !wasAlreadyEnded {
             session.lastActivity = Date()
@@ -4019,6 +4117,7 @@ actor SessionStore {
             previewText: previousSession.previewText,
             latestHookMessage: previousSession.latestHookMessage,
             intervention: previousSession.intervention,
+            pendingInterventions: previousSession.pendingInterventions,
             codexParentThreadId: previousSession.codexParentThreadId,
             codexSubagentDepth: previousSession.codexSubagentDepth,
             codexSubagentNickname: previousSession.codexSubagentNickname,

--- a/PingIslandTests/ClaudeAskUserQuestionSessionTests.swift
+++ b/PingIslandTests/ClaudeAskUserQuestionSessionTests.swift
@@ -74,6 +74,65 @@ final class ClaudeAskUserQuestionSessionTests: XCTestCase {
         await store.process(.sessionArchived(sessionId: sessionId))
     }
 
+    func testConcurrentClaudeQuestionsQueueWithoutCancellingOlderPendingHook() async {
+        let sessionId = "claude-concurrent-question-\(UUID().uuidString)"
+        let store = SessionStore.shared
+        let cancellations = CancellationRecorder()
+        await store.setPendingHookResponseCancellationHandlerForTesting { toolUseId, ingress in
+            cancellations.record(toolUseId: toolUseId, ingress: ingress)
+        }
+
+        await store.process(.hookReceived(makeClaudeQuestionEvent(
+            sessionId: sessionId,
+            toolUseId: "toolu_first_\(sessionId)",
+            questionId: "first",
+            question: "先回答第一个问题？"
+        )))
+        await store.process(.hookReceived(makeClaudeQuestionEvent(
+            sessionId: sessionId,
+            toolUseId: "toolu_second_\(sessionId)",
+            questionId: "second",
+            question: "再回答第二个问题？"
+        )))
+
+        var session = await store.session(for: sessionId)
+        XCTAssertEqual(session?.phase, .waitingForInput)
+        XCTAssertEqual(session?.intervention?.metadata["originalToolUseId"], "toolu_first_\(sessionId)")
+        XCTAssertEqual(session?.intervention?.resolvedQuestions.first?.prompt, "先回答第一个问题？")
+        XCTAssertEqual(session?.pendingInterventions.map { $0.metadata["originalToolUseId"] }, [
+            "toolu_first_\(sessionId)",
+            "toolu_second_\(sessionId)"
+        ])
+        XCTAssertFalse(cancellations.toolUseIds.contains("toolu_first_\(sessionId)"))
+
+        await store.process(
+            .interventionResolved(
+                sessionId: sessionId,
+                nextPhase: .processing,
+                submittedAnswers: ["first": ["会话层"]]
+            )
+        )
+
+        session = await store.session(for: sessionId)
+        XCTAssertEqual(session?.phase, .waitingForInput)
+        XCTAssertEqual(session?.intervention?.metadata["originalToolUseId"], "toolu_second_\(sessionId)")
+        XCTAssertEqual(session?.intervention?.resolvedQuestions.first?.prompt, "再回答第二个问题？")
+        XCTAssertEqual(session?.pendingInterventions.map { $0.metadata["originalToolUseId"] }, [
+            "toolu_second_\(sessionId)"
+        ])
+        XCTAssertFalse(cancellations.toolUseIds.contains("toolu_first_\(sessionId)"))
+
+        await store.process(
+            .interventionResolved(
+                sessionId: sessionId,
+                nextPhase: .processing,
+                submittedAnswers: ["second": ["UI 层"]]
+            )
+        )
+        await store.setPendingHookResponseCancellationHandlerForTesting(nil)
+        await store.process(.sessionArchived(sessionId: sessionId))
+    }
+
     func testQoderWorkPermissionRequestStaysNotifyOnly() async {
         let sessionId = "qoderwork-permission-\(UUID().uuidString)"
         let store = SessionStore.shared
@@ -421,7 +480,12 @@ final class ClaudeAskUserQuestionSessionTests: XCTestCase {
         await store.process(.sessionArchived(sessionId: sessionId))
     }
 
-    private func makeClaudeQuestionEvent(sessionId: String) -> HookEvent {
+    private func makeClaudeQuestionEvent(
+        sessionId: String,
+        toolUseId: String? = nil,
+        questionId: String = "project",
+        question: String = "你想先处理哪个模块？"
+    ) -> HookEvent {
         HookEvent(
             sessionId: sessionId,
             cwd: "/tmp/project",
@@ -440,9 +504,9 @@ final class ClaudeAskUserQuestionSessionTests: XCTestCase {
             toolInput: [
                 "questions": AnyCodable([
                     [
-                        "id": "project",
+                        "id": questionId,
                         "header": "方向",
-                        "question": "你想先处理哪个模块？",
+                        "question": question,
                         "options": [
                             ["label": "会话层"],
                             ["label": "UI 层"]
@@ -450,7 +514,7 @@ final class ClaudeAskUserQuestionSessionTests: XCTestCase {
                     ]
                 ])
             ],
-            toolUseId: "toolu_\(sessionId)",
+            toolUseId: toolUseId ?? "toolu_\(sessionId)",
             notificationType: nil,
             message: nil
         )
@@ -891,5 +955,22 @@ final class ClaudeAskUserQuestionSessionTests: XCTestCase {
             notificationType: nil,
             message: "使用工具问我一个问题"
         )
+    }
+}
+
+private final class CancellationRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var records: [(toolUseId: String, ingress: SessionIngress)] = []
+
+    var toolUseIds: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return records.map { $0.toolUseId }
+    }
+
+    func record(toolUseId: String, ingress: SessionIngress) {
+        lock.lock()
+        records.append((toolUseId, ingress))
+        lock.unlock()
     }
 }


### PR DESCRIPTION
## Summary
- queue concurrent inline Claude AskUserQuestion interventions per session instead of overwriting the active question
- treat queued question toolUseIds as visible pending hook responses so orphan cleanup does not close the older socket
- promote the next queued question after the current one is answered

Fixes #185

## Tests
- xcodebuild -project PingIsland.xcodeproj -scheme PingIsland -configuration Debug CODE_SIGNING_ALLOWED=NO test -only-testing:PingIslandTests/ClaudeAskUserQuestionSessionTests
- xcodebuild -project PingIsland.xcodeproj -scheme PingIsland -configuration Debug CODE_SIGNING_ALLOWED=NO test -only-testing:PingIslandTests
- git diff --check

## Notes
- The UI still renders one active question at a time; multiple pending questions are tracked and answered sequentially by toolUseId.