### PR TITLE
[codex] Add temporary notch sleep control

### DIFF
--- a/PingIsland/Core/NotchViewModel.swift
+++ b/PingIsland/Core/NotchViewModel.swift
@@ -61,6 +61,7 @@ class NotchViewModel: ObservableObject {
 
     private static let defaultClosedHeight = ScreenNotchMetrics.fallbackClosedHeight
     private static let defaultClosedWidth: CGFloat = 266
+    static let temporarySleepClosedWidth: CGFloat = 30
     // Preserve the visible side rails that the default closed island has beyond
     // the physical camera housing, so mascot/count content never sits under it.
     private static let physicalNotchContentAllowance: CGFloat =
@@ -75,14 +76,20 @@ class NotchViewModel: ObservableObject {
     var screenRect: CGRect { geometry.screenRect }
     var windowHeight: CGFloat { geometry.windowHeight }
     var closedHeight: CGFloat {
-        usesPhysicalNotchClosedPresentation
+        return usesPhysicalNotchClosedPresentation
             ? deviceNotchRect.height
             : detectedClosedHeight
+    }
+    var isTemporaryNotchSleepActive: Bool {
+        temporaryNotchSleepProvider()
     }
     var usesPhysicalNotchClosedPresentation: Bool {
         hasPhysicalNotch && isFullscreenPhysicalNotchCompactActive
     }
     var closedSize: CGSize {
+        if isTemporaryNotchSleepActive {
+            return CGSize(width: Self.temporarySleepClosedWidth, height: closedHeight)
+        }
         if usesPhysicalNotchClosedPresentation {
             return deviceNotchRect.size
         }
@@ -280,6 +287,7 @@ class NotchViewModel: ObservableObject {
     private let fullscreenBrowserHiddenProvider: @MainActor (CGRect) -> Bool
     private let hideInFullscreenProvider: @MainActor () -> Bool
     private let autoHideWhenIdleProvider: @MainActor () -> Bool
+    private let temporaryNotchSleepProvider: @MainActor () -> Bool
     private var hoverTimer: DispatchWorkItem?
     // Keep hover previews feeling responsive without making incidental cursor
     // passes over the notch expand it too aggressively.
@@ -324,6 +332,7 @@ class NotchViewModel: ObservableObject {
         hideInFullscreenProvider: @escaping @MainActor () -> Bool = { AppSettings.hideInFullscreen },
         fullscreenBrowserHiddenProvider: @escaping @MainActor (CGRect) -> Bool = FullscreenAppDetector.isFullscreenBrowserActive,
         autoHideWhenIdleProvider: @escaping @MainActor () -> Bool = { AppSettings.autoHideWhenIdle },
+        temporaryNotchSleepProvider: @escaping @MainActor () -> Bool = { AppSettings.isNotchSleepingTemporarily },
         fullscreenStateSettleDelay: TimeInterval = 0.18
     ) {
         self.geometry = NotchGeometry(
@@ -341,6 +350,7 @@ class NotchViewModel: ObservableObject {
         self.fullscreenBrowserHiddenProvider = fullscreenBrowserHiddenProvider
         self.hideInFullscreenProvider = hideInFullscreenProvider
         self.autoHideWhenIdleProvider = autoHideWhenIdleProvider
+        self.temporaryNotchSleepProvider = temporaryNotchSleepProvider
         self.fullscreenStateSettleDelay = fullscreenStateSettleDelay
         if enableEventMonitoring {
             setupEventHandlers()
@@ -736,6 +746,7 @@ class NotchViewModel: ObservableObject {
         presentationMode == .detached
             || isFullscreenBrowserHiddenActive
             || (isFullscreenEdgeRevealActive && status != .opened)
+            || isTemporaryNotchSleepActive
     }
 
     var closedPresentationOffsetY: CGFloat {

--- a/PingIsland/Core/Settings.swift
+++ b/PingIsland/Core/Settings.swift
@@ -358,6 +358,7 @@ final class AppSettingsStore: ObservableObject {
         static let soundEnabled = "soundEnabled"
         static let soundVolume = "soundVolume"
         static let temporarilyMuteNotificationsUntil = "temporarilyMuteNotificationsUntil"
+        static let temporarilySleepNotchUntil = "temporarilySleepNotchUntil"
         static let processingStartSound = "processingStartSound"
         static let attentionRequiredSound = "attentionRequiredSound"
         static let taskCompletedSound = "taskCompletedSound"
@@ -462,6 +463,21 @@ final class AppSettingsStore: ObservableObject {
                 )
             } else {
                 defaults.removeObject(forKey: Keys.temporarilyMuteNotificationsUntil)
+            }
+        }
+    }
+
+    @Published var temporarilySleepNotchUntil: Date? {
+        didSet {
+            guard !isBootstrapping else { return }
+
+            if let temporarilySleepNotchUntil {
+                defaults.set(
+                    temporarilySleepNotchUntil.timeIntervalSince1970,
+                    forKey: Keys.temporarilySleepNotchUntil
+                )
+            } else {
+                defaults.removeObject(forKey: Keys.temporarilySleepNotchUntil)
             }
         }
     }
@@ -1012,11 +1028,24 @@ final class AppSettingsStore: ObservableObject {
         Self.isNotificationMuteActive(until: temporarilyMuteNotificationsUntil)
     }
 
+    var isNotchSleepingTemporarily: Bool {
+        Self.isNotchSleepActive(until: temporarilySleepNotchUntil)
+    }
+
     func muteNotifications(for duration: TimeInterval, now: Date = Date()) {
         temporarilyMuteNotificationsUntil = now.addingTimeInterval(duration)
     }
 
+    func sleepNotch(for duration: TimeInterval, now: Date = Date()) {
+        temporarilySleepNotchUntil = now.addingTimeInterval(duration)
+    }
+
     nonisolated static func isNotificationMuteActive(until date: Date?, now: Date = Date()) -> Bool {
+        guard let date else { return false }
+        return date > now
+    }
+
+    nonisolated static func isNotchSleepActive(until date: Date?, now: Date = Date()) -> Bool {
         guard let date else { return false }
         return date > now
     }
@@ -1190,6 +1219,9 @@ final class AppSettingsStore: ObservableObject {
         let temporarilyMuteNotificationsUntilTimestamp = persistedKeys.contains(Keys.temporarilyMuteNotificationsUntil)
             ? defaults.double(forKey: Keys.temporarilyMuteNotificationsUntil)
             : nil
+        let temporarilySleepNotchUntilTimestamp = persistedKeys.contains(Keys.temporarilySleepNotchUntil)
+            ? defaults.double(forKey: Keys.temporarilySleepNotchUntil)
+            : nil
         let notchPetStyleRaw = defaults.string(forKey: Keys.notchPetStyle)
         let notchDisplayModeRaw = defaults.string(forKey: Keys.notchDisplayMode)
         let closedNotchTrailingContentModeRaw = defaults.string(forKey: Keys.closedNotchTrailingContentMode)
@@ -1213,9 +1245,16 @@ final class AppSettingsStore: ObservableObject {
         let temporarilyMuteNotificationsUntil = temporarilyMuteNotificationsUntilTimestamp.map {
             Date(timeIntervalSince1970: $0)
         }
+        let temporarilySleepNotchUntil = temporarilySleepNotchUntilTimestamp.map {
+            Date(timeIntervalSince1970: $0)
+        }
         let activeTemporaryMute =
             Self.isNotificationMuteActive(until: temporarilyMuteNotificationsUntil)
             ? temporarilyMuteNotificationsUntil
+            : nil
+        let activeTemporarySleep =
+            Self.isNotchSleepActive(until: temporarilySleepNotchUntil)
+            ? temporarilySleepNotchUntil
             : nil
 
         _appLanguage = Published(initialValue: AppLanguage(rawValue: appLanguageRaw ?? "") ?? .system)
@@ -1233,6 +1272,7 @@ final class AppSettingsStore: ObservableObject {
             default: 0.9
         ))
         _temporarilyMuteNotificationsUntil = Published(initialValue: activeTemporaryMute)
+        _temporarilySleepNotchUntil = Published(initialValue: activeTemporarySleep)
         _processingStartSound = Published(initialValue: NotificationSound(
             rawValue: defaults.string(forKey: Keys.processingStartSound) ?? ""
         ) ?? .tink)
@@ -1447,6 +1487,9 @@ final class AppSettingsStore: ObservableObject {
         if activeTemporaryMute == nil {
             defaults.removeObject(forKey: Keys.temporarilyMuteNotificationsUntil)
         }
+        if activeTemporarySleep == nil {
+            defaults.removeObject(forKey: Keys.temporarilySleepNotchUntil)
+        }
         if !persistedKeys.contains(Keys.processingStartSoundEnabled) {
             defaults.set(true, forKey: Keys.processingStartSoundEnabled)
         }
@@ -1510,8 +1553,17 @@ enum AppSettings {
         set { shared.temporarilyMuteNotificationsUntil = newValue }
     }
 
+    static var temporarilySleepNotchUntil: Date? {
+        get { shared.temporarilySleepNotchUntil }
+        set { shared.temporarilySleepNotchUntil = newValue }
+    }
+
     static var areReminderNotificationsSuppressed: Bool {
         shared.areNotificationsMutedTemporarily
+    }
+
+    static var isNotchSleepingTemporarily: Bool {
+        shared.isNotchSleepingTemporarily
     }
 
     static var soundThemeMode: SoundThemeMode {
@@ -1562,8 +1614,20 @@ enum AppSettings {
         shared.temporarilyMuteNotificationsUntil = nil
     }
 
+    static func sleepNotch(for duration: TimeInterval, now: Date = Date()) {
+        shared.sleepNotch(for: duration, now: now)
+    }
+
+    static func clearTemporaryNotchSleep() {
+        shared.temporarilySleepNotchUntil = nil
+    }
+
     nonisolated static func isNotificationMuteActive(until date: Date?, now: Date = Date()) -> Bool {
         AppSettingsStore.isNotificationMuteActive(until: date, now: now)
+    }
+
+    nonisolated static func isNotchSleepActive(until date: Date?, now: Date = Date()) -> Bool {
+        AppSettingsStore.isNotchSleepActive(until: date, now: now)
     }
 
     static var showAgentDetail: Bool {

--- a/PingIsland/UI/Views/NotchView.swift
+++ b/PingIsland/UI/Views/NotchView.swift
@@ -29,6 +29,7 @@ struct OpenedPanelContentHeightPreferenceKey: PreferenceKey {
 
 struct NotchView: View {
     private static let temporaryReminderMuteDuration: TimeInterval = 10 * 60
+    private static let temporaryNotchSleepDuration: TimeInterval = 10 * 60
     private static let startupDetachmentHintDelay: TimeInterval = 1.8
     private static let detachmentHintRetryDelay: TimeInterval = 0.75
 
@@ -59,6 +60,7 @@ struct NotchView: View {
     @State private var isShowingDetachmentHint: Bool = false
     @State private var detachmentHintDismissWorkItem: DispatchWorkItem?
     @State private var detachmentHintPresentationWorkItem: DispatchWorkItem?
+    @State private var temporaryNotchSleepRestoreWorkItem: DispatchWorkItem?
 
     @Namespace private var activityNamespace
 
@@ -240,6 +242,14 @@ struct NotchView: View {
         settings.areNotificationsMutedTemporarily
     }
 
+    private var isTemporaryNotchSleepActive: Bool {
+        settings.isNotchSleepingTemporarily
+    }
+
+    private var isSleepingClosedPresentation: Bool {
+        isTemporaryNotchSleepActive && viewModel.status != .opened
+    }
+
     private var temporaryMuteButtonHelpText: String {
         guard let mutedUntil = settings.temporarilyMuteNotificationsUntil,
               AppSettings.isNotificationMuteActive(until: mutedUntil) else {
@@ -249,6 +259,18 @@ struct NotchView: View {
         return AppLocalization.format(
             "通知与声音已静音至 %@，点击恢复",
             formattedTemporaryMuteTime(mutedUntil)
+        )
+    }
+
+    private var temporaryNotchSleepButtonHelpText: String {
+        guard let sleepUntil = settings.temporarilySleepNotchUntil,
+              AppSettings.isNotchSleepActive(until: sleepUntil) else {
+            return AppLocalization.string("10 分钟休眠刘海屏")
+        }
+
+        return AppLocalization.format(
+            "刘海屏已休眠至 %@，点击恢复",
+            formattedTemporaryMuteTime(sleepUntil)
         )
     }
 
@@ -288,6 +310,12 @@ struct NotchView: View {
         viewModel.closedSize
     }
 
+    private var closedHeaderHeight: CGFloat {
+        isSleepingClosedPresentation
+            ? closedNotchSize.height
+            : max(24, closedNotchSize.height)
+    }
+
     private var notchSize: CGSize {
         switch viewModel.status {
         case .closed, .popping:
@@ -321,7 +349,11 @@ struct NotchView: View {
     }
 
     private var currentNotchShape: NotchShape {
-        NotchShape(
+        if isSleepingClosedPresentation {
+            return NotchShape(topCornerRadius: 4, bottomCornerRadius: 4)
+        }
+
+        return NotchShape(
             topCornerRadius: topCornerRadius,
             bottomCornerRadius: bottomCornerRadius
         )
@@ -356,10 +388,12 @@ struct NotchView: View {
                 viewModel.setManualAttentionActive(hasManualAttentionIndicator)
                 handleProcessingChange()
                 primeStartupPresentationState(sessionMonitor.instances)
+                scheduleTemporaryNotchSleepRestoreIfNeeded(until: settings.temporarilySleepNotchUntil)
                 scheduleDetachmentHintPresentationIfNeeded(delay: Self.startupDetachmentHintDelay)
             }
             .onDisappear {
                 cancelScheduledDetachmentHintPresentation()
+                cancelTemporaryNotchSleepRestore()
             }
             .onChange(of: viewModel.status) { oldStatus, newStatus in
                 handleStatusChange(from: oldStatus, to: newStatus)
@@ -390,6 +424,14 @@ struct NotchView: View {
             }
             .onChange(of: settings.temporarilyMuteNotificationsUntil) { _, mutedUntil in
                 guard AppSettings.isNotificationMuteActive(until: mutedUntil) else { return }
+                clearCompletionNotifications(keepPanelOpen: true)
+                if viewModel.openReason == .notification {
+                    viewModel.exitChat()
+                }
+            }
+            .onChange(of: settings.temporarilySleepNotchUntil) { _, sleepUntil in
+                scheduleTemporaryNotchSleepRestoreIfNeeded(until: sleepUntil)
+                guard AppSettings.isNotchSleepActive(until: sleepUntil) else { return }
                 clearCompletionNotifications(keepPanelOpen: true)
                 if viewModel.openReason == .notification {
                     viewModel.exitChat()
@@ -607,7 +649,7 @@ struct NotchView: View {
         VStack(alignment: .leading, spacing: 0) {
             // Header row - always present, contains pet and spinner that persist across states
             headerRow
-                .frame(height: max(24, closedNotchSize.height))
+                .frame(height: closedHeaderHeight)
                 .zIndex(1)
 
             // Main content only when opened
@@ -632,7 +674,11 @@ struct NotchView: View {
     @ViewBuilder
     private var headerRow: some View {
         Group {
-            if shouldHideClosedContent {
+            if isSleepingClosedPresentation {
+                Color.clear
+                    .frame(width: closedInnerWidth, height: closedNotchSize.height)
+                    .accessibilityLabel("刘海屏正在休眠")
+            } else if shouldHideClosedContent {
                 Color.clear
                     // Preserve the native-notch footprint without letting the
                     // empty closed state expand across the whole window.
@@ -761,6 +807,12 @@ struct NotchView: View {
                 isActive: areReminderNotificationsSuppressed,
                 action: activateTemporaryReminderMute,
                 helpText: temporaryMuteButtonHelpText
+            )
+
+            NotchTemporarySleepButton(
+                isActive: isTemporaryNotchSleepActive,
+                action: activateTemporaryNotchSleep,
+                helpText: temporaryNotchSleepButtonHelpText
             )
 
             NotchSettingsButton(
@@ -941,6 +993,31 @@ struct NotchView: View {
     private func cancelScheduledDetachmentHintPresentation() {
         detachmentHintPresentationWorkItem?.cancel()
         detachmentHintPresentationWorkItem = nil
+    }
+
+    private func scheduleTemporaryNotchSleepRestoreIfNeeded(until sleepUntil: Date?) {
+        temporaryNotchSleepRestoreWorkItem?.cancel()
+        temporaryNotchSleepRestoreWorkItem = nil
+
+        guard let sleepUntil else { return }
+        let remaining = sleepUntil.timeIntervalSinceNow
+        guard remaining > 0 else {
+            AppSettings.clearTemporaryNotchSleep()
+            return
+        }
+
+        let workItem = DispatchWorkItem {
+            guard AppSettings.temporarilySleepNotchUntil == sleepUntil,
+                  AppSettings.isNotchSleepActive(until: sleepUntil) else { return }
+            AppSettings.clearTemporaryNotchSleep()
+        }
+        temporaryNotchSleepRestoreWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + remaining, execute: workItem)
+    }
+
+    private func cancelTemporaryNotchSleepRestore() {
+        temporaryNotchSleepRestoreWorkItem?.cancel()
+        temporaryNotchSleepRestoreWorkItem = nil
     }
 
     private func handlePendingSessionsChange(_ sessions: [SessionState]) {
@@ -1442,6 +1519,20 @@ struct NotchView: View {
         }
     }
 
+    private func activateTemporaryNotchSleep() {
+        if isTemporaryNotchSleepActive {
+            AppSettings.clearTemporaryNotchSleep()
+            return
+        }
+
+        AppSettings.sleepNotch(for: Self.temporaryNotchSleepDuration)
+        clearCompletionNotifications(keepPanelOpen: true)
+
+        withAnimation(viewModel.animation) {
+            viewModel.notchClose()
+        }
+    }
+
     /// Determine if notification sound should play for the given sessions
     /// Returns true if ANY session is not actively focused
     private func shouldPlayNotificationSound(for sessions: [SessionState]) async -> Bool {
@@ -1576,11 +1667,42 @@ private struct NotchTemporaryMuteButton: View {
     let action: () -> Void
     let helpText: String
 
+    var body: some View {
+        NotchHeaderControlButton(
+            systemName: isActive ? "speaker.slash.fill" : "speaker.wave.2.fill",
+            isActive: isActive,
+            action: action,
+            helpText: helpText
+        )
+    }
+}
+
+private struct NotchTemporarySleepButton: View {
+    let isActive: Bool
+    let action: () -> Void
+    let helpText: String
+
+    var body: some View {
+        NotchHeaderControlButton(
+            systemName: "moon.fill",
+            isActive: isActive,
+            action: action,
+            helpText: helpText
+        )
+    }
+}
+
+private struct NotchHeaderControlButton: View {
+    let systemName: String
+    let isActive: Bool
+    let action: () -> Void
+    let helpText: String
+
     @State private var isHovering = false
 
     var body: some View {
         Button(action: action) {
-            Image(systemName: isActive ? "speaker.slash.fill" : "speaker.wave.2.fill")
+            Image(systemName: systemName)
                 .font(.system(size: 11, weight: .semibold))
                 .foregroundStyle(iconForegroundStyle)
                 .frame(width: 28, height: 28)

--- a/PingIslandTests/AppSettingsPersistenceTests.swift
+++ b/PingIslandTests/AppSettingsPersistenceTests.swift
@@ -160,6 +160,36 @@ final class AppSettingsPersistenceTests: XCTestCase {
         XCTAssertEqual(defaults.object(forKey: "autoOpenCompactedNotificationPanel") as? Bool, false)
     }
 
+    func testTemporaryNotchSleepPersistsActiveExpiry() {
+        let defaults = makeDefaults()
+        let store = makeStore(defaults: defaults)
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+        store.sleepNotch(for: 600, now: now)
+
+        let reloadedStore = makeStore(defaults: defaults)
+        XCTAssertEqual(
+            reloadedStore.temporarilySleepNotchUntil?.timeIntervalSince1970 ?? 0,
+            now.addingTimeInterval(600).timeIntervalSince1970,
+            accuracy: 0.001
+        )
+        XCTAssertEqual(
+            defaults.double(forKey: "temporarilySleepNotchUntil"),
+            now.addingTimeInterval(600).timeIntervalSince1970,
+            accuracy: 0.001
+        )
+    }
+
+    func testExpiredTemporaryNotchSleepIsClearedOnReload() {
+        let defaults = makeDefaults()
+        defaults.set(Date.distantPast.timeIntervalSince1970, forKey: "temporarilySleepNotchUntil")
+
+        let store = makeStore(defaults: defaults)
+
+        XCTAssertNil(store.temporarilySleepNotchUntil)
+        XCTAssertNil(defaults.object(forKey: "temporarilySleepNotchUntil"))
+    }
+
     func testAutomaticUpdateChecksEnabledPersists() {
         let defaults = makeDefaults()
         let store = makeStore(defaults: defaults)

--- a/PingIslandTests/NotchViewModelTests.swift
+++ b/PingIslandTests/NotchViewModelTests.swift
@@ -160,6 +160,35 @@ final class NotchViewModelTests: XCTestCase {
         }
     }
 
+    func testTemporaryNotchSleepUsesSmallClosedBarAndStillAllowsHoverOpen() async {
+        await MainActor.run {
+            let viewModel = NotchViewModel(
+                deviceNotchRect: CGRect(x: 0, y: 0, width: 220, height: 38),
+                screenRect: CGRect(x: 0, y: 0, width: 1512, height: 982),
+                windowHeight: 320,
+                hasPhysicalNotch: true,
+                enableEventMonitoring: false,
+                observeSystemEnvironment: false,
+                fullscreenActivityProvider: { _ in false },
+                temporaryNotchSleepProvider: { true }
+            )
+            let hoverPoint = CGPoint(x: viewModel.screenRect.midX, y: viewModel.screenRect.maxY - 4)
+
+            XCTAssertEqual(
+                viewModel.closedSize,
+                CGSize(width: NotchViewModel.temporarySleepClosedWidth, height: 38)
+            )
+            XCTAssertTrue(viewModel.shouldSuppressAutomaticPresentation)
+            XCTAssertTrue(viewModel.isPointInHoverTrigger(hoverPoint))
+
+            viewModel.isHovering = true
+            viewModel.performDeferredHoverOpenIfNeeded()
+
+            XCTAssertEqual(viewModel.status, .opened)
+            XCTAssertEqual(viewModel.openReason, .hover)
+        }
+    }
+
     func testScreenGeometryUpdateRefreshesClosedSizeAndPanelLimits() async {
         await MainActor.run {
             let viewModel = NotchViewModel(


### PR DESCRIPTION
## Summary
- Add a temporary notch sleep button beside the mute control in the opened notch header.
- Persist a 10-minute sleep expiry, auto-clear expired state, and suppress automatic notification presentations while sleeping.
- Collapse the closed docked notch to a centered 30px-wide bar while keeping the normal closed height and hover expansion behavior.
- Add persistence and view-model regression coverage for the new sleep state.

## Impact
Users can temporarily reduce the notch footprint without fully hiding it. Hovering the small center bar still opens the panel for intentional inspection, and the notch restores automatically after 10 minutes.

## Validation
- `swift test --package-path Prototype`
- `xcodebuild -project PingIsland.xcodeproj -scheme PingIsland -configuration Debug CODE_SIGNING_ALLOWED=NO test -only-testing:PingIslandTests/AppSettingsPersistenceTests -only-testing:PingIslandTests/NotchViewModelTests`
- `xcodebuild -project PingIsland.xcodeproj -scheme PingIsland -configuration Debug CODE_SIGNING_ALLOWED=NO test -only-testing:PingIslandTests/NotchViewModelTests/testTemporaryNotchSleepUsesSmallClosedBarAndStillAllowsHoverOpen`
- `git diff --check`

## Notes
- `docs/videos/` was already untracked locally and is intentionally excluded from this PR.
- Manual visual hover testing on a physical notch display was not performed.
