### PR TITLE
feat: display per-session token usage and output rate in session list

### DIFF
--- a/PingIsland/Models/ChatMessage.swift
+++ b/PingIsland/Models/ChatMessage.swift
@@ -7,11 +7,69 @@
 
 import Foundation
 
+struct MessageTokenUsage: Equatable, Sendable {
+    let inputTokens: Int
+    let outputTokens: Int
+    let cacheCreationInputTokens: Int
+    let cacheReadInputTokens: Int
+
+    nonisolated var totalTokens: Int {
+        inputTokens + cacheCreationInputTokens + cacheReadInputTokens + outputTokens
+    }
+
+    static let zero = MessageTokenUsage(inputTokens: 0, outputTokens: 0, cacheCreationInputTokens: 0, cacheReadInputTokens: 0)
+}
+
+struct SessionTokenUsage: Equatable, Sendable {
+    var inputTokens: Int
+    var outputTokens: Int
+    var cacheCreationInputTokens: Int
+    var cacheReadInputTokens: Int
+    var turnCount: Int
+    var firstTurnTimestamp: Date?
+    var lastTurnTimestamp: Date?
+
+    nonisolated var totalTokens: Int {
+        inputTokens + cacheCreationInputTokens + cacheReadInputTokens + outputTokens
+    }
+
+    nonisolated var tokensPerSecond: Double? {
+        guard let first = firstTurnTimestamp,
+              let last = lastTurnTimestamp,
+              turnCount > 1 else { return nil }
+        let elapsed = last.timeIntervalSince(first)
+        guard elapsed > 0 else { return nil }
+        return Double(totalTokens) / elapsed
+    }
+
+    nonisolated var outputTokensPerSecond: Double? {
+        guard let first = firstTurnTimestamp,
+              let last = lastTurnTimestamp,
+              turnCount > 1 else { return nil }
+        let elapsed = last.timeIntervalSince(first)
+        guard elapsed > 0 else { return nil }
+        return Double(outputTokens) / elapsed
+    }
+
+    static let zero = SessionTokenUsage(inputTokens: 0, outputTokens: 0, cacheCreationInputTokens: 0, cacheReadInputTokens: 0, turnCount: 0)
+
+    mutating func accumulate(_ usage: MessageTokenUsage, timestamp: Date) {
+        inputTokens += usage.inputTokens
+        outputTokens += usage.outputTokens
+        cacheCreationInputTokens += usage.cacheCreationInputTokens
+        cacheReadInputTokens += usage.cacheReadInputTokens
+        turnCount += 1
+        if firstTurnTimestamp == nil { firstTurnTimestamp = timestamp }
+        lastTurnTimestamp = timestamp
+    }
+}
+
 struct ChatMessage: Identifiable, Equatable {
     let id: String
     let role: ChatRole
     let timestamp: Date
     let content: [MessageBlock]
+    let usage: MessageTokenUsage?
 
     static func == (lhs: ChatMessage, rhs: ChatMessage) -> Bool {
         lhs.id == rhs.id

--- a/PingIsland/Models/SessionState.swift
+++ b/PingIsland/Models/SessionState.swift
@@ -96,6 +96,10 @@ struct SessionState: Equatable, Identifiable, Sendable {
 
     var conversationInfo: ConversationInfo
 
+    // MARK: - Token Usage
+
+    var tokenUsage: SessionTokenUsage
+
     // MARK: - Clear Reconciliation
 
     /// When true, the next file update should reconcile chatItems with parser state
@@ -145,6 +149,7 @@ struct SessionState: Equatable, Identifiable, Sendable {
             summary: nil, lastMessage: nil, lastMessageRole: nil,
             lastToolName: nil, firstUserMessage: nil, lastUserMessageDate: nil
         ),
+        tokenUsage: SessionTokenUsage = .zero,
         needsClearReconciliation: Bool = false,
         lastActivity: Date = Date(),
         createdAt: Date = Date()
@@ -177,6 +182,7 @@ struct SessionState: Equatable, Identifiable, Sendable {
         self.completedErrorToolIDs = completedErrorToolIDs
         self.subagentState = subagentState
         self.conversationInfo = conversationInfo
+        self.tokenUsage = tokenUsage
         self.needsClearReconciliation = needsClearReconciliation
         self.lastActivity = lastActivity
         self.createdAt = createdAt

--- a/PingIsland/Services/Hooks/HookWalkthroughDemoRunner.swift
+++ b/PingIsland/Services/Hooks/HookWalkthroughDemoRunner.swift
@@ -71,7 +71,8 @@ final class HookWalkthroughDemoRunner {
                         id: "\(sessionId)-assistant-complete",
                         role: .assistant,
                         timestamp: now,
-                        content: [.text(AppLocalization.string("Hooks 审批演示完成：你刚刚体验了通知、审批提交、处理完成、以及完成提醒。顶部 Island 和独立悬浮宠物会共用这一套流程。"))]
+                        content: [.text(AppLocalization.string("Hooks 审批演示完成：你刚刚体验了通知、审批提交、处理完成、以及完成提醒。顶部 Island 和独立悬浮宠物会共用这一套流程。"))],
+                        usage: nil
                     )
                 ],
                 completedTools: [toolUseId],

--- a/PingIsland/Services/Session/ConversationParser.swift
+++ b/PingIsland/Services/Session/ConversationParser.swift
@@ -908,7 +908,7 @@ actor ConversationParser {
         }
 
         guard !blocks.isEmpty else { return nil }
-        return ChatMessage(id: messageID, role: chatRole, timestamp: timestamp, content: blocks)
+        return ChatMessage(id: messageID, role: chatRole, timestamp: timestamp, content: blocks, usage: nil)
     }
 
     private func parseCodeBuddyHistoryToolMessage(
@@ -1704,11 +1704,29 @@ actor ConversationParser {
 
         let role: ChatRole = type == "user" ? .user : .assistant
 
+        let usage: MessageTokenUsage? = type == "assistant" ? Self.parseUsage(from: messageDict) : nil
+
         return ChatMessage(
             id: uuid,
             role: role,
             timestamp: timestamp,
-            content: blocks
+            content: blocks,
+            usage: usage
+        )
+    }
+
+    private nonisolated static func parseUsage(from messageDict: [String: Any]) -> MessageTokenUsage? {
+        guard let usageDict = messageDict["usage"] as? [String: Any] else { return nil }
+        let inputTokens = usageDict["input_tokens"] as? Int ?? 0
+        let outputTokens = usageDict["output_tokens"] as? Int ?? 0
+        let cacheCreation = usageDict["cache_creation_input_tokens"] as? Int ?? 0
+        let cacheRead = usageDict["cache_read_input_tokens"] as? Int ?? 0
+        guard inputTokens > 0 || outputTokens > 0 || cacheCreation > 0 || cacheRead > 0 else { return nil }
+        return MessageTokenUsage(
+            inputTokens: inputTokens,
+            outputTokens: outputTokens,
+            cacheCreationInputTokens: cacheCreation,
+            cacheReadInputTokens: cacheRead
         )
     }
 
@@ -1759,7 +1777,7 @@ actor ConversationParser {
         }
 
         guard !blocks.isEmpty else { return nil }
-        return ChatMessage(id: id, role: role, timestamp: timestamp, content: blocks)
+        return ChatMessage(id: id, role: role, timestamp: timestamp, content: blocks, usage: nil)
     }
 
     private func parseToolUse(_ block: [String: Any]) -> ToolUseBlock? {

--- a/PingIsland/Services/State/SessionStore.swift
+++ b/PingIsland/Services/State/SessionStore.swift
@@ -1940,6 +1940,12 @@ actor SessionStore {
 
         session.toolTracker.lastSyncTime = Date()
 
+        for message in payload.messages {
+            if let usage = message.usage {
+                session.tokenUsage.accumulate(usage, timestamp: message.timestamp)
+            }
+        }
+
         await populateSubagentToolsFromAgentFiles(
             session: &session,
             cwd: payload.cwd,
@@ -2699,6 +2705,12 @@ actor SessionStore {
 
         // Sort by timestamp
         session.chatItems.sort { $0.timestamp < $1.timestamp }
+
+        for message in messages {
+            if let usage = message.usage {
+                session.tokenUsage.accumulate(usage, timestamp: message.timestamp)
+            }
+        }
 
         await applyQoderFallbackIntervention(to: &session)
         applyClaudeTranscriptQuestionFallback(to: &session)

--- a/PingIsland/UI/Views/SessionListView.swift
+++ b/PingIsland/UI/Views/SessionListView.swift
@@ -767,6 +767,14 @@ struct InstanceRow: View {
                         if let primarySupplementaryBadge {
                             supplementaryBadgeView(primarySupplementaryBadge)
                         }
+                        if let tokenBadgeLabel {
+                            metaBadge(
+                                tokenBadgeLabel,
+                                tint: tokenBadgeTint,
+                                foreground: tokenBadgeForeground,
+                                fontDesign: .monospaced
+                            )
+                        }
                     }
 
                     trailingActions
@@ -989,6 +997,50 @@ struct InstanceRow: View {
 
     private var timeLabel: String {
         SessionPhaseHelpers.timeBadgeLabel(for: session.attentionRequestedAt ?? session.lastActivity)
+    }
+
+    private var tokenBadgeLabel: String? {
+        let usage = session.tokenUsage
+        guard usage.totalTokens > 0 else { return nil }
+        if let rate = usage.outputTokensPerSecond, rate > 0 {
+            return "\(formatTokenCount(usage.totalTokens)) · \(formatTokenRate(rate))/s"
+        }
+        return formatTokenCount(usage.totalTokens)
+    }
+
+    private var tokenBadgeTint: Color {
+        guard session.tokenUsage.totalTokens > 0 else { return Color.clear }
+        if let rate = session.tokenUsage.outputTokensPerSecond {
+            if rate >= 100 { return TerminalColors.green.opacity(0.18) }
+            if rate >= 30 { return TerminalColors.amber.opacity(0.18) }
+        }
+        return Color.white.opacity(0.08)
+    }
+
+    private var tokenBadgeForeground: Color {
+        guard session.tokenUsage.totalTokens > 0 else { return Color.clear }
+        if let rate = session.tokenUsage.outputTokensPerSecond {
+            if rate >= 100 { return TerminalColors.green }
+            if rate >= 30 { return TerminalColors.amber }
+        }
+        return .white.opacity(0.6)
+    }
+
+    private func formatTokenCount(_ count: Int) -> String {
+        if count >= 1_000_000 {
+            return String(format: "%.1fM", Double(count) / 1_000_000)
+        }
+        if count >= 1_000 {
+            return String(format: "%.1fk", Double(count) / 1_000)
+        }
+        return "\(count)"
+    }
+
+    private func formatTokenRate(_ rate: Double) -> String {
+        if rate >= 1_000 {
+            return String(format: "%.0fk", rate / 1_000)
+        }
+        return String(format: "%.0f", rate)
     }
 
     private var ideHostBadgeTint: Color {

--- a/PingIslandTests/ClaudeAskUserQuestionSessionTests.swift
+++ b/PingIslandTests/ClaudeAskUserQuestionSessionTests.swift
@@ -394,7 +394,8 @@ final class ClaudeAskUserQuestionSessionTests: XCTestCase {
                                     ]
                                 )
                             )
-                        ]
+                        ],
+                        usage: nil
                     )
                 ],
                 completedTools: [],
@@ -456,7 +457,8 @@ final class ClaudeAskUserQuestionSessionTests: XCTestCase {
                                     ]
                                 )
                             )
