### PR TITLE
Fix Claude approvals inside Qoder IDE terminals

### DIFF
--- a/PingIsland/Services/Hooks/HookSocketServer.swift
+++ b/PingIsland/Services/Hooks/HookSocketServer.swift
@@ -712,10 +712,13 @@ private extension BridgeEnvelope {
             metadata["origin"],
             metadata["_source"]
         )
-        let explicitOriginator = firstNonEmpty(
+        let explicitMetadataOriginator = firstNonEmpty(
             metadata["client_originator"],
             metadata["originator"],
-            metadata["source_title"],
+            metadata["source_title"]
+        )
+        let explicitOriginator = firstNonEmpty(
+            explicitMetadataOriginator,
             terminalContext.ideName
         )
         let explicitThreadSource = firstNonEmpty(
@@ -745,12 +748,12 @@ private extension BridgeEnvelope {
             metadata["source_process_name"],
             metadata["process_name"]
         )
-        let hostBundleIdentifier = (explicitBundleID ?? terminalBundleID)?
+        let explicitClientBundleIdentifier = explicitBundleID?
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
         let effectiveExplicitKind: String?
         let effectiveExplicitName: String?
-        switch hostBundleIdentifier {
+        switch explicitClientBundleIdentifier {
         case "com.qoder.ide":
             effectiveExplicitKind = "qoder"
             effectiveExplicitName = "Qoder"
@@ -768,9 +771,11 @@ private extension BridgeEnvelope {
             explicitKind: effectiveExplicitKind,
             explicitName: effectiveExplicitName,
             explicitBundleIdentifier: explicitBundleID,
-            terminalBundleIdentifier: terminalBundleID,
+            terminalBundleIdentifier: explicitKind == nil && explicitName == nil && explicitBundleID == nil
+                ? nil
+                : terminalBundleID,
             origin: explicitOrigin,
-            originator: explicitOriginator,
+            originator: explicitMetadataOriginator,
             threadSource: explicitThreadSource,
             processName: processName
         )

--- a/PingIslandTests/SessionStateTests.swift
+++ b/PingIslandTests/SessionStateTests.swift
@@ -387,6 +387,42 @@ final class SessionStateTests: XCTestCase {
         XCTAssertTrue(session.supportsSessionScopedApproval)
     }
 
+    func testClaudeCodeHostedInQoderTerminalKeepsAutoApproveAction() {
+        let intervention = SessionIntervention(
+            id: "tool-1",
+            kind: .approval,
+            title: "Claude needs approval",
+            message: "Run Bash?",
+            options: [
+                SessionInterventionOption(id: "approve", title: "Allow Once", detail: nil),
+                SessionInterventionOption(id: "approveForSession", title: "Allow for Session", detail: nil),
+                SessionInterventionOption(id: "deny", title: "Deny", detail: nil)
+            ],
+            questions: [],
+            supportsSessionScope: false,
+            metadata: [:]
+        )
+        let session = SessionState(
+            sessionId: "claude-hosted-in-qoder",
+            cwd: "/tmp/project",
+            provider: .claude,
+            clientInfo: SessionClientInfo(
+                kind: .claudeCode,
+                name: "Claude Code",
+                originator: "Qoder",
+                terminalBundleIdentifier: "com.qoder.ide"
+            ),
+            intervention: intervention,
+            phase: .waitingForApproval(
+                PermissionContext(toolUseId: "tool-1", toolName: "Bash", toolInput: nil, receivedAt: Date())
+            )
+        )
+
+        XCTAssertEqual(session.scopedApprovalAction, .autoApprove)
+        XCTAssertTrue(session.supportsSessionScopedApproval)
+        XCTAssertEqual(session.clientInfo.ideHostBadgeLabel(for: .claude), "Qoder 终端")
+    }
+
     func testQoderWaitingForApprovalDoesNotExposeClaudeAutoApproveAction() {
         let session = SessionState(
             sessionId: "qoder-no-auto-approve",

--- a/Prototype/Sources/IslandShared/HookPayloadMapper.swift
+++ b/Prototype/Sources/IslandShared/HookPayloadMapper.swift
@@ -1209,13 +1209,25 @@ public enum HookPayloadMapper {
     }
 
     private static func normalizedClientKind(from metadata: [String: String]) -> String? {
-        let bundleIdentifier = metadata["client_bundle_id"]?
+        let explicitClientKind = metadata["client_kind"]?
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
-            ?? metadata["terminal_bundle_id"]?
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-                .lowercased()
-        switch bundleIdentifier {
+        if let explicitClientKind, !explicitClientKind.isEmpty {
+            if explicitClientKind == "qoder-cli",
+               metadataHasQoderIDEHost(metadata) {
+                return "qoder"
+            }
+            if explicitClientKind == "qoder",
+               metadataLooksLikeQoderCLI(metadata) {
+                return "qoder-cli"
+            }
+            return explicitClientKind
+        }
+
+        let clientBundleIdentifier = metadata["client_bundle_id"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        switch clientBundleIdentifier {
         case "com.qoder.work":
             return "qoderwork"
         case "com.qoder.ide":
@@ -1224,18 +1236,7 @@ public enum HookPayloadMapper {
             break
         }
 
-        if let explicitClientKind = metadata["client_kind"]?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .lowercased(),
-           !explicitClientKind.isEmpty {
-            if explicitClientKind == "qoder",
-               metadataLooksLikeQoderCLI(metadata) {
-                return "qoder-cli"
-            }
-            return explicitClientKind
-        }
-
-        switch bundleIdentifier {
+        switch clientBundleIdentifier {
         case "com.tencent.codebuddy", "com.codebuddy.app":
             return "codebuddy"
         case "com.workbuddy.workbuddy":
@@ -1247,7 +1248,7 @@ public enum HookPayloadMapper {
         let nameHint = metadata["client_name"]?
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
-            ?? metadata["client_originator"]?
+            ?? metadata["client"]?
                 .trimmingCharacters(in: .whitespacesAndNewlines)
                 .lowercased()
         if let nameHint {
@@ -1396,6 +1397,17 @@ public enum HookPayloadMapper {
 
         return normalizedOrigin == "cli"
             && nameHints.contains(where: { $0 == "qoder" || $0.contains("qoder ") })
+    }
+
+    private static func metadataHasQoderIDEHost(_ metadata: [String: String]) -> Bool {
+        [
+            metadata["terminal_bundle_id"],
+            metadata["ide_bundle_id"]
+        ].contains { value in
+            value?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .lowercased() == "com.qoder.ide"
+        }
     }
 
     private static func isCodeBuddyFamilyHookClient(_ clientKind: String?) -> Bool {

--- a/Prototype/Tests/IslandTests/HookPayloadMapperTests.swift
+++ b/Prototype/Tests/IslandTests/HookPayloadMapperTests.swift
@@ -1175,6 +1175,39 @@ func qoderCLIHooksExecutedInsideQoderIDEStayNotifyOnly() throws {
 }
 
 @Test
+func claudeHooksExecutedInsideQoderIDETerminalKeepClaudeApprovalOptions() throws {
+    let payload = """
+    {
+      "hook_event_name": "PermissionRequest",
+      "session_id": "claude-in-qoder-ide",
+      "tool_name": "Bash",
+      "tool_input": {
+        "command": "npm test"
+      }
+    }
+    """.data(using: .utf8)!
+
+    let envelope = HookPayloadMapper.makeEnvelope(
+        source: .claude,
+        arguments: ["island-bridge", "--source", "claude"],
+        environment: [
+            "TERM_PROGRAM": "vscode",
+            "__CFBundleIdentifier": "com.qoder.ide",
+            "VSCODE_GIT_IPC_HANDLE": "/Applications/Qoder.app/Contents/Resources/app/out/vs/workbench",
+            "PWD": "/tmp/demo"
+        ],
+        stdinData: payload
+    )
+
+    #expect(envelope.metadata["client_kind"] == nil)
+    #expect(envelope.metadata["terminal_bundle_id"] == "com.qoder.ide")
+    #expect(envelope.expectsResponse)
+    #expect(envelope.intervention?.kind == .approval)
+    #expect(envelope.intervention?.options.map(\.id) == ["approve", "approveForSession", "deny"])
+    #expect(HookPayloadMapper.shouldDeliverEnvelope(envelope))
+}
+
+@Test
 func qoderCLINonQuestionHooksExecutedInsideQoderIDESkipDelivery() throws {
     let payload = """
     {


### PR DESCRIPTION
## Summary
- keep plain Claude Code hooks launched inside Qoder IDE terminals classified as Claude, not Qoder
- stop using terminal host metadata alone as bridge/client identity while preserving explicit Qoder IDE and Qoder CLI behavior
- add regressions for Qoder-hosted Claude approval options and scoped approval UI state

Fixes #202

## Tests
- `swift test --package-path Prototype`
- `xcodebuild -project PingIsland.xcodeproj -scheme PingIsland -configuration Debug CODE_SIGNING_ALLOWED=NO test -only-testing:PingIslandTests`