### PR TITLE
Quiet settled Island presentation by surface mode

### DIFF
--- a/PingIsland/Core/NotchViewModel.swift
+++ b/PingIsland/Core/NotchViewModel.swift
@@ -50,6 +50,7 @@ class NotchViewModel: ObservableObject {
     @Published private(set) var isFullscreenPhysicalNotchCompactActive = false
     @Published private(set) var isFullscreenBrowserHiddenActive = false
     @Published private(set) var isIdleAutoHiddenActive = false
+    @Published private(set) var isQuietBackgroundPresentationActive = false
     @Published private(set) var isSettingsPopoverPresented = false
     @Published private(set) var isInlineTextInputActive = false
 
@@ -715,6 +716,9 @@ class NotchViewModel: ObservableObject {
         if isIdleAutoHiddenActive && status != .opened {
             return true
         }
+        if isQuietBackgroundPresentationActive && status != .opened {
+            return true
+        }
         return false
     }
 
@@ -748,6 +752,11 @@ class NotchViewModel: ObservableObject {
         if shouldHide != isIdleAutoHiddenActive {
             isIdleAutoHiddenActive = shouldHide
         }
+    }
+
+    func updateQuietBackgroundPresentationState(isActive: Bool) {
+        guard isQuietBackgroundPresentationActive != isActive else { return }
+        isQuietBackgroundPresentationActive = isActive
     }
 
     private var fullscreenRevealTriggerRect: CGRect {

--- a/PingIsland/UI/Views/NotchView.swift
+++ b/PingIsland/UI/Views/NotchView.swift
@@ -447,6 +447,14 @@ struct NotchView: View {
                     scheduleDetachmentHintPresentationIfNeeded(delay: Self.detachmentHintRetryDelay)
                 }
             }
+            .onChange(of: viewModel.isQuietBackgroundPresentationActive) { _, isActive in
+                if isActive && viewModel.status != .opened {
+                    isVisible = false
+                } else {
+                    handleProcessingChange()
+                    scheduleDetachmentHintPresentationIfNeeded(delay: Self.detachmentHintRetryDelay)
+                }
+            }
             .onChange(of: viewModel.presentationMode) { _, _ in
                 scheduleDetachmentHintPresentationIfNeeded(delay: Self.detachmentHintRetryDelay)
             }

--- a/PingIsland/UI/Window/DetachedIslandWindowController.swift
+++ b/PingIsland/UI/Window/DetachedIslandWindowController.swift
@@ -151,11 +151,14 @@ final class DetachedIslandViewController: NSViewController {
 final class DetachedIslandWindowController: NSWindowController, NSWindowDelegate {
     private static let defaultTrailingInset: CGFloat = 32
     private static let defaultBottomInset: CGFloat = 48
+    private static let quietBackgroundWindowAlpha: CGFloat = 0.38
+    private static let interactiveWindowAlpha: CGFloat = 1
 
     private let viewModel: NotchViewModel
     private let sessionMonitor: SessionMonitor
     private let onClose: () -> Void
     private let onPetAnchorChanged: (CGPoint) -> Void
+    private let energyModePublisher: AnyPublisher<EnergyMode, Never>
     var onRedockRequested: (() -> Void)?
     private let interactionModel = DetachedIslandInteractionModel()
     private let bubbleViewState = DetachedIslandBubbleViewState()
@@ -187,11 +190,13 @@ final class DetachedIslandWindowController: NSWindowController, NSWindowDelegate
     private var previousResourceLimitIds = Set<String>()
     private var previousCompletionNotificationPhases: [String: SessionPhase] = [:]
     private var completionNotificationQueue: [SessionCompletionNotification] = []
+    private var currentEnergyMode: EnergyMode = .quietBackground
     var bubbleHoverGraceDelay: TimeInterval = 3
     var completionNotificationDismissDelay: TimeInterval = 5
     private var activeCompletionNotification: SessionCompletionNotification? {
         didSet {
             bubbleViewState.setActiveCompletionNotification(activeCompletionNotification)
+            updateQuietBackgroundWindowOpacity(animated: true)
         }
     }
 
@@ -203,12 +208,14 @@ final class DetachedIslandWindowController: NSWindowController, NSWindowDelegate
         viewModel: NotchViewModel,
         sessionMonitor: SessionMonitor,
         onClose: @escaping () -> Void,
-        onPetAnchorChanged: @escaping (CGPoint) -> Void = { _ in }
+        onPetAnchorChanged: @escaping (CGPoint) -> Void = { _ in },
+        energyModePublisher: AnyPublisher<EnergyMode, Never>? = nil
     ) {
         self.viewModel = viewModel
         self.sessionMonitor = sessionMonitor
         self.onClose = onClose
         self.onPetAnchorChanged = onPetAnchorChanged
+        self.energyModePublisher = energyModePublisher ?? EnergyGovernor.shared.$mode.eraseToAnyPublisher()
         self.lastAppliedLayout = Self.windowLayout(
             for: viewModel,
             sessionMonitor: sessionMonitor
@@ -249,6 +256,7 @@ final class DetachedIslandWindowController: NSWindowController, NSWindowDelegate
         window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .ignoresCycle]
         window.tabbingMode = .disallowed
         window.isReleasedWhenClosed = false
+        window.alphaValue = Self.quietBackgroundWindowAlpha
 
         super.init(window: window)
 
@@ -325,6 +333,7 @@ final class DetachedIslandWindowController: NSWindowController, NSWindowDelegate
         )
         window.setFrame(initialFrame, display: false)
         updateBubblePlacementForCurrentWindow()
+        updateQuietBackgroundWindowOpacity(animated: false)
         showWindow(
             window,
             activatesApplication: activatesApplication
@@ -363,6 +372,7 @@ final class DetachedIslandWindowController: NSWindowController, NSWindowDelegate
         let frame = NSRect(origin: origin, size: lastAppliedLayout.containerSize)
         window.setFrame(frame, display: false)
         updateBubblePlacementForCurrentWindow()
+        updateQuietBackgroundWindowOpacity(animated: false)
         showWindow(
             window,
             activatesApplication: activatesApplication
@@ -446,6 +456,7 @@ final class DetachedIslandWindowController: NSWindowController, NSWindowDelegate
         cancelInteractionActivation()
         interactionModel.resetForDragSuppression()
         interactionModel.setPetDragging(true)
+        updateQuietBackgroundWindowOpacity(animated: true)
         hideBubbleRenderingImmediately()
         floatingDragStartOrigin = window?.frame.origin
     }
@@ -478,6 +489,7 @@ final class DetachedIslandWindowController: NSWindowController, NSWindowDelegate
         if let currentPetAnchor {
             onPetAnchorChanged(currentPetAnchor)
         }
+        updateQuietBackgroundWindowOpacity(animated: true)
         activateInteraction()
     }
 
@@ -487,6 +499,7 @@ final class DetachedIslandWindowController: NSWindowController, NSWindowDelegate
             onRedockRequested?()
             return
         }
+        updateQuietBackgroundWindowOpacity(animated: true)
         activateInteraction()
     }
 