-                        ]
+                        ],
+                        usage: nil
                     )
                 ],
                 completedTools: [],

--- a/PingIslandTests/QoderWorkContinuationTests.swift
+++ b/PingIslandTests/QoderWorkContinuationTests.swift
@@ -63,7 +63,8 @@ final class QoderWorkContinuationTests: XCTestCase {
                         id: "assistant-next",
                         role: .assistant,
                         timestamp: answeredAt.addingTimeInterval(1),
-                        content: [.text("继续处理后续任务")]
+                        content: [.text("继续处理后续任务")],
+                        usage: nil
                     )
                 ],
                 isIncremental: true,
@@ -196,7 +197,8 @@ final class QoderWorkContinuationTests: XCTestCase {
                         id: "assistant-next",
                         role: .assistant,
                         timestamp: Date(),
-                        content: [.text("继续处理后续任务")]
+                        content: [.text("继续处理后续任务")],
+                        usage: nil
                     )
                 ],
                 isIncremental: true,
@@ -241,7 +243,8 @@ final class QoderWorkContinuationTests: XCTestCase {
                         id: "assistant-next",
                         role: .assistant,
                         timestamp: Date(),
-                        content: [.text("继续处理后续任务")]
+                        content: [.text("继续处理后续任务")],
+                        usage: nil
                     )
                 ],
                 isIncremental: true,
