### PR TITLE
fix(codex): suppress approval cards when approvalPolicy is "never"

### DIFF
--- a/PingIsland/Services/Codex/CodexAppServerMonitor.swift
+++ b/PingIsland/Services/Codex/CodexAppServerMonitor.swift
@@ -649,26 +649,13 @@ actor CodexAppServerMonitor {
             return nil
         }
 
-        // 1. Check per-thread heartbeat permissions (most authoritative).
+        // Check per-thread heartbeat permissions (most authoritative for Desktop threads).
+        // CLI-only sessions (e.g. agentloop) are not present here; their approval policy
+        // is signalled by permission_mode=bypassPermissions in the hook payload instead.
         if let permsMap = atomState["heartbeat-thread-permissions-by-id"] as? [String: Any],
            let entry = permsMap[threadId] as? [String: Any],
            let policy = entry["approvalPolicy"] as? String {
             return policy
-        }
-
-        // 2. Fall back to the global default agent mode.
-        // New threads inherit the global mode before the first heartbeat writes their
-        // per-thread entry. "full-access" in the UI corresponds to approvalPolicy "never".
-        if let agentModeMap = atomState["agent-mode-by-host-id"] as? [String: Any],
-           let globalMode = agentModeMap["local"] as? String {
-            switch globalMode {
-            case "full-access":
-                return "never"
-            case "guardian-approvals":
-                return "untrusted"
-            default:
-                return nil
-            }
         }
 
         return nil

