### PR TITLE
[codex] Surface remote Codex progress over SSH

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ This file is a routing layer for coding agents working in this repo. Keep it sho
   - Terminal focus flows currently cover iTerm2, Ghostty, Terminal.app, tmux, and IDE-hosted terminals
 - Remote SSH forwarding and remote-host management: `PingIsland/Services/Remote/`
   - Remote hosts can bootstrap a bridge on the SSH target, rewrite remote hooks, install managed plugin-directory integrations such as Hermes under the remote home directory, and attach a bidirectional forwarding channel back into PingIsland
+  - The remote bridge forwards recent Codex app-server thread activity from the SSH target's `~/.codex/state_*.sqlite` through the existing remote hook-event channel
 - Provider/client routing: bridge envelopes are normalized in `PingIsland/Services/Hooks/HookSocketServer.swift`, stored on `SessionState`, and launched via `PingIsland/Services/Window/SessionLauncher.swift`
 - Client profile registry: installable hook clients and runtime client branding / recognition are centralized in `PingIsland/Models/ClientProfile.swift`
 - VS Code-compatible IDE focus extension install / URI launch: `PingIsland/Services/Window/IDEExtensionInstaller.swift`, `PingIsland/Services/Window/TerminalSessionFocuser.swift`

--- a/Prototype/Sources/IslandBridge/main.swift
+++ b/Prototype/Sources/IslandBridge/main.swift
@@ -695,6 +695,8 @@ private final class RemoteAgentService: @unchecked Sendable {
     private var controlReadBuffer = Data()
     private var pendingRequests: [UUID: PendingRemoteBridgeRequest] = [:]
     private var queuedMessages: [Data] = []
+    private var codexStateSource: DispatchSourceTimer?
+    private var deliveredCodexThreadUpdates: [String: Int64] = [:]
     private let encoder = JSONEncoder()
     private let decoder = JSONDecoder()
 
@@ -728,6 +730,8 @@ private final class RemoteAgentService: @unchecked Sendable {
             self?.acceptControlConnection()
         }
         controlAcceptSource?.resume()
+
+        startCodexStatePolling()
     }
 
     private func makeListeningSocket(path: String) throws -> Int32 {
@@ -763,6 +767,34 @@ private final class RemoteAgentService: @unchecked Sendable {
             throw BridgeError.connectionFailed
         }
         return fd
+    }
+
+    private func startCodexStatePolling() {
+        let source = DispatchSource.makeTimerSource(queue: queue)
+        source.schedule(deadline: .now() + 1, repeating: 2)
+        source.setEventHandler { [weak self] in
+            self?.pollCodexState()
+        }
+        codexStateSource = source
+        source.resume()
+    }
+
+    private func pollCodexState() {
+        let cutoff = Int64(Date().timeIntervalSince1970 * 1000) - 15 * 60 * 1000
+        let codexHome = Self.homeDirectory.appendingPathComponent(".codex", isDirectory: true)
+        for thread in RemoteCodexStatePoller.readRecentThreads(codexHome: codexHome, updatedSinceMs: cutoff) {
+            guard thread.updatedAtMs > (deliveredCodexThreadUpdates[thread.id] ?? 0) else { continue }
+            deliveredCodexThreadUpdates[thread.id] = thread.updatedAtMs
+            enqueue(RemoteBridgeMessageBuilder.message(from: thread))
+        }
+    }
+
+    private nonisolated static var homeDirectory: URL {
+        if let home = ProcessInfo.processInfo.environment["HOME"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !home.isEmpty {
+            return URL(fileURLWithPath: home, isDirectory: true)
+        }
+        return FileManager.default.homeDirectoryForCurrentUser
     }
 
     private func acceptHookConnection() {
@@ -995,6 +1027,275 @@ private struct PendingRemoteBridgeRequest {
     let clientSocket: Int32
 }
 
+private struct RemoteCodexThread: Equatable {
+    let id: String
+    let cwd: String
+    let title: String?
+    let preview: String?
+    let rolloutPath: String?
+    let source: String?
+    let threadSource: String?
+    let updatedAtMs: Int64
+}
+
+private enum RemoteCodexStatePoller {
+    static func readRecentThreads(codexHome: URL, updatedSinceMs: Int64) -> [RemoteCodexThread] {
+        guard let stateURL = newestStateDatabase(in: codexHome),
+              let database = RemoteSQLiteDatabase.openReadOnly(path: stateURL.path) else {
+            return []
+        }
+        defer { database.close() }
+
+        let columns = database.tableColumns(named: "threads")
+        guard columns.contains("id"),
+              columns.contains("cwd"),
+              let updatedExpression = updatedAtExpression(columns: columns) else {
+            return []
+        }
+
+        let titleExpression = coalescedTextExpression(["title", "first_user_message"], columns: columns)
+        let previewExpression = nullableTextExpression("preview", columns: columns)
+        let rolloutPathExpression = nullableTextExpression("rollout_path", columns: columns)
+        let sourceExpression = nullableTextExpression("source", columns: columns)
+        let threadSourceExpression = nullableTextExpression("thread_source", columns: columns)
+        let archivedPredicate = columns.contains("archived") ? "AND COALESCE(archived, 0) = 0" : ""
+        let messagePredicate = "COALESCE(\(previewExpression), \(titleExpression)) IS NOT NULL"
+        let query = """
+        SELECT
+          id,
+          cwd,
+          \(titleExpression) AS title,
+          \(previewExpression) AS preview,
+          \(rolloutPathExpression) AS rolloutPath,
+          \(sourceExpression) AS source,
+          \(threadSourceExpression) AS threadSource,
+          \(updatedExpression) AS updatedAtMs
+        FROM threads
+        WHERE cwd != ''
+          \(archivedPredicate)
+          AND \(messagePredicate)
+          AND \(updatedExpression) >= ?
+        ORDER BY updatedAtMs DESC
+        LIMIT 12
+        """
+
+        return database.recentCodexThreads(query: query, updatedSinceMs: updatedSinceMs)
+    }
+
+    private static func newestStateDatabase(in codexHome: URL) -> URL? {
+        let contents = (try? FileManager.default.contentsOfDirectory(
+            at: codexHome,
+            includingPropertiesForKeys: nil
+        )) ?? []
+
+        return contents
+            .compactMap(CodexStateDatabase.init(url:))
+            .max(by: { $0.version < $1.version })?
+            .url
+    }
+
+    private static func updatedAtExpression(columns: Set<String>) -> String? {
+        let candidates: [String] = [
+            columns.contains("updated_at_ms") ? "updated_at_ms" : nil,
+            columns.contains("updated_at") ? "updated_at * 1000" : nil,
+            columns.contains("created_at_ms") ? "created_at_ms" : nil,
+            columns.contains("created_at") ? "created_at * 1000" : nil
+        ].compactMap { $0 }
+        guard !candidates.isEmpty else { return nil }
+        return "COALESCE(\(candidates.joined(separator: ", ")))"
+    }
+
+    private static func coalescedTextExpression(_ names: [String], columns: Set<String>) -> String {
+        let expressions = names.map { nullableTextExpression($0, columns: columns) }
+        return "COALESCE(\(expressions.joined(separator: ", ")))"
+    }
+
+    private static func nullableTextExpression(_ name: String, columns: Set<String>) -> String {
+        columns.contains(name) ? "NULLIF(\(name), '')" : "NULL"
+    }
+}
+
+private final class RemoteSQLiteDatabase {
+    fileprivate typealias SQLiteOpenV2 = @convention(c) (UnsafePointer<CChar>?, UnsafeMutablePointer<OpaquePointer?>?, Int32, UnsafePointer<CChar>?) -> Int32
+    fileprivate typealias SQLiteClose = @convention(c) (OpaquePointer?) -> Int32
+    fileprivate typealias SQLitePrepareV2 = @convention(c) (OpaquePointer?, UnsafePointer<CChar>?, Int32, UnsafeMutablePointer<OpaquePointer?>?, UnsafeMutablePointer<UnsafePointer<CChar>?>?) -> Int32
+    fileprivate typealias SQLiteStep = @convention(c) (OpaquePointer?) -> Int32
+    fileprivate typealias SQLiteFinalize = @convention(c) (OpaquePointer?) -> Int32
+    fileprivate typealias SQLiteColumnText = @convention(c) (OpaquePointer?, Int32) -> UnsafePointer<UInt8>?
+    fileprivate typealias SQLiteColumnInt64 = @convention(c) (OpaquePointer?, Int32) -> Int64
+    fileprivate typealias SQLiteBindInt64 = @convention(c) (OpaquePointer?, Int32, Int64) -> Int32
+
+    private static let sqliteOpenReadonly: Int32 = 0x00000001
+    private static let sqliteRow: Int32 = 100
+
+    private let handle: OpaquePointer?
+    private let symbols: RemoteSQLiteSymbols
+
+    private init(handle: OpaquePointer?, symbols: RemoteSQLiteSymbols) {
+        self.handle = handle
+        self.symbols = symbols
+    }
+
+    static func openReadOnly(path: String) -> RemoteSQLiteDatabase? {
+        guard let symbols = RemoteSQLiteSymbols.load() else { return nil }
+        var handle: OpaquePointer?
+        let result = path.withCString { pathPointer in
+            symbols.openV2(pathPointer, &handle, sqliteOpenReadonly, nil)
+        }
+        guard result == 0 else {
+            if handle != nil {
+                _ = symbols.close(handle)
+            }
+            return nil
+        }
+        return RemoteSQLiteDatabase(handle: handle, symbols: symbols)
+    }
+
+    func close() {
+        _ = symbols.close(handle)
+    }
+
+    func tableColumns(named tableName: String) -> Set<String> {
+        guard tableName.range(of: #"^[A-Za-z_][A-Za-z0-9_]*$"#, options: .regularExpression) != nil else {
+            return []
+        }
+
+        var statement: OpaquePointer?
+        guard prepare("PRAGMA table_info(\(tableName))", statement: &statement) else { return [] }
+        defer { _ = symbols.finalize(statement) }
+
+        var columns = Set<String>()
+        while symbols.step(statement) == Self.sqliteRow {
+            if let name = textColumn(statement, 1) {
+                columns.insert(name)
+            }
+        }
+        return columns
+    }
+
+    func recentCodexThreads(query: String, updatedSinceMs: Int64) -> [RemoteCodexThread] {
+        var statement: OpaquePointer?
+        guard prepare(query, statement: &statement) else { return [] }
+        defer { _ = symbols.finalize(statement) }
+
+        guard symbols.bindInt64(statement, 1, updatedSinceMs) == 0 else { return [] }
+
+        var threads: [RemoteCodexThread] = []
+        while symbols.step(statement) == Self.sqliteRow {
+            guard let id = textColumn(statement, 0),
+                  let cwd = textColumn(statement, 1),
+                  !id.isEmpty,
+                  !cwd.isEmpty else {
+                continue
+            }
+
+            threads.append(RemoteCodexThread(
+                id: id,
+                cwd: cwd,
+                title: textColumn(statement, 2),
+                preview: textColumn(statement, 3),
+                rolloutPath: textColumn(statement, 4),
+                source: textColumn(statement, 5),
+                threadSource: textColumn(statement, 6),
+                updatedAtMs: symbols.columnInt64(statement, 7)
+            ))
+        }
+        return threads
+    }
+
+    private func prepare(_ sql: String, statement: UnsafeMutablePointer<OpaquePointer?>) -> Bool {
+        sql.withCString { sqlPointer in
+            symbols.prepareV2(handle, sqlPointer, -1, statement, nil) == 0
+        }
+    }
+
+    private func textColumn(_ statement: OpaquePointer?, _ index: Int32) -> String? {
+        guard let text = symbols.columnText(statement, index) else { return nil }
+        let value = String(cString: UnsafeRawPointer(text).assumingMemoryBound(to: CChar.self))
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : value
+    }
+}
+
+private struct RemoteSQLiteSymbols: @unchecked Sendable {
+    // Keep the dlopen handle alive for the lifetime of the cached C symbols.
+    let library: UnsafeMutableRawPointer
+    let openV2: RemoteSQLiteDatabase.SQLiteOpenV2
+    let close: RemoteSQLiteDatabase.SQLiteClose
+    let prepareV2: RemoteSQLiteDatabase.SQLitePrepareV2
+    let step: RemoteSQLiteDatabase.SQLiteStep
+    let finalize: RemoteSQLiteDatabase.SQLiteFinalize
+    let columnText: RemoteSQLiteDatabase.SQLiteColumnText
+    let columnInt64: RemoteSQLiteDatabase.SQLiteColumnInt64
+    let bindInt64: RemoteSQLiteDatabase.SQLiteBindInt64
+
+    static func load() -> RemoteSQLiteSymbols? {
+        cached
+    }
+
+    private static let cached: RemoteSQLiteSymbols? = loadUncached()
+
+    private static func loadUncached() -> RemoteSQLiteSymbols? {
+        for name in libraryNames {
+            guard let library = dlopen(name, RTLD_NOW | RTLD_LOCAL),
+                  let openV2: RemoteSQLiteDatabase.SQLiteOpenV2 = symbol("sqlite3_open_v2", in: library),
+                  let close: RemoteSQLiteDatabase.SQLiteClose = symbol("sqlite3_close", in: library),
+                  let prepareV2: RemoteSQLiteDatabase.SQLitePrepareV2 = symbol("sqlite3_prepare_v2", in: library),
+                  let step: RemoteSQLiteDatabase.SQLiteStep = symbol("sqlite3_step", in: library),
+                  let finalize: RemoteSQLiteDatabase.SQLiteFinalize = symbol("sqlite3_finalize", in: library),
+                  let columnText: RemoteSQLiteDatabase.SQLiteColumnText = symbol("sqlite3_column_text", in: library),
+                  let columnInt64: RemoteSQLiteDatabase.SQLiteColumnInt64 = symbol("sqlite3_column_int64", in: library),
+                  let bindInt64: RemoteSQLiteDatabase.SQLiteBindInt64 = symbol("sqlite3_bind_int64", in: library) else {
+                continue
+            }
+
+            return RemoteSQLiteSymbols(
+                library: library,
+                openV2: openV2,
+                close: close,
+                prepareV2: prepareV2,
+                step: step,
+                finalize: finalize,
+                columnText: columnText,
+                columnInt64: columnInt64,
+                bindInt64: bindInt64
+            )
+        }
+        return nil
+    }
+
+    private static var libraryNames: [String] {
+        #if canImport(Darwin)
+        ["/usr/lib/libsqlite3.dylib", "libsqlite3.dylib"]
+        #else
+        ["libsqlite3.so.0", "libsqlite3.so"]
+        #endif
+    }
+
+    private static func symbol<T>(_ name: String, in library: UnsafeMutableRawPointer) -> T? {
+        guard let pointer = dlsym(library, name) else { return nil }
+        return unsafeBitCast(pointer, to: T.self)
+    }
+}
+
+private struct CodexStateDatabase {
+    let url: URL
+    let version: Int
+
+    init?(url: URL) {
+        let name = url.lastPathComponent
+        guard name.hasPrefix("state_"), name.hasSuffix(".sqlite") else { return nil }
+
+        let versionText = name
+            .dropFirst("state_".count)
+            .dropLast(".sqlite".count)
+        guard let version = Int(versionText) else { return nil }
+
+        self.url = url
+        self.version = version
+    }
+}
+
 private struct RemoteHookClientInfoPayload: Codable {
     let kind: String
     let profileID: String?
@@ -1054,6 +1355,10 @@ private struct RemoteDecisionEnvelope: Codable {
 }
 
 private enum RemoteBridgeMessageBuilder {
+    static func message(from thread: RemoteCodexThread) -> RemoteHookEventMessage {
+        RemoteHookEventMessage(type: "hook_event", payload: payload(from: thread))
+    }
+
     static func payload(from envelope: BridgeEnvelope) -> RemoteHookEventPayload {
         let metadata = envelope.metadata
         let toolInput = decodeToolInput(from: metadata["tool_input_json"])
@@ -1070,7 +1375,7 @@ private enum RemoteBridgeMessageBuilder {
             event: envelope.eventType,
             status: mapStatus(eventType: envelope.eventType, status: envelope.status?.kind, notificationType: metadata["notification_type"]),
             provider: envelope.provider.rawValue,
-            pid: Int(metadata["pid"] ?? "") ?? Int(getppid()) ?? Int(getppid()),
+            pid: Int(metadata["pid"] ?? "") ?? Int(getppid()),
             tty: terminalContext.tty,
             tool: normalizedToolName(metadata["tool_name"] ?? envelope.title),
             toolInput: toolInput,
@@ -1100,6 +1405,46 @@ private enum RemoteBridgeMessageBuilder {
                 tmuxSessionIdentifier: terminalContext.tmuxSession,
                 tmuxPaneIdentifier: terminalContext.tmuxPane,
                 processName: firstNonEmpty(metadata["source_process_name"], metadata["process_name"])
+            )
+        )
+    }
+
+    private static func payload(from thread: RemoteCodexThread) -> RemoteHookEventPayload {
+        let message = firstNonEmpty(thread.preview, thread.title)
+        return RemoteHookEventPayload(
+            requestID: UUID(),
+            sessionID: thread.id,
+            cwd: thread.cwd,
+            event: "RemoteCodexThreadUpdated",
+            status: "processing",
+            provider: AgentProvider.codex.rawValue,
+            pid: nil,
+            tty: nil,
+            tool: nil,
+            toolInput: nil,
+            toolUseID: nil,
+            notificationType: nil,
+            message: message,
+            expectsResponse: false,
+            clientInfo: RemoteHookClientInfoPayload(
+                kind: "codexCLI",
+                profileID: "codex-cli",
+                name: "Codex CLI",
+                bundleIdentifier: nil,
+                launchURL: nil,
+                origin: "cli",
+                originator: "Codex App",
+                threadSource: firstNonEmpty(thread.threadSource, thread.source, "app-server"),
+                transport: "ssh",
+                remoteHost: ProcessInfo.processInfo.hostName,
+                sessionFilePath: thread.rolloutPath,
+                terminalBundleIdentifier: nil,
+                terminalProgram: nil,
+                terminalSessionIdentifier: nil,
+                iTermSessionIdentifier: nil,
+                tmuxSessionIdentifier: nil,
+                tmuxPaneIdentifier: nil,
+                processName: "codex app-server"
             )
         )
     }

--- a/Prototype/Tests/IslandTests/IslandBridgeE2ETests.swift
+++ b/Prototype/Tests/IslandTests/IslandBridgeE2ETests.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import IslandShared
 @testable import IslandApp
@@ -266,4 +267,177 @@ func remoteAgentFailsOpenWhenNoControlClientIsAttached() async throws {
     #expect(response.decision == nil)
     #expect(response.updatedInput == nil)
     #expect(response.reason == nil)
+}
+
+@Test
+func remoteAgentForwardsCodexAppServerStateUpdates() async throws {
+    try await withTemporaryDirectory { directory in
+        let executable = try TestRuntime.executableURL(named: "PingIslandBridge")
+        let codexHome = directory.appending(path: ".codex", directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(at: codexHome, withIntermediateDirectories: true)
+        try createCodexStateDatabase(
+            at: codexHome.appending(path: "state_5.sqlite"),
+            updatedAtMs: Int64(Date().timeIntervalSince1970 * 1000)
+        )
+
+        let socketID = UUID().uuidString.prefix(8)
+        let hookSocketPath = "/tmp/pi-\(socketID)-h.sock"
+        let controlSocketPath = "/tmp/pi-\(socketID)-c.sock"
+        let service = try RunningProcess(
+            executableURL: executable,
+            arguments: [
+                "--mode", "remote-agent-service",
+                "--hook-socket", hookSocketPath,
+                "--control-socket", controlSocketPath
+            ],
+            environment: ["HOME": directory.path()]
+        )
+        defer {
+            service.terminate()
+            _ = service.waitForExit()
+            try? FileManager.default.removeItem(atPath: hookSocketPath)
+            try? FileManager.default.removeItem(atPath: controlSocketPath)
+        }
+
+        try await waitUntil(description: "remote agent service should create control socket") {
+            FileManager.default.fileExists(atPath: controlSocketPath)
+        }
+
+        let event = try await readRemoteHookEvent(
+            controlSocketPath: controlSocketPath,
+            matching: { $0.payload.sessionID == "remote-codex-thread" }
+        )
+
+        #expect(event.type == "hook_event")
+        #expect(event.payload.provider == "codex")
+        #expect(event.payload.cwd == "/work/project")
+        #expect(event.payload.status == "processing")
+        #expect(event.payload.message == "Remote Codex is editing files")
+        #expect(event.payload.clientInfo.kind == "codexCLI")
+        #expect(event.payload.clientInfo.transport == "ssh")
+        #expect(event.payload.clientInfo.sessionFilePath == "/home/dev/.codex/sessions/rollout.jsonl")
+    }
+}
+
+private func createCodexStateDatabase(at url: URL, updatedAtMs: Int64) throws {
+    try runSQLite(
+        databaseURL: url,
+        sql: """
+        CREATE TABLE threads (
+          id TEXT PRIMARY KEY,
+          rollout_path TEXT,
+          created_at INTEGER,
+          updated_at INTEGER,
+          source TEXT,
+          model_provider TEXT,
+          cwd TEXT,
+          title TEXT,
+          archived INTEGER,
+          created_at_ms INTEGER,
+          updated_at_ms INTEGER,
+          thread_source TEXT,
+          preview TEXT
+        );
+        INSERT INTO threads VALUES (
+          'remote-codex-thread',
+          '/home/dev/.codex/sessions/rollout.jsonl',
+          1,
+          1,
+          'vscode',
+          'codex',
+          '/work/project',
+          'Remote Codex',
+          0,
+          \(updatedAtMs),
+          \(updatedAtMs),
+          'vscode',
+          'Remote Codex is editing files'
+        );
+        """
+    )
+}
+
+private func readRemoteHookEvent(
+    controlSocketPath: String,
+    matching predicate: @escaping (TestRemoteHookEventMessage) -> Bool
+) async throws -> TestRemoteHookEventMessage {
+    let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+    guard fd >= 0 else { throw POSIXError(.EIO) }
+    defer { close(fd) }
+    _ = fcntl(fd, F_SETFL, fcntl(fd, F_GETFL, 0) | O_NONBLOCK)
+
+    var address = sockaddr_un()
+    address.sun_family = sa_family_t(AF_UNIX)
+    let utf8 = controlSocketPath.utf8CString.map(UInt8.init(bitPattern:))
+    guard utf8.count <= MemoryLayout.size(ofValue: address.sun_path) else {
+        throw POSIXError(.ENAMETOOLONG)
+    }
+    withUnsafeMutableBytes(of: &address.sun_path) { buffer in
+        buffer.copyBytes(from: utf8)
+    }
+    let connectResult = withUnsafePointer(to: &address) {
+        $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+            connect(fd, $0, socklen_t(MemoryLayout<sockaddr_un>.size))
+        }
+    }
+    guard connectResult == 0 else { throw POSIXError(.ECONNREFUSED) }
+
+    let decoder = JSONDecoder()
+    var buffer = Data()
+    var bytes = [UInt8](repeating: 0, count: 4096)
+    let deadline = ContinuousClock().now + .seconds(4)
+    while ContinuousClock().now < deadline {
+        let count = read(fd, &bytes, bytes.count)
+        if count > 0 {
+            buffer.append(bytes, count: count)
+            while let newline = buffer.firstRange(of: Data([0x0A])) {
+                let line = buffer.subdata(in: 0..<newline.lowerBound)
+                buffer.removeSubrange(0...newline.lowerBound)
+                if let event = try? decoder.decode(TestRemoteHookEventMessage.self, from: line),
+                   predicate(event) {
+                    return event
+                }
+            }
+        } else {
+            try await Task.sleep(for: .milliseconds(25))
+        }
+    }
+
+    throw TestSupportError.timedOut("remote Codex hook event")
+}
+
+private struct TestRemoteHookEventMessage: Decodable {
+    let type: String
+    let payload: TestRemoteHookEventPayload
+}
+
+private struct TestRemoteHookEventPayload: Decodable {
+    let sessionID: String
+    let cwd: String
+    let status: String
+    let provider: String
+    let message: String?
+    let clientInfo: TestRemoteHookClientInfoPayload
+}
+
+private struct TestRemoteHookClientInfoPayload: Decodable {
+    let kind: String
+    let transport: String?
+    let sessionFilePath: String?
+}
+
+private func runSQLite(databaseURL: URL, sql: String) throws {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+    process.arguments = ["sqlite3", databaseURL.path(), sql]
+    let stderr = Pipe()
+    process.standardError = stderr
+    try process.run()
+    process.waitUntilExit()
+    guard process.terminationStatus == 0 else {
+        let message = String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        throw NSError(domain: "IslandBridgeE2ETests", code: Int(process.terminationStatus), userInfo: [
+            NSLocalizedDescriptionKey: message
+        ])
+    }
 }

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Ping Island focuses on the moments that actually interrupt coding flow, then kee
 - **Act from the notch** - Approve tools, deny requests, and answer follow-up prompts without hunting through tabs.
 - **Claude Code auto-approve** - Turn on per-session auto-approval when you want Claude Code to stop pausing on every permission request.
 - **One-click return** - Jump back to the right iTerm2, Ghostty, Terminal.app, tmux pane, or IDE window.
-- **SSH terminal support** - Bootstrap a remote PingIslandBridge over SSH, rewrite the remote Claude-compatible hooks to point back at your Mac, and keep remote terminal activity visible in the same local Island UI.
+- **SSH terminal support** - Bootstrap a remote PingIslandBridge over SSH, rewrite remote hooks to point back at your Mac, forward remote Codex app-server activity, and keep remote terminal activity visible in the same local Island UI.
 - **Multi-agent coverage** - Track Claude Code, Codex, Gemini CLI, Hermes Agent, Qwen Code, Kimi CLI, OpenClaw, OpenCode, Cursor, Qoder, CodeBuddy, WorkBuddy, GitHub Copilot, and other compatible sessions in one place.
 - **OpenClaw gateway support** - Follow OpenClaw sessions from managed internal hooks, then refill the conversation from OpenClaw's local session transcripts so the Island UI can show the actual back-and-forth instead of a single inbound message.
 - **Codex hook + app-server sync** - Support Codex CLI hooks, live app-server threads, and rollout parsing fallback when needed.
@@ -119,7 +119,7 @@ Kimi CLI is supported through its official hooks in `~/.kimi/config.toml`. Ping 
 
 OpenClaw is supported through a managed internal hook directory under `~/.openclaw/hooks/` plus transcript-aware session refresh from `~/.openclaw/agents/main/sessions/`. That combination lets Ping Island surface OpenClaw's lightweight message hooks quickly, then backfill the full conversation from the local session log once the assistant reply lands.
 
-SSH support is a core workflow, not a sidecar script. Ping Island can bootstrap a bridge onto a remote macOS or Linux host, rewrite remote Claude-compatible and Qwen Code hook configs to use that bridge, install supported OpenClaw internal hooks on the remote host, and keep a bidirectional forwarding path back into the local menu-bar UI. That means approvals, follow-up questions, notifications, and jump-back routing from remote SSH terminals still land in the same Island surface on your Mac.
+SSH support is a core workflow, not a sidecar script. Ping Island can bootstrap a bridge onto a remote macOS or Linux host, rewrite remote Claude-compatible and Qwen Code hook configs to use that bridge, install supported OpenClaw internal hooks on the remote host, forward recent remote Codex app-server thread activity, and keep a bidirectional forwarding path back into the local menu-bar UI. That means approvals, follow-up questions, notifications, Codex progress, and jump-back routing from remote SSH terminals still land in the same Island surface on your Mac.
 
 The mascot GIFs used throughout this README are generated from the live `MascotView` implementation via `./scripts/render-mascots.sh`.
 The OpenClaw feature poster in `docs/images/ping-island-openclaw-poster.png` is generated via `./scripts/render-openclaw-poster.sh`.


### PR DESCRIPTION
## Summary

This follows the direction from #184 and keeps the same product outcome: SSH remote Codex sessions now show progress in the local Island UI even when the remote Codex app-server updates `~/.codex/state_*.sqlite` without emitting hook traffic.

Instead of shelling out to `python3` on the remote host, the remote bridge loads SQLite directly and polls recent Codex threads from the newest state database. Matching thread updates are forwarded through the existing remote hook-event channel as Codex CLI sessions, so the local app does not need a separate remote-Codex UI path.

## Changes

- Start a lightweight Codex state poller in `PingIslandBridge --mode remote-agent-service`.
- Read recent non-archived Codex threads from the remote `~/.codex/state_*.sqlite` using dynamically loaded `libsqlite3`.
- Forward thread activity as `RemoteCodexThreadUpdated` hook-event payloads with SSH client metadata and rollout path.
- Add an E2E test that boots the remote agent, writes a synthetic Codex state DB, and verifies the forwarded control-channel event.
- Update README and AGENTS guidance for SSH remote Codex forwarding.

## Why

Remote SSH Codex usage can otherwise feel invisible: the bridge forwards hook traffic well, but app-server-backed Codex activity may only update the state database on the SSH target. Polling that database from the already-running remote bridge lets Ping Island surface Codex progress without requiring the user to babysit the remote terminal.

## Related

- Related to #184
- Keeps the #184 behavior, but avoids a remote `python3` runtime dependency.

## Verification

- `swift test --package-path Prototype`
- `swift test --package-path Prototype --filter remoteAgentForwardsCodexAppServerStateUpdates`
- `xcodebuild -project PingIsland.xcodeproj -scheme PingIsland -configuration Debug CODE_SIGNING_ALLOWED=NO test -only-testing:PingIslandTests`
- `git diff --check`

## Not tested

- Live SSH host with Codex app-server running against a real remote `~/.codex/state_*.sqlite`.