@@ -552,6 +565,15 @@ final class DetachedIslandWindowController: NSWindowController, NSWindowDelegate
         interactionModel.isPetDragging
     }
 
+    var windowAlphaForTesting: CGFloat? {
+        window?.alphaValue
+    }
+
+    func applyEnergyModeForTesting(_ mode: EnergyMode) {
+        currentEnergyMode = mode
+        updateQuietBackgroundWindowOpacity(animated: false)
+    }
+
     func applySessionSnapshotForTesting(_ sessions: [SessionState]) {
         sessionMonitor.instances = sessions
         handleManualAttentionChange()
@@ -592,6 +614,7 @@ final class DetachedIslandWindowController: NSWindowController, NSWindowDelegate
         floatingDragStartOrigin = nil
         interactionModel.setPetDragging(false)
         window?.orderOut(nil)
+        window?.alphaValue = Self.interactiveWindowAlpha
     }
 
     func windowShouldClose(_ sender: NSWindow) -> Bool {
@@ -657,6 +680,24 @@ final class DetachedIslandWindowController: NSWindowController, NSWindowDelegate
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.scheduleWindowSizeUpdate()
+            }
+            .store(in: &cancellables)
+
+        interactionModel.$isPetDragging
+            .dropFirst()
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.updateQuietBackgroundWindowOpacity(animated: true)
+            }
+            .store(in: &cancellables)
+
+        energyModePublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] mode in
+                guard let self else { return }
+                self.currentEnergyMode = mode
+                self.updateQuietBackgroundWindowOpacity(animated: true)
             }
             .store(in: &cancellables)
 
