### PR TITLE
fix: start file watcher for Codex sessions using non-official API providers

### DIFF
--- a/PingIsland/Models/SessionState.swift
+++ b/PingIsland/Models/SessionState.swift
@@ -1070,6 +1070,12 @@ struct SessionState: Equatable, Identifiable, Sendable {
         return Date().timeIntervalSince(lastActivity) >= Self.autoArchiveDelay
     }
 
+    /// Whether this session recently completed and should still appear in hover previews.
+    nonisolated var isRecentlyCompleted: Bool {
+        guard phase == .ended || phase == .idle else { return false }
+        return Date().timeIntervalSince(lastActivity) < Self.minimalCompactDelay
+    }
+
     /// Older background sessions collapse to a header-only presentation in compact surfaces.
     nonisolated var shouldUseMinimalCompactPresentation: Bool {
         if shouldAutoArchiveFromPrimaryUI {

--- a/PingIsland/Services/State/SessionStore.swift
+++ b/PingIsland/Services/State/SessionStore.swift
@@ -3398,6 +3398,21 @@ actor SessionStore {
         sessions[resolvedSessionId] = session
         publishState()
         updateCodexPlaceholderPrune(for: session)
+
+        // Start file watcher for Codex sessions discovered via App Server
+        // (Hook-based sessions already get watchers via SessionMonitor.processHookEvent)
+        if session.phase == .processing || session.phase == .waitingForInput || session.phase.isWaitingForApproval {
+            let watcherSessionId = resolvedSessionId
+            let watcherCwd = session.cwd
+            let watcherFilePath = session.clientInfo.sessionFilePath
+            Task { @MainActor in
+                InterruptWatcherManager.shared.startWatching(
+                    sessionId: watcherSessionId,
+                    cwd: watcherCwd,
+                    explicitFilePath: watcherFilePath
+                )
+            }
+        }
     }
 
     func updateCodexThreadName(sessionId: String, name: String?) {
@@ -3547,6 +3562,21 @@ actor SessionStore {
         sessions[resolvedSessionId] = session
         publishState()
         updateCodexPlaceholderPrune(for: session)
+
+        // Start file watcher for Codex sessions discovered via App Server
+        if ingress != .hookBridge,
+           session.phase == .processing || session.phase == .waitingForInput || session.phase.isWaitingForApproval {
+            let watcherSessionId = resolvedSessionId
+            let watcherCwd = session.cwd
+            let watcherFilePath = session.clientInfo.sessionFilePath
+            Task { @MainActor in
+                InterruptWatcherManager.shared.startWatching(
+                    sessionId: watcherSessionId,
+                    cwd: watcherCwd,
+                    explicitFilePath: watcherFilePath
+                )
+            }
+        }
     }
 
     private func shouldPreserveExternalCodexIntervention(

--- a/PingIsland/UI/Views/IslandExpandedRoute.swift
+++ b/PingIsland/UI/Views/IslandExpandedRoute.swift
@@ -81,7 +81,9 @@ enum IslandExpandedRouteResolver {
     }
 
     nonisolated static func activePreviewSessions(from sessions: [SessionState]) -> [SessionState] {
-        orderedSessions(from: sessions).filter(\.phase.isActive)
+        orderedSessions(from: sessions).filter {
+            $0.phase.isActive || $0.phase == .waitingForInput || $0.isRecentlyCompleted
+        }
     }
 
     nonisolated static func highestPriorityAttentionSession(from sessions: [SessionState]) -> SessionState? {


### PR DESCRIPTION
## Problem

When Codex uses non-official API providers (e.g. ccswitch, local proxies), Ping Island fails to monitor the session — no sound alerts, no hover preview updates, no real-time file change notifications.

Closes #205

## Root Cause

`InterruptWatcherManager.startWatching()` was only called from `SessionMonitor.processHookEvent()`, which requires `ingress == .hookBridge`. Codex sessions discovered via `CodexAppServerMonitor` (WebSocket) have `ingress == .codexAppServer`, so the file watcher was never started for these sessions.

Additionally, `activePreviewSessions()` in `IslandExpandedRoute` filtered sessions by `phase.isActive`, which only includes `.processing` and `.compacting`. Sessions in `.waitingForInput` or recently completed (`.ended`/`.idle`) were excluded from the hover preview dashboard.

## Changes

### 1. Start file watcher for App Server discovered Codex sessions

**`SessionStore.swift`**
- In `upsertCodexSession()`: start `InterruptWatcherManager` when session is in an active phase (`processing`/`waitingForInput`/`waitingForApproval`)
- In `syncCodexThreadSnapshot()`: start `InterruptWatcherManager` when `ingress != .hookBridge` and session is active (avoids duplicate watchers for hook-based sessions)

This ensures that regardless of how a Codex session is discovered (Hook bridge or App Server WebSocket), the transcript file is monitored for real-time changes.

### 2. Show recently completed sessions in hover preview

**`SessionState.swift`**
- Add `isRecentlyCompleted` computed property: returns `true` for `.ended`/`.idle` sessions within 10 minutes of `lastActivity`

**`IslandExpandedRoute.swift`**
- Expand `activePreviewSessions()` filter to include `.waitingForInput` and `isRecentlyCompleted` sessions, not just actively processing ones

## Testing

- Verified build succeeds with `CODE_SIGN_IDENTITY="-" CODE_SIGNING_REQUIRED=NO`
- Tested with Codex using alternative API provider — session now appears in hover preview and receives real-time file change notifications