### PR TITLE
[codex] Hide Island only for fullscreen Chrome

### DIFF
--- a/PingIsland/Core/NotchViewModel.swift
+++ b/PingIsland/Core/NotchViewModel.swift
@@ -48,7 +48,7 @@ class NotchViewModel: ObservableObject {
     @Published private(set) var openedMeasuredHeight: CGFloat?
     @Published private(set) var isFullscreenEdgeRevealActive = false
     @Published private(set) var isFullscreenPhysicalNotchCompactActive = false
-    @Published private(set) var isFullscreenBrowserHiddenActive = false
+    @Published private(set) var isFullscreenChromeHiddenActive = false
     @Published private(set) var isIdleAutoHiddenActive = false
     @Published private(set) var isSettingsPopoverPresented = false
     @Published private(set) var isInlineTextInputActive = false
@@ -277,7 +277,7 @@ class NotchViewModel: ObservableObject {
     private var cancellables = Set<AnyCancellable>()
     private let events: EventMonitors?
     private let fullscreenActivityProvider: @MainActor (CGRect) -> Bool
-    private let fullscreenBrowserHiddenProvider: @MainActor (CGRect) -> Bool
+    private let fullscreenChromeHiddenProvider: @MainActor (CGRect) -> Bool
     private let hideInFullscreenProvider: @MainActor () -> Bool
     private let autoHideWhenIdleProvider: @MainActor () -> Bool
     private var hoverTimer: DispatchWorkItem?
@@ -322,7 +322,7 @@ class NotchViewModel: ObservableObject {
         observeSystemEnvironment: Bool = true,
         fullscreenActivityProvider: @escaping @MainActor (CGRect) -> Bool = FullscreenAppDetector.isFullscreenAppActive,
         hideInFullscreenProvider: @escaping @MainActor () -> Bool = { AppSettings.hideInFullscreen },
-        fullscreenBrowserHiddenProvider: @escaping @MainActor (CGRect) -> Bool = FullscreenAppDetector.isFullscreenBrowserActive,
+        fullscreenChromeHiddenProvider: @escaping @MainActor (CGRect) -> Bool = FullscreenAppDetector.isFullscreenChromeActive,
         autoHideWhenIdleProvider: @escaping @MainActor () -> Bool = { AppSettings.autoHideWhenIdle },
         fullscreenStateSettleDelay: TimeInterval = 0.18
     ) {
@@ -338,7 +338,7 @@ class NotchViewModel: ObservableObject {
         )
         self.events = enableEventMonitoring ? EventMonitors.shared : nil
         self.fullscreenActivityProvider = fullscreenActivityProvider
-        self.fullscreenBrowserHiddenProvider = fullscreenBrowserHiddenProvider
+        self.fullscreenChromeHiddenProvider = fullscreenChromeHiddenProvider
         self.hideInFullscreenProvider = hideInFullscreenProvider
         self.autoHideWhenIdleProvider = autoHideWhenIdleProvider
         self.fullscreenStateSettleDelay = fullscreenStateSettleDelay
@@ -414,12 +414,12 @@ class NotchViewModel: ObservableObject {
 
     private func refreshFullscreenPresentationState() {
         let isFullscreenActive = fullscreenActivityProvider(screenRect)
-        let shouldHideForFullscreenBrowser = fullscreenBrowserHiddenProvider(screenRect)
+        let shouldHideForFullscreenChrome = fullscreenChromeHiddenProvider(screenRect)
         let shouldUseEdgeReveal = shouldUseFullscreenEdgeReveal(isFullscreenActive: isFullscreenActive)
         let shouldUsePhysicalNotchCompact = shouldUsePhysicalNotchCompact(isFullscreenActive: isFullscreenActive)
 
-        if shouldHideForFullscreenBrowser != isFullscreenBrowserHiddenActive {
-            isFullscreenBrowserHiddenActive = shouldHideForFullscreenBrowser
+        if shouldHideForFullscreenChrome != isFullscreenChromeHiddenActive {
+            isFullscreenChromeHiddenActive = shouldHideForFullscreenChrome
         }
 
         applyPhysicalNotchFullscreenState(shouldUsePhysicalNotchCompact)
@@ -436,7 +436,7 @@ class NotchViewModel: ObservableObject {
             }
         }
 
-        if shouldHideForFullscreenBrowser {
+        if shouldHideForFullscreenChrome {
             hoverTimer?.cancel()
             hoverTimer = nil
             isHovering = false
@@ -485,7 +485,7 @@ class NotchViewModel: ObservableObject {
         hideInFullscreenProvider()
             && hasPhysicalNotch
             && isFullscreenActive
-            && !isFullscreenBrowserHiddenActive
+            && !isFullscreenChromeHiddenActive
     }
 
     // MARK: - Event Handling
@@ -716,7 +716,7 @@ class NotchViewModel: ObservableObject {
         if presentationMode == .detached {
             return true
         }
-        if isFullscreenBrowserHiddenActive {
+        if isFullscreenChromeHiddenActive {
             return true
         }
         if isFullscreenEdgeRevealActive && status != .opened {
@@ -734,7 +734,7 @@ class NotchViewModel: ObservableObject {
 
     var shouldSuppressAutomaticPresentation: Bool {
         presentationMode == .detached
-            || isFullscreenBrowserHiddenActive
+            || isFullscreenChromeHiddenActive
             || (isFullscreenEdgeRevealActive && status != .opened)
     }
 

--- a/PingIsland/UI/Views/NotchView.swift
+++ b/PingIsland/UI/Views/NotchView.swift
@@ -430,7 +430,7 @@ struct NotchView: View {
                     scheduleDetachmentHintPresentationIfNeeded(delay: Self.detachmentHintRetryDelay)
                 }
             }
-            .onChange(of: viewModel.isFullscreenBrowserHiddenActive) { _, isActive in
+            .onChange(of: viewModel.isFullscreenChromeHiddenActive) { _, isActive in
                 if isActive {
                     isVisible = false
                 } else {

--- a/PingIsland/UI/Window/NotchWindowController.swift
+++ b/PingIsland/UI/Window/NotchWindowController.swift
@@ -80,7 +80,7 @@ class NotchWindowController: NSWindowController {
             }
             .store(in: &cancellables)
 
-        viewModel.$isFullscreenBrowserHiddenActive
+        viewModel.$isFullscreenChromeHiddenActive
             .receive(on: DispatchQueue.main)
             .sink { [weak self, weak notchWindow, weak viewModel] _ in
                 guard let self, let notchWindow, let viewModel else { return }
@@ -104,7 +104,7 @@ class NotchWindowController: NSWindowController {
             }
             .store(in: &cancellables)
 
-        viewModel.$isFullscreenBrowserHiddenActive
+        viewModel.$isFullscreenChromeHiddenActive
             .receive(on: DispatchQueue.main)
             .sink { [weak self, weak notchWindow, weak viewModel] _ in
                 guard let self, let notchWindow, let viewModel else { return }

--- a/PingIsland/Utilities/FullscreenAppDetector.swift
+++ b/PingIsland/Utilities/FullscreenAppDetector.swift
@@ -10,43 +10,23 @@ struct FullscreenAppDetector {
         return isFullscreenWindowOwned(by: frontmostApp.processIdentifier, screenFrame: screenFrame)
     }
 
-    static func isFullscreenBrowserActive(screenFrame: CGRect) -> Bool {
+    static func isFullscreenChromeActive(screenFrame: CGRect) -> Bool {
         guard let frontmostApp = frontmostApplicationExcludingSelf(),
-              isBrowserBundleIdentifier(frontmostApp.bundleIdentifier) else {
+              isChromeBundleIdentifier(frontmostApp.bundleIdentifier) else {
             return false
         }
 
         return isFullscreenWindowOwned(by: frontmostApp.processIdentifier, screenFrame: screenFrame)
     }
 
-    static func isBrowserBundleIdentifier(_ bundleIdentifier: String?) -> Bool {
+    static func isChromeBundleIdentifier(_ bundleIdentifier: String?) -> Bool {
         guard let normalized = bundleIdentifier?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
               !normalized.isEmpty else {
             return false
         }
 
-        let knownBundleIdentifiers: Set<String> = [
-            "com.apple.safari",
-            "com.apple.safaritechnologypreview",
-            "com.google.chrome",
-            "com.google.chrome.canary",
-            "com.microsoft.edgemac",
-            "com.brave.browser",
-            "company.thebrowser.browser",
-            "com.operasoftware.opera",
-            "org.mozilla.firefox"
-        ]
-
-        if knownBundleIdentifiers.contains(normalized) {
-            return true
-        }
-
-        return normalized.contains("chrome")
-            || normalized.contains("safari")
-            || normalized.contains("edge")
-            || normalized.contains("brave")
-            || normalized.contains("opera")
-            || normalized.contains("firefox")
+        return normalized == "com.google.chrome"
+            || normalized == "com.google.chrome.canary"
     }
 
     private static func frontmostApplicationExcludingSelf() -> NSRunningApplication? {

--- a/PingIslandTests/FullscreenAppDetectorTests.swift
+++ b/PingIslandTests/FullscreenAppDetectorTests.swift
@@ -26,10 +26,10 @@ final class FullscreenAppDetectorTests: XCTestCase {
         )
     }
 
-    func testRecognizesBrowserBundleIdentifiers() {
-        XCTAssertTrue(FullscreenAppDetector.isBrowserBundleIdentifier("com.google.Chrome"))
-        XCTAssertTrue(FullscreenAppDetector.isBrowserBundleIdentifier("com.apple.Safari"))
-        XCTAssertTrue(FullscreenAppDetector.isBrowserBundleIdentifier("com.microsoft.edgemac"))
-        XCTAssertFalse(FullscreenAppDetector.isBrowserBundleIdentifier("com.openai.codex"))
+    func testRecognizesChromeBundleIdentifiers() {
+        XCTAssertTrue(FullscreenAppDetector.isChromeBundleIdentifier("com.google.Chrome"))
+        XCTAssertTrue(FullscreenAppDetector.isChromeBundleIdentifier("com.google.Chrome.Canary"))
+        XCTAssertFalse(FullscreenAppDetector.isChromeBundleIdentifier("com.apple.Safari"))
+        XCTAssertFalse(FullscreenAppDetector.isChromeBundleIdentifier("com.openai.codex"))
     }
 }

--- a/PingIslandTests/NotchViewModelTests.swift
+++ b/PingIslandTests/NotchViewModelTests.swift
@@ -318,7 +318,7 @@ final class NotchViewModelTests: XCTestCase {
         }
     }
 
-    func testFullscreenBrowserHidesWindowPresentationEvenOnPhysicalNotch() async {
+    func testFullscreenChromeHidesWindowPresentationEvenOnPhysicalNotch() async {
         let viewModel = await MainActor.run {
             NotchViewModel(
                 deviceNotchRect: CGRect(x: 0, y: 0, width: 220, height: 38),
@@ -328,12 +328,12 @@ final class NotchViewModelTests: XCTestCase {
                 enableEventMonitoring: false,
                 observeSystemEnvironment: false,
                 fullscreenActivityProvider: { _ in true },
-                fullscreenBrowserHiddenProvider: { _ in true }
+                fullscreenChromeHiddenProvider: { _ in true }
             )
         }
 
         await MainActor.run {
-            XCTAssertTrue(viewModel.isFullscreenBrowserHiddenActive)
+            XCTAssertTrue(viewModel.isFullscreenChromeHiddenActive)
             XCTAssertTrue(viewModel.shouldHideWindowPresentation)
             XCTAssertTrue(viewModel.shouldSuppressAutomaticPresentation)
         }


### PR DESCRIPTION
## Summary
- Limit the special fullscreen suppression path to Google Chrome and Chrome Canary.
- Rename the notch presentation state/provider from fullscreen browser to fullscreen Chrome.
- Update unit tests so Safari and non-browser bundle IDs do not match the Chrome-only path.

## Why
The requested behavior is to hide the Island presentation when the current foreground window is fullscreen Chrome. The previous broad browser matcher also suppressed the Island for Safari, Edge, Firefox, Brave, and similar browsers.

## Validation
- `xcodebuild -project PingIsland.xcodeproj -scheme PingIsland -configuration Debug CODE_SIGNING_ALLOWED=NO test -only-testing:PingIslandTests/FullscreenAppDetectorTests -only-testing:PingIslandTests/NotchViewModelTests`
- `git diff --check`