@@ -286,7 +289,8 @@ final class QoderWorkContinuationTests: XCTestCase {
                         id: "assistant-next",
                         role: .assistant,
                         timestamp: Date(),
-                        content: [.text("继续处理后续任务")]
+                        content: [.text("继续处理后续任务")],
+                        usage: nil
                     )
                 ],
                 isIncremental: true,
@@ -334,7 +338,8 @@ final class QoderWorkContinuationTests: XCTestCase {
                         id: "assistant-existing",
                         role: .assistant,
                         timestamp: answeredAt.addingTimeInterval(-10),
-                        content: [.text("这是提交前就存在的旧消息")]
+                        content: [.text("这是提交前就存在的旧消息")],
+                        usage: nil
                     )
                 ],
                 isIncremental: false,

--- a/PingIslandTests/SessionInterventionFallbackTests.swift
+++ b/PingIslandTests/SessionInterventionFallbackTests.swift
@@ -115,7 +115,8 @@ final class SessionInterventionFallbackTests: XCTestCase {
                                     """
                                 ]
                             ))
-                        ]
+                        ],
+                        usage: nil
                     )
                 ],
                 isIncremental: true,
@@ -181,7 +182,8 @@ final class SessionInterventionFallbackTests: XCTestCase {
                                     """
                                 ]
                             ))