@@ -1116,6 +1157,7 @@ final class DetachedIslandWindowController: NSWindowController, NSWindowDelegate
     private func syncBubblePresentation(to targetState: DetachedIslandBubbleState) {
         bubbleVisibilityWorkItem?.cancel()
         bubbleVisibilityWorkItem = nil
+        updateQuietBackgroundWindowOpacity(animated: true)
 
         switch targetState {
         case .hidden:
@@ -1159,6 +1201,7 @@ final class DetachedIslandWindowController: NSWindowController, NSWindowDelegate
             guard self.interactionModel.bubbleState == .hidden else { return }
             self.applyWindowSizeUpdateImmediately(renderedBubbleState: .hidden)
             self.bubbleViewState.prepareLayout(for: .hidden)
+            self.updateQuietBackgroundWindowOpacity(animated: true)
         }
 
         bubbleVisibilityWorkItem = workItem
@@ -1184,6 +1227,30 @@ final class DetachedIslandWindowController: NSWindowController, NSWindowDelegate
         syncOutsideClickMonitor()
         reconcileHighlightedSessionState()
         recordBubbleTelemetryTransition(from: previousState, to: interactionModel.bubbleState)
+    }
+
+    private var shouldDimForQuietBackground: Bool {
+        currentEnergyMode == .quietBackground
+            && interactionModel.bubbleState == .hidden
+            && !interactionModel.isPetDragging
+            && activeCompletionNotification == nil
+    }
+
+    private func updateQuietBackgroundWindowOpacity(animated: Bool) {
+        guard let window else { return }
+        let targetAlpha = shouldDimForQuietBackground
+            ? Self.quietBackgroundWindowAlpha
+            : Self.interactiveWindowAlpha
+        guard abs(window.alphaValue - targetAlpha) > 0.01 else { return }
+
+        if animated {
+            NSAnimationContext.runAnimationGroup { context in
+                context.duration = 0.18
+                window.animator().alphaValue = targetAlpha
+            }
+        } else {
+            window.alphaValue = targetAlpha
+        }
     }
 
     private func recordBubbleTelemetryTransition(

--- a/PingIsland/UI/Window/NotchWindowController.swift
+++ b/PingIsland/UI/Window/NotchWindowController.swift
@@ -96,6 +96,14 @@ class NotchWindowController: NSWindowController {
             }
             .store(in: &cancellables)
 
+        viewModel.$isQuietBackgroundPresentationActive
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self, weak notchWindow, weak viewModel] _ in
+                guard let self, let notchWindow, let viewModel else { return }
+                self.updateWindowPresentation(window: notchWindow, viewModel: viewModel)
+            }
+            .store(in: &cancellables)
+
         viewModel.$presentationMode
             .receive(on: DispatchQueue.main)
             .sink { [weak self, weak notchWindow, weak viewModel] _ in
@@ -116,6 +124,15 @@ class NotchWindowController: NSWindowController {
             .receive(on: DispatchQueue.main)
             .sink { [weak self, weak notchWindow, weak viewModel] _ in
                 guard let self, let notchWindow, let viewModel else { return }
+                self.updateWindowPresentation(window: notchWindow, viewModel: viewModel)
+            }
+            .store(in: &cancellables)
+
+        EnergyGovernor.shared.$mode
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self, weak notchWindow, weak viewModel] mode in
+                guard let self, let notchWindow, let viewModel else { return }
+                viewModel.updateQuietBackgroundPresentationState(isActive: mode == .quietBackground)
                 self.updateWindowPresentation(window: notchWindow, viewModel: viewModel)
             }
             .store(in: &cancellables)

--- a/PingIslandTests/DetachedIslandWindowControllerTests.swift
+++ b/PingIslandTests/DetachedIslandWindowControllerTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Combine
 import SwiftUI
 import XCTest
 @testable import Ping_Island
