### PR TITLE
feat: drag floating pet back to notch zone to redock

### DIFF
--- a/PingIsland/App/IslandPresentationCoordinator.swift
+++ b/PingIsland/App/IslandPresentationCoordinator.swift
@@ -90,7 +90,7 @@ final class IslandPresentationCoordinator {
         }
 
         DispatchQueue.main.async { [weak self] in
-            self?.detachedWindowController?.activateInteraction()
+            self?.detachedWindowController?.endWindowDrag()
             self?.persistCurrentFloatingPetAnchor()
         }
     }
@@ -116,6 +116,7 @@ final class IslandPresentationCoordinator {
         detachedWindowController = nil
         activeDetachmentPayload = nil
 
+        AppSettings.surfaceMode = .notch
         viewModel.redockAfterDetached()
         recreateDockedWindow(performBootAnimation: false)
     }
@@ -222,6 +223,9 @@ final class IslandPresentationCoordinator {
                 self?.persistFloatingPetAnchor(petAnchor)
             }
         )
+        detachedWindowController.onRedockRequested = { [weak self] in
+            self?.redockDetached()
+        }
         self.detachedWindowController = detachedWindowController
         return detachedWindowController
     }

--- a/PingIsland/UI/Window/DetachedIslandWindowController.swift
+++ b/PingIsland/UI/Window/DetachedIslandWindowController.swift
@@ -156,6 +156,7 @@ final class DetachedIslandWindowController: NSWindowController, NSWindowDelegate
     private let sessionMonitor: SessionMonitor
     private let onClose: () -> Void
     private let onPetAnchorChanged: (CGPoint) -> Void
+    var onRedockRequested: (() -> Void)?
     private let interactionModel = DetachedIslandInteractionModel()
     private let bubbleViewState = DetachedIslandBubbleViewState()
     private var manualAttentionTracker = SessionManualAttentionTracker()
@@ -176,6 +177,7 @@ final class DetachedIslandWindowController: NSWindowController, NSWindowDelegate
     private var petMouseDownPoint: CGPoint?
     private var petMouseDownScreenPoint: CGPoint?
     private var isPetDragActive = false
+    private var isPetInNotchZone = false
     private var isPetSecondaryClickArmed = false
     private var hasPrimedSoundTransitions = false
     private var previousProcessingIds = Set<String>()
@@ -436,6 +438,7 @@ final class DetachedIslandWindowController: NSWindowController, NSWindowDelegate
         )
         window.setFrameOrigin(origin)
         updateBubblePlacementForCurrentWindow()
+        isPetInNotchZone = isPetAnchorInNotchZone()
     }
 
     func beginFloatingDrag() {
@@ -461,13 +464,28 @@ final class DetachedIslandWindowController: NSWindowController, NSWindowDelegate
         )
         window.setFrameOrigin(origin)
         updateBubblePlacementForCurrentWindow()
+        isPetInNotchZone = isPetAnchorInNotchZone()
     }
 
     func endFloatingDrag() {
         floatingDragStartOrigin = nil
         interactionModel.setPetDragging(false)
+        if isPetInNotchZone {
+            isPetInNotchZone = false
+            onRedockRequested?()
+            return
+        }
         if let currentPetAnchor {
             onPetAnchorChanged(currentPetAnchor)
+        }
+        activateInteraction()
+    }
+
+    func endWindowDrag() {
+        if isPetInNotchZone {
+            isPetInNotchZone = false
+            onRedockRequested?()
+            return
         }
         activateInteraction()
     }
@@ -1072,11 +1090,27 @@ final class DetachedIslandWindowController: NSWindowController, NSWindowDelegate
     }
 
     private func screenPoint(for event: NSEvent) -> CGPoint {
-        // Window movement and hit-testing use AppKit screen coordinates (origin at bottom-left).
         MouseEventReplay.appKitScreenLocation(
             for: event,
             fallbackScreenLocation: NSEvent.mouseLocation
         )
+    }
+
+    private func isPetAnchorInNotchZone() -> Bool {
+        guard let petAnchor = currentPetAnchor else { return false }
+        let targetRect: CGRect
+        if viewModel.shouldHideWindowPresentation {
+            let screenRect = viewModel.screenRect
+            targetRect = CGRect(
+                x: screenRect.midX - 80,
+                y: screenRect.maxY - 60,
+                width: 160,
+                height: 60
+            )
+        } else {
+            targetRect = viewModel.closedScreenRect.insetBy(dx: -30, dy: -30)
+        }
+        return targetRect.contains(petAnchor)
     }
 
     private func syncBubblePresentation(to targetState: DetachedIslandBubbleState) {


### PR DESCRIPTION
## Summary

This PR adds the ability to drag the floating pet back to the notch zone to automatically redock and switch back to the docked island presentation mode.

## Changes

### `DetachedIslandWindowController.swift`
- Add `onRedockRequested` callback property for notifying the coordinator when a redock is requested
- Add `isPetInNotchZone` state to track whether the pet anchor is within the notch zone during drag
- Add `isPetAnchorInNotchZone()` method that detects when the pet is near the notch area:
  - On devices with a physical notch: checks if the pet anchor is within the closed screen rect (with 30pt inset tolerance)
  - On notch-less displays (including fullscreen-hidden mode): checks if the pet anchor is within a 160×60pt area centered at the top of the screen
- Update `updateDragPosition()` to track `isPetInNotchZone` during detachment drag
- Update `updateFloatingDrag()` to track `isPetInNotchZone` during floating pet drag
- Update `endFloatingDrag()` to check for redock before normalizing the pet position
- Add `endWindowDrag()` method to handle detachment drag end with redock check

### `IslandPresentationCoordinator.swift`
- Connect `onRedockRequested` callback in `ensureDetachedWindowController()` to call `redockDetached()`
- Update `finishDetachment()` to call `endWindowDrag()` instead of `activateInteraction()` to support redock detection
- Add `AppSettings.surfaceMode = .notch` in `redockDetached()` to sync the surface mode setting

## Demo

1. Long-press the docked island to detach the pet
2. Drag the floating pet back to the notch area
3. Release — the pet automatically redocks and switches back to island mode

On devices without a physical notch, dragging the pet to the top-center of the screen triggers the same redock behavior.