-                        ]
+                        ],
+                        usage: nil
                     )
                 ],
                 isIncremental: true,

--- a/PingIslandTests/SessionStoreFileUpdateTests.swift
+++ b/PingIslandTests/SessionStoreFileUpdateTests.swift
@@ -151,7 +151,8 @@ final class SessionStoreFileUpdateTests: XCTestCase {
                         id: "assistant-update",
                         role: .assistant,
                         timestamp: Date(),
-                        content: [.text("Continuing work")]
+                        content: [.text("Continuing work")],
+                        usage: nil
                     )
                 ],
                 isIncremental: true,
@@ -249,7 +250,8 @@ final class SessionStoreFileUpdateTests: XCTestCase {
                         id: "user-followup",
                         role: .user,
                         timestamp: Date(),
-                        content: [.text("One more thing")]
+                        content: [.text("One more thing")],
+                        usage: nil
                     )
                 ],
                 isIncremental: true,
@@ -337,7 +339,8 @@ final class SessionStoreFileUpdateTests: XCTestCase {
                         id: "assistant-final",
                         role: .assistant,
                         timestamp: Date(),
-                        content: [.text("Final answer")]
+                        content: [.text("Final answer")],
+                        usage: nil
                     )
                 ],
                 isIncremental: true,
@@ -491,7 +494,8 @@ final class SessionStoreFileUpdateTests: XCTestCase {
                         id: "assistant-followup",
                         role: .assistant,
                         timestamp: Date(),
-                        content: [.text("Fresh transcript output")]
+                        content: [.text("Fresh transcript output")],
+                        usage: nil
                     )
                 ],
                 isIncremental: true,


### PR DESCRIPTION
## Summary

Display per-session token usage and output token rate in the session list, giving users real-time visibility into how many tokens each agent session is consuming and at what speed.

## Changes

### Data Models
- **`MessageTokenUsage`**: Captures per-message token breakdown (`inputTokens`, `outputTokens`, `cacheCreationInputTokens`, `cacheReadInputTokens`)
- **`SessionTokenUsage`**: Aggregates token data per session with `turnCount`, `firstTurnTimestamp`, `lastTurnTimestamp`, and computed properties for `totalTokens`, `tokensPerSecond`, `outputTokensPerSecond`

### Parsing
- **`ConversationParser.parseMessageLine()`**: Now extracts `message.usage` from `assistant`-type JSONL lines
- **`ConversationParser.parseUsage()`**: New static method that parses the `usage` dictionary from Claude's JSONL format

### State Management
- **`SessionState.tokenUsage`**: New field tracking cumulative token consumption per session
- **`SessionStore.processFileUpdate()`**: Accumulates token data from new messages as they arrive
- **`SessionStore.processHistoryLoaded()`**: Accumulates token data when full conversation history is loaded

### UI
- **InstanceRow token badge**: Displays token count and output rate (e.g., `1.2k · 85/s`)
- Rate-based color coding:
  - 🟢 Green: ≥100 output tokens/sec
  - 🟡 Amber: ≥30 output tokens/sec
  - ⚪ Gray: <30 output tokens/sec or rate unavailable

## Screenshot

Token badge appears in the session list row alongside the time and provider badges:
```
[🤖] projectName · task description
     latest message preview...
     2m · Claude  [1.2k · 85/s]
```

## Test Plan

- [x] Build succeeds with `CODE_SIGNING_ALLOWED=NO`
- [ ] Manual test: Start a Claude Code session and verify token badge appears in session list
- [ ] Verify token count increases as the session progresses
- [ ] Verify output rate badge color changes based on activity
- [ ] Verify badge is hidden when no token data is available
- [ ] Verify existing test suite passes