### PR TITLE
Wrap remote SSH commands in /bin/sh to avoid shell interpretation issues

### DIFF
--- a/PingIsland/Services/Remote/RemoteConnectorManager.swift
+++ b/PingIsland/Services/Remote/RemoteConnectorManager.swift
@@ -2204,7 +2204,10 @@ private enum RemoteSSHCommandRunner {
             arguments += ["-p", "\(port)"]
         }
         arguments.append(target)
-        arguments.append(remoteCommand)
+        // Wrap in /bin/sh to avoid fish (or other non-POSIX shells) interpreting
+        // the generated POSIX sh scripts and failing with syntax errors.
+        let encoded = Data(remoteCommand.utf8).base64EncodedString()
+        arguments.append("echo \(encoded) | base64 -d | /bin/sh")
         return arguments
     }
 


### PR DESCRIPTION
Encode the remote command in base64 and decode it through /bin/sh to ensure POSIX sh semantics are used, preventing fish or other non-POSIX shells from misinterpreting the generated scripts.