@@ -93,6 +94,42 @@ final class DetachedIslandWindowControllerTests: XCTestCase {
         XCTAssertTrue(window.collectionBehavior.contains(.canJoinAllSpaces))
         XCTAssertTrue(window.collectionBehavior.contains(.fullScreenAuxiliary))
         XCTAssertTrue(window.collectionBehavior.contains(.ignoresCycle))
+    }
+
+    func testQuietBackgroundDimsDetachedPetUntilBubbleInteraction() throws {
+        let viewModel = makeViewModel()
+        let sessionMonitor = makeSessionMonitor()
+        sessionMonitor.instances = [
+            makeSession(id: "active", phase: .processing)
+        ]
+
+        let controller = DetachedIslandWindowController(
+            viewModel: viewModel,
+            sessionMonitor: sessionMonitor,
+            onClose: {},
+            energyModePublisher: Empty<EnergyMode, Never>(completeImmediately: false).eraseToAnyPublisher()
+        )
+        defer { controller.dismiss() }
+
+        controller.present(atPetAnchor: CGPoint(x: 1260, y: 180), activatesApplication: false)
+        controller.applyEnergyModeForTesting(.quietBackground)
+
+        XCTAssertEqual(try XCTUnwrap(controller.windowAlphaForTesting), 0.38, accuracy: 0.01)
+        XCTAssertTrue(try XCTUnwrap(controller.window).isVisible)
+
+        controller.presentHoverBubbleForTesting()
+        controller.applyEnergyModeForTesting(.quietBackground)
+
+        XCTAssertEqual(try XCTUnwrap(controller.windowAlphaForTesting), 1, accuracy: 0.01)
+
+        controller.hideBubbleForTesting()
+        waitForBubbleHidden(controller)
+        controller.applyEnergyModeForTesting(.quietBackground)
+
+        XCTAssertEqual(try XCTUnwrap(controller.windowAlphaForTesting), 0.38, accuracy: 0.01)
+
+        controller.applyEnergyModeForTesting(.active)
+        XCTAssertEqual(try XCTUnwrap(controller.windowAlphaForTesting), 1, accuracy: 0.01)
     }
 
     func testPetInteractionFrameConvertsTopAnchoredLayoutIntoWindowCoordinates() {

--- a/PingIslandTests/NotchViewModelTests.swift
+++ b/PingIslandTests/NotchViewModelTests.swift
@@ -456,6 +456,35 @@ final class NotchViewModelTests: XCTestCase {
         }
     }
 
+    func testQuietBackgroundHidesClosedDockedPresentationButPreservesOpenedPanel() async {
+        let viewModel = await MainActor.run {
+            NotchViewModel(
+                deviceNotchRect: .zero,
+                screenRect: CGRect(x: 0, y: 0, width: 1440, height: 900),
+                windowHeight: 320,
+                hasPhysicalNotch: false,
+                enableEventMonitoring: false,
+                observeSystemEnvironment: false
+            )
+        }
+
+        await MainActor.run {
+            viewModel.updateQuietBackgroundPresentationState(isActive: true)
+
+            XCTAssertTrue(viewModel.isQuietBackgroundPresentationActive)
+            XCTAssertTrue(viewModel.shouldHideWindowPresentation)
+
+            viewModel.notchOpen(reason: .click)
+            XCTAssertFalse(viewModel.shouldHideWindowPresentation)
+
+            viewModel.notchClose()
+            XCTAssertTrue(viewModel.shouldHideWindowPresentation)
+
+            viewModel.updateQuietBackgroundPresentationState(isActive: false)
+            XCTAssertFalse(viewModel.shouldHideWindowPresentation)
+        }
+    }
+
     func testToggleChatClosesWhenSameSessionIsAlreadyVisible() async {
         await MainActor.run {
             let viewModel = makeViewModel()


### PR DESCRIPTION
## Summary
- hide the closed docked notch when EnergyGovernor reaches quietBackground
- keep the detached floating pet visible in quietBackground by dimming the window alpha
- restore full detached opacity during bubble interaction, drag, completion notification, or active energy mode

## Tests
- xcodebuild -project PingIsland.xcodeproj -scheme PingIsland -configuration Debug CODE_SIGNING_ALLOWED=NO test -only-testing:PingIslandTests/NotchViewModelTests/testQuietBackgroundHidesClosedDockedPresentationButPreservesOpenedPanel -only-testing:PingIslandTests/DetachedIslandWindowControllerTests/testQuietBackgroundDimsDetachedPetUntilBubbleInteraction
- xcodebuild -project PingIsland.xcodeproj -scheme PingIsland -configuration Debug CODE_SIGNING_ALLOWED=NO test -only-testing:PingIslandTests/EnergyGovernorTests