--- a/PingIsland/Services/Codex/CodexAppServerMonitor.swift
+++ b/PingIsland/Services/Codex/CodexAppServerMonitor.swift
@@ -622,14 +622,15 @@ actor CodexAppServerMonitor {
     // MARK: - Codex approval-policy helpers
 
     /// Returns `true` if the thread's approval policy is "never", meaning
-    /// Returns `true` if the thread's approval policy is "never", meaning
-    /// Codex auto-approves without waiting for our response.
+    /// Codex auto-approves WebSocket approval requests without waiting for our response.
+    ///
+    /// Used for the WebSocket path (`item/*/requestApproval`).  The hook-based path
+    /// uses `codexBypassPermissions` on the `HookEvent` instead, which is populated
+    /// directly from `permission_mode=bypassPermissions` in the hook payload.
     ///
     /// Lookup order:
-    /// 1. In-memory cache populated from app-server thread data.
-    /// 2. `~/.codex/.codex-global-state.json` — per-thread entry, then global
-    ///    agent-mode default (new threads inherit the global mode before their
-    ///    first heartbeat write).
+    /// 1. In-memory cache populated from WebSocket thread list / thread/read responses.
+    /// 2. `~/.codex/.codex-global-state.json` — per-thread heartbeat entry only.
     private func isAutoApproveThread(_ threadId: String) -> Bool {
         if let cached = threadApprovalModes[threadId] {
             return cached == "never"

--- a/PingIsland/Services/Codex/CodexAppServerMonitor.swift
+++ b/PingIsland/Services/Codex/CodexAppServerMonitor.swift
@@ -49,6 +49,7 @@ actor CodexAppServerMonitor {
     private var requestSequence = 0
     private var pendingResponses: [String: CheckedContinuation<[String: Any], Error>] = [:]
     private var pendingRequestsByThread: [String: PendingRequest] = [:]
+    private var threadApprovalModes: [String: String] = [:]  // threadId → approvalMode
     private var resolvedClientBundleIdentifier: String?
     private var resolvedClientName: String?
     private var lastThreadDiagnostics: [ThreadDiagnosticsSnapshot] = []
@@ -108,6 +109,7 @@ actor CodexAppServerMonitor {
         process?.terminate()
         process = nil
         pendingRequestsByThread.removeAll()
+        threadApprovalModes.removeAll()
         lastThreadDiagnostics.removeAll()
 
         for (_, continuation) in pendingResponses {
@@ -619,10 +621,24 @@ actor CodexAppServerMonitor {
 
     // MARK: - Codex approval-policy helpers
 
-    /// Returns `true` if the thread's persisted approval policy is "never",
-    /// meaning Codex will auto-approve the request without waiting for our
-    /// response. We mirror that auto-approval so no blocking card appears.
-    nonisolated static func threadIsAutoApprove(_ threadId: String) -> Bool {
+    /// Returns `true` if the thread's approval policy is "never", meaning
+    /// Codex auto-approves without waiting for our response.
+    ///
+    /// Lookup order:
+    /// 1. In-memory cache populated from app-server thread data (most reliable,
+    ///    available as soon as the thread is ingested).
+    /// 2. `~/.codex/.codex-global-state.json` persisted by Codex Desktop
+    ///    (fallback for threads whose policy was set after last ingestion).
+    private func isAutoApproveThread(_ threadId: String) -> Bool {
+        // 1. Check in-memory cache first.
+        if let cached = threadApprovalModes[threadId] {
+            return cached == "never"
+        }
+        // 2. Fall back to reading the Codex global state file.
+        return Self.approvalPolicyFromGlobalState(threadId: threadId) == "never"
+    }
+
+    nonisolated static func approvalPolicyFromGlobalState(threadId: String) -> String? {
         guard
             let data = try? Data(contentsOf: URL(
                 fileURLWithPath: NSHomeDirectory()
@@ -631,12 +647,11 @@ actor CodexAppServerMonitor {
             let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
             let atomState = root["electron-persisted-atom-state"] as? [String: Any],
             let permsMap = atomState["heartbeat-thread-permissions-by-id"] as? [String: Any],
-            let entry = permsMap[threadId] as? [String: Any],
-            let policy = entry["approvalPolicy"] as? String
+            let entry = permsMap[threadId] as? [String: Any]
         else {
-            return false
+            return nil
         }
-        return policy == "never"
+        return entry["approvalPolicy"] as? String
     }
 
     private func handleServerRequest(id: String, method: String, params: [String: Any]) async {
@@ -647,7 +662,7 @@ actor CodexAppServerMonitor {
 
             let command = ((params["command"] as? [String]) ?? []).joined(separator: " ")
 
-            if Self.threadIsAutoApprove(threadId) {
+            if isAutoApproveThread(threadId) {
                 await sendResponse(id: id, result: ["decision": "accept"])
                 return
             }
@@ -695,7 +710,7 @@ actor CodexAppServerMonitor {
             let reason = params["reason"] as? String
             let grantRoot = params["grantRoot"] as? String
 
-            if Self.threadIsAutoApprove(threadId) {
+            if isAutoApproveThread(threadId) {
                 await sendResponse(id: id, result: ["decision": "accept"])
                 return
             }
@@ -741,7 +756,7 @@ actor CodexAppServerMonitor {
             let reason = params["reason"] as? String
             let message = reason ?? permissionSummary(permissions)
 
-            if Self.threadIsAutoApprove(threadId) {
+            if isAutoApproveThread(threadId) {
                 await sendResponse(id: id, result: [
                     "permissions": permissions,
                     "scope": "session"
@@ -893,6 +908,11 @@ actor CodexAppServerMonitor {
 
     private func ingestThread(_ thread: [String: Any]) async {
         guard let threadId = thread["id"] as? String else { return }
+        // Cache approvalMode from app-server data so approval-policy checks
+        // don't have to re-read the global state file on every request.
+        if let mode = thread["approvalMode"] as? String ?? thread["approval_mode"] as? String {
+            threadApprovalModes[threadId] = mode
+        }
         let name = thread["name"] as? String
         let preview = thread["preview"] as? String
         let cwd = thread["cwd"] as? String
@@ -993,6 +1013,13 @@ actor CodexAppServerMonitor {
 
     private func parseThreadSnapshot(_ thread: [String: Any]) -> CodexThreadSnapshot? {
         guard let threadId = thread["id"] as? String else { return nil }
+
+        // Keep the approval-mode cache fresh: thread/read and thread/list both
+        // call this path, so any policy change made in Codex Desktop will be
+        // reflected within the next polling cycle (≤ 30 s).
+        if let mode = thread["approvalMode"] as? String ?? thread["approval_mode"] as? String {
+            threadApprovalModes[threadId] = mode
+        }
 
         let createdAt = date(fromUnixTimestamp: thread["createdAt"]) ?? Date()
         let updatedAt = date(fromUnixTimestamp: thread["updatedAt"]) ?? createdAt

--- a/PingIsland/Services/Codex/CodexAppServerMonitor.swift
+++ b/PingIsland/Services/Codex/CodexAppServerMonitor.swift
@@ -505,7 +505,7 @@ actor CodexAppServerMonitor {
         }
 
         if let method = json["method"] as? String {
-            if let idValue = json["id"] {
+            if let idValue = json["id"], !(idValue is NSNull) {
                 await handleServerRequest(
                     id: stringify(idValue),
                     method: method,
@@ -622,19 +622,18 @@ actor CodexAppServerMonitor {
     // MARK: - Codex approval-policy helpers
 
     /// Returns `true` if the thread's approval policy is "never", meaning
+    /// Returns `true` if the thread's approval policy is "never", meaning
     /// Codex auto-approves without waiting for our response.
     ///
     /// Lookup order:
-    /// 1. In-memory cache populated from app-server thread data (most reliable,
-    ///    available as soon as the thread is ingested).
-    /// 2. `~/.codex/.codex-global-state.json` persisted by Codex Desktop
-    ///    (fallback for threads whose policy was set after last ingestion).
+    /// 1. In-memory cache populated from app-server thread data.
+    /// 2. `~/.codex/.codex-global-state.json` — per-thread entry, then global
+    ///    agent-mode default (new threads inherit the global mode before their
+    ///    first heartbeat write).
     private func isAutoApproveThread(_ threadId: String) -> Bool {
-        // 1. Check in-memory cache first.
         if let cached = threadApprovalModes[threadId] {
             return cached == "never"
         }
-        // 2. Fall back to reading the Codex global state file.
         return Self.approvalPolicyFromGlobalState(threadId: threadId) == "never"
     }
 
@@ -645,13 +644,34 @@ actor CodexAppServerMonitor {
                     .appending("/.codex/.codex-global-state.json")
             )),
             let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let atomState = root["electron-persisted-atom-state"] as? [String: Any],
-            let permsMap = atomState["heartbeat-thread-permissions-by-id"] as? [String: Any],
-            let entry = permsMap[threadId] as? [String: Any]
+            let atomState = root["electron-persisted-atom-state"] as? [String: Any]
         else {
             return nil
         }
-        return entry["approvalPolicy"] as? String
+
+        // 1. Check per-thread heartbeat permissions (most authoritative).
+        if let permsMap = atomState["heartbeat-thread-permissions-by-id"] as? [String: Any],
+           let entry = permsMap[threadId] as? [String: Any],
+           let policy = entry["approvalPolicy"] as? String {
+            return policy
+        }
+
+        // 2. Fall back to the global default agent mode.
+        // New threads inherit the global mode before the first heartbeat writes their
+        // per-thread entry. "full-access" in the UI corresponds to approvalPolicy "never".
+        if let agentModeMap = atomState["agent-mode-by-host-id"] as? [String: Any],
+           let globalMode = agentModeMap["local"] as? String {
+            switch globalMode {
+            case "full-access":
+                return "never"
+            case "guardian-approvals":
+                return "untrusted"
+            default:
+                return nil
+            }
+        }
+
+        return nil
     }
 
     private func handleServerRequest(id: String, method: String, params: [String: Any]) async {
@@ -910,7 +930,8 @@ actor CodexAppServerMonitor {
         guard let threadId = thread["id"] as? String else { return }
         // Cache approvalMode from app-server data so approval-policy checks
         // don't have to re-read the global state file on every request.
-        if let mode = thread["approvalMode"] as? String ?? thread["approval_mode"] as? String {
+        let rawMode = thread["approvalMode"] as? String ?? thread["approval_mode"] as? String
+        if let mode = rawMode {
             threadApprovalModes[threadId] = mode
         }
         let name = thread["name"] as? String
@@ -1606,4 +1627,6 @@ actor CodexAppServerMonitor {
         return bundle.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String
             ?? bundle.object(forInfoDictionaryKey: "CFBundleName") as? String
     }
+
 }
+

--- a/PingIsland/Services/Codex/CodexAppServerMonitor.swift
+++ b/PingIsland/Services/Codex/CodexAppServerMonitor.swift
@@ -617,6 +617,28 @@ actor CodexAppServerMonitor {
         }
     }
 
+    // MARK: - Codex approval-policy helpers
+
+    /// Returns `true` if the thread's persisted approval policy is "never",
+    /// meaning Codex will auto-approve the request without waiting for our
+    /// response. We mirror that auto-approval so no blocking card appears.
+    nonisolated static func threadIsAutoApprove(_ threadId: String) -> Bool {
+        guard
+            let data = try? Data(contentsOf: URL(
+                fileURLWithPath: NSHomeDirectory()
+                    .appending("/.codex/.codex-global-state.json")
+            )),
+            let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let atomState = root["electron-persisted-atom-state"] as? [String: Any],
+            let permsMap = atomState["heartbeat-thread-permissions-by-id"] as? [String: Any],
+            let entry = permsMap[threadId] as? [String: Any],
+            let policy = entry["approvalPolicy"] as? String
+        else {
+            return false
+        }
+        return policy == "never"
+    }
+
     private func handleServerRequest(id: String, method: String, params: [String: Any]) async {
         switch method {
         case "item/commandExecution/requestApproval":
@@ -624,6 +646,12 @@ actor CodexAppServerMonitor {
             guard !threadId.isEmpty else { return }
 
             let command = ((params["command"] as? [String]) ?? []).joined(separator: " ")
+
+            if Self.threadIsAutoApprove(threadId) {
+                await sendResponse(id: id, result: ["decision": "accept"])
+                return
+            }
+
             let cwd = params["cwd"] as? String
             let reason = params["reason"] as? String
             let intervention = SessionIntervention(
@@ -666,6 +694,12 @@ actor CodexAppServerMonitor {
             guard let threadId = params["threadId"] as? String else { return }
             let reason = params["reason"] as? String
             let grantRoot = params["grantRoot"] as? String
+
+            if Self.threadIsAutoApprove(threadId) {
+                await sendResponse(id: id, result: ["decision": "accept"])
+                return
+            }
+
             let intervention = SessionIntervention(
                 id: id,
                 kind: .approval,
@@ -706,6 +740,15 @@ actor CodexAppServerMonitor {
             let permissions = params["permissions"] as? [String: Any] ?? [:]
             let reason = params["reason"] as? String
             let message = reason ?? permissionSummary(permissions)
+
+            if Self.threadIsAutoApprove(threadId) {
+                await sendResponse(id: id, result: [
+                    "permissions": permissions,
+                    "scope": "session"
+                ])
+                return
+            }
+
             let intervention = SessionIntervention(
                 id: id,
                 kind: .approval,

--- a/PingIsland/Services/Hooks/HookSocketServer.swift
+++ b/PingIsland/Services/Hooks/HookSocketServer.swift
@@ -83,6 +83,10 @@ struct HookEvent: Sendable {
     let ingress: SessionIngress
     let bridgeIntervention: SessionIntervention?
     let suppressInAppPrompt: Bool
+    /// True when Codex fires a PermissionRequest hook with `permission_mode=bypassPermissions`,
+    /// meaning Codex has already auto-approved the tool call internally.  Island should
+    /// respond to the hook immediately without showing an approval card.
+    let codexBypassPermissions: Bool
 
     init(
         sessionId: String,
@@ -100,7 +104,8 @@ struct HookEvent: Sendable {
         message: String?,
         ingress: SessionIngress = .hookBridge,
         bridgeIntervention: SessionIntervention? = nil,
-        suppressInAppPrompt: Bool = false
+        suppressInAppPrompt: Bool = false,
+        codexBypassPermissions: Bool = false
     ) {
         self.sessionId = sessionId
         self.cwd = cwd
@@ -118,6 +123,7 @@ struct HookEvent: Sendable {
         self.ingress = ingress
         self.bridgeIntervention = bridgeIntervention
         self.suppressInAppPrompt = suppressInAppPrompt
+        self.codexBypassPermissions = codexBypassPermissions
     }
 
     nonisolated var sessionPhase: SessionPhase {
@@ -228,7 +234,8 @@ extension HookEvent {
             message: message,
             ingress: ingress,
             bridgeIntervention: bridgeIntervention?.withResolvedToolUseId(toolUseId),
-            suppressInAppPrompt: suppressInAppPrompt
+            suppressInAppPrompt: suppressInAppPrompt,
+            codexBypassPermissions: codexBypassPermissions
         )
     }
 
@@ -249,7 +256,8 @@ extension HookEvent {
             message: message,
             ingress: ingress,
             bridgeIntervention: bridgeIntervention,
-            suppressInAppPrompt: suppressInAppPrompt
+            suppressInAppPrompt: suppressInAppPrompt,
+            codexBypassPermissions: codexBypassPermissions
         )
     }
 }
@@ -607,7 +615,11 @@ private extension BridgeEnvelope {
                 fallbackID: metadata["tool_use_id"],
                 metadata: metadata
             ),
-            suppressInAppPrompt: (metadata["suppress_in_app_prompt"] == "true")
+            suppressInAppPrompt: (metadata["suppress_in_app_prompt"] == "true"),
+            codexBypassPermissions: (
+                eventType == "PermissionRequest"
+                && metadata["permission_mode"] == "bypassPermissions"
+            )
         )
     }
 

--- a/PingIsland/Services/State/SessionStore.swift
+++ b/PingIsland/Services/State/SessionStore.swift
@@ -378,9 +378,13 @@ actor SessionStore {
         // Codex has already auto-approved the tool call internally (approval_mode "never").
         // No UI card is needed — respond to the hook immediately so the hook client is
         // never left waiting on a 24-hour timeout.
+        //
+        // All other PermissionRequest hooks (permission_mode=default etc.) represent
+        // genuine approval requests where Codex is waiting for Island's response.
+        // Fall through to show an approval card.
         if event.codexBypassPermissions {
             Self.logger.notice(
-                "Auto-approving bypassPermissions hook session=\(sessionId.prefix(8), privacy: .public)"
+                "Suppressing bypassPermissions hook session=\(sessionId.prefix(8), privacy: .public)"
             )
             HookSocketServer.shared.respondToPermissionBySession(sessionId: sessionId, decision: "approve")
             return

--- a/PingIsland/Services/State/SessionStore.swift
+++ b/PingIsland/Services/State/SessionStore.swift
@@ -373,6 +373,27 @@ actor SessionStore {
         let sessionId = event.provider == .codex
             ? resolveOrAdoptCodexHookSession(event)
             : event.sessionId
+
+        // Auto-approve PermissionRequest for Codex threads whose approvalPolicy is "never".
+        // Codex already handles approval internally in this mode; showing a UI card is
+        // misleading since the user's response has no effect.  Respond immediately so the
+        // hook client (Codex process) is never left waiting.
+        if event.provider == .codex,
+           event.event == "PermissionRequest",
+           event.expectsResponse {
+            let isNeverPolicy =
+                CodexAppServerMonitor.approvalPolicyFromGlobalState(threadId: event.sessionId) == "never"
+                || (sessionId != event.sessionId
+                    && CodexAppServerMonitor.approvalPolicyFromGlobalState(threadId: sessionId) == "never")
+            if isNeverPolicy {
+                Self.logger.notice(
+                    "Auto-approving Codex PermissionRequest (approvalPolicy=never) session=\(sessionId.prefix(8), privacy: .public)"
+                )
+                HookSocketServer.shared.respondToPermissionBySession(sessionId: sessionId, decision: "approve")
+                return
+            }
+        }
+
         if shouldIgnoreClaudeAskUserQuestionPermissionRequest(event) {
             Self.logger.notice(
                 "Ignoring duplicate Claude AskUserQuestion permission session=\(sessionId, privacy: .public)"

--- a/PingIsland/Services/State/SessionStore.swift
+++ b/PingIsland/Services/State/SessionStore.swift
@@ -374,24 +374,16 @@ actor SessionStore {
             ? resolveOrAdoptCodexHookSession(event)
             : event.sessionId
 
-        // Auto-approve PermissionRequest for Codex threads whose approvalPolicy is "never".
-        // Codex already handles approval internally in this mode; showing a UI card is
-        // misleading since the user's response has no effect.  Respond immediately so the
-        // hook client (Codex process) is never left waiting.
-        if event.provider == .codex,
-           event.event == "PermissionRequest",
-           event.expectsResponse {
-            let isNeverPolicy =
-                CodexAppServerMonitor.approvalPolicyFromGlobalState(threadId: event.sessionId) == "never"
-                || (sessionId != event.sessionId
-                    && CodexAppServerMonitor.approvalPolicyFromGlobalState(threadId: sessionId) == "never")
-            if isNeverPolicy {
-                Self.logger.notice(
-                    "Auto-approving Codex PermissionRequest (approvalPolicy=never) session=\(sessionId.prefix(8), privacy: .public)"
-                )
-                HookSocketServer.shared.respondToPermissionBySession(sessionId: sessionId, decision: "approve")
-                return
-            }
+        // When Codex fires a PermissionRequest hook with permission_mode=bypassPermissions,
+        // Codex has already auto-approved the tool call internally (approval_mode "never").
+        // No UI card is needed — respond to the hook immediately so the hook client is
+        // never left waiting on a 24-hour timeout.
+        if event.codexBypassPermissions {
+            Self.logger.notice(
+                "Auto-approving bypassPermissions hook session=\(sessionId.prefix(8), privacy: .public)"
+            )
+            HookSocketServer.shared.respondToPermissionBySession(sessionId: sessionId, decision: "approve")
+            return
         }
 
         if shouldIgnoreClaudeAskUserQuestionPermissionRequest(event) {


### PR DESCRIPTION
## Problem

When a Codex thread has \`approvalPolicy: \"never\"\`, Codex auto-executes all tool calls without waiting for a response from the app-server client. However, Island was still showing a blocking approve/deny card for \`item/commandExecution/requestApproval\`, \`item/fileChange/requestApproval\`, and \`item/permissions/requestApproval\` messages.

The card was misleading: clicking **Allow** or **Deny** had no effect because Codex had already executed the tool by the time the user saw the prompt.

## Root cause

Codex fires \`requestApproval\` JSON-RPC requests to all connected app-server clients regardless of the thread's approval policy. With \`approvalPolicy: \"never\"\` the Codex app-server auto-approves internally, but the message still arrives at Island, which surfaced it as a blocking card.

## Fix

**Approval-mode cache** (\`threadApprovalModes\`): populated whenever Island ingests thread data (\`ingestThread\`, \`parseThreadSnapshot\`). \`parseThreadSnapshot\` is called on every \`thread/read\` and \`thread/list\` response, so the cache stays current within the polling cycle (≤ 30 s) — covering the case where the user changes the policy at runtime.

**Auto-approve check**: before building any intervention, \`CodexAppServerMonitor\` calls \`isAutoApproveThread(_:)\`, which checks the cache first and falls back to reading \`~/.codex/.codex-global-state.json\`. If the policy is \`\"never\"\`, it sends back an accept response immediately and skips the card:

- \`item/commandExecution/requestApproval\` → \`{"decision": "accept"}\`
- \`item/fileChange/requestApproval\` → \`{"decision": "accept"}\`
- \`item/permissions/requestApproval\` → \`{"permissions": <original>, "scope": "session"}\`

Threads with any other approval policy (e.g. \`"on-request"\`) continue to show the card as before.

## Test

Verified manually: with a thread set to \`approvalPolicy: \"never\"\` in Codex Desktop, MCP tool calls (e.g. \`list_repo_merge_requests\`) no longer produce approval cards in Island. Threads with \`"on-request"\` continue to show cards normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)