### PR TITLE
Add focus-based screen migration

### DIFF
--- a/PingIsland/App/WindowManager.swift
+++ b/PingIsland/App/WindowManager.swift
@@ -6,6 +6,7 @@
 //
 
 import AppKit
+import Combine
 import os.log
 
 /// Logger for window management
@@ -15,6 +16,12 @@ private let logger = Logger(subsystem: "com.wudanwu.pingisland", category: "Wind
 class WindowManager {
     private(set) var presentationCoordinator: IslandPresentationCoordinator?
     private var activeScreenNumber: NSNumber?
+    private var cancellables = Set<AnyCancellable>()
+    private var lastMigrationTime: Date = .distantPast
+
+    init() {
+        startFocusTracking()
+    }
 
     /// Set up or recreate the notch window
     func setupNotchWindow() -> NotchWindowController? {
@@ -39,5 +46,50 @@ class WindowManager {
         self.presentationCoordinator = presentationCoordinator
         activeScreenNumber = screenNumber
         return nil
+    }
+
+    // MARK: - Focus-based screen migration
+
+    /// Track application focus changes. When the user activates an app on a
+    /// different screen, migrate the notch to follow.
+    private func startFocusTracking() {
+        // Track app-level focus changes
+        NSWorkspace.shared.notificationCenter
+            .publisher(for: NSWorkspace.didActivateApplicationNotification)
+            .sink { [weak self] _ in
+                self?.handleFocusChange()
+            }
+            .store(in: &cancellables)
+
+        // Track window-level focus changes (covers same-app window switches)
+        NotificationCenter.default
+            .publisher(for: NSWindow.didBecomeKeyNotification)
+            .sink { [weak self] _ in
+                self?.handleFocusChange()
+            }
+            .store(in: &cancellables)
+    }
+
+    private func handleFocusChange() {
+        let selector = ScreenSelector.shared
+        guard selector.selectionMode == .automatic else { return }
+
+        // Debounce
+        let now = Date()
+        guard now.timeIntervalSince(lastMigrationTime) > 1.0 else { return }
+
+        // Determine target screen from cursor position
+        guard let targetScreen = selector.screenContaining(NSEvent.mouseLocation),
+              let currentScreen = selector.selectedScreen else { return }
+
+        let targetID = selector.screenID(of: targetScreen)
+        let currentID = selector.screenID(of: currentScreen)
+
+        guard targetID != currentID else { return }
+
+        lastMigrationTime = now
+        logger.info("Focus changed, migrating notch to cursor screen")
+        selector.migrateToScreen(targetScreen)
+        _ = setupNotchWindow()
     }
 }

--- a/PingIsland/Core/ScreenSelector.swift
+++ b/PingIsland/Core/ScreenSelector.swift
@@ -60,6 +60,9 @@ class ScreenSelector: ObservableObject {
 
     // MARK: - Private State
     private var savedIdentifier: ScreenIdentifier?
+    /// Screen chosen by cursor-follow in automatic mode.
+    /// Persists across refreshScreens() until the user explicitly changes mode.
+    private var cursorFollowScreen: NSScreen?
 
     private init() {
         loadPreferences()
@@ -78,6 +81,7 @@ class ScreenSelector: ObservableObject {
     func selectScreen(_ screen: NSScreen) {
         selectionMode = .specificScreen
         savedIdentifier = ScreenIdentifier(screen: screen)
+        cursorFollowScreen = nil
         selectedScreen = screen
         savePreferences()
     }
@@ -86,6 +90,7 @@ class ScreenSelector: ObservableObject {
     func selectAutomatic() {
         selectionMode = .automatic
         savedIdentifier = nil
+        cursorFollowScreen = nil
         selectedScreen = resolveSelectedScreen()
         savePreferences()
     }
@@ -94,6 +99,18 @@ class ScreenSelector: ObservableObject {
     func isSelected(_ screen: NSScreen) -> Bool {
         guard let selected = selectedScreen else { return false }
         return screenID(of: screen) == screenID(of: selected)
+    }
+
+    /// Find the screen containing a point in AppKit global coordinates.
+    func screenContaining(_ point: CGPoint) -> NSScreen? {
+        NSScreen.screens.first(where: { NSMouseInRect(point, $0.frame, false) })
+    }
+
+    /// Migrate the notch to the given screen (automatic mode cursor-follow).
+    func migrateToScreen(_ screen: NSScreen) {
+        guard selectionMode == .automatic else { return }
+        cursorFollowScreen = screen
+        selectedScreen = screen
     }
 
     /// Extra height needed when picker is expanded
@@ -105,13 +122,22 @@ class ScreenSelector: ObservableObject {
 
     // MARK: - Private Methods
 
-    private func screenID(of screen: NSScreen) -> CGDirectDisplayID? {
+    func screenID(of screen: NSScreen) -> CGDirectDisplayID? {
         screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID
     }
 
     private func resolveSelectedScreen() -> NSScreen? {
         switch selectionMode {
         case .automatic:
+            // Prefer cursor-followed screen, then cursor's current screen, then built-in, then main
+            if let cursor = cursorFollowScreen,
+               availableScreens.contains(where: { screenID(of: $0) == screenID(of: cursor) }) {
+                return cursor
+            }
+            if let cursorScreen = screenContaining(NSEvent.mouseLocation),
+               availableScreens.contains(where: { screenID(of: $0) == screenID(of: cursorScreen) }) {
+                return cursorScreen
+            }
             return NSScreen.builtin ?? NSScreen.main
 
         case .specificScreen:


### PR DESCRIPTION
## Summary
- Track both app-level and window-level focus changes to migrate the notch to the cursor's screen
- On startup, prefer the cursor's screen over builtin/main display
- Add `NSWindow.didBecomeKeyNotification` listener to detect same-app window switches
- Add `ScreenSelector.screenContaining()` and `migrateToScreen()` helpers

## Test plan
- [ ] Launch app on screen A, verify island appears on screen A (not builtin/main)
- [ ] Switch to an app on screen B, verify island migrates to screen B
- [ ] On screen A, switch between windows of the same app, verify island follows
- [ ] Set display mode to "specific screen", verify migration is disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)