### PR TITLE
fix: resolve remote ~/.claude path instead of literal $HOME

### DIFF
--- a/PingIsland/Services/Remote/RemoteConnectorManager.swift
+++ b/PingIsland/Services/Remote/RemoteConnectorManager.swift
@@ -708,6 +708,7 @@ final class RemoteConnectorManager: ObservableObject {
                 installRoot: endpoint.remoteInstallRoot,
                 controlSocketPath: endpoint.remoteControlSocketPath,
                 hookSocketPath: endpoint.remoteHookSocketPath,
+                homeDirectory: probe.homeDirectory,
                 configDirectoryPaths: Self.remoteManagedHookConfigDirectoryPaths(
                     homeDirectory: probe.homeDirectory,
                     profiles: remoteHookProfiles
@@ -1454,10 +1455,12 @@ final class RemoteConnectorManager: ObservableObject {
         installRoot: String,
         controlSocketPath: String,
         hookSocketPath: String,
+        homeDirectory: String,
         configDirectoryPaths: [String]
     ) -> String {
         let agentPattern = "\(installRoot)/bin/[P]ingIslandBridge --mode remote-agent-service"
-        let directoryList = ([ "\(installRoot)/bin", "\(installRoot)/run", "\(installRoot)/logs", "$HOME/.claude" ] + configDirectoryPaths)
+        let claudeDirectory = remoteConfigurationPath(relativePath: ".claude", homeDirectory: homeDirectory)
+        let directoryList = ([ "\(installRoot)/bin", "\(installRoot)/run", "\(installRoot)/logs", claudeDirectory ] + configDirectoryPaths)
             .uniquedPreservingOrder()
             .map(shellQuote)
             .joined(separator: " ")

--- a/PingIslandTests/RemoteHookConfigurationTests.swift
+++ b/PingIslandTests/RemoteHookConfigurationTests.swift
@@ -7,6 +7,7 @@ final class RemoteHookConfigurationTests: XCTestCase {
             installRoot: "/root/.ping-island",
             controlSocketPath: "/root/.ping-island/run/agent-control.sock",
             hookSocketPath: "/root/.ping-island/run/agent-hook.sock",
+            homeDirectory: "/root",
             configDirectoryPaths: ["/root/.codex", "/root/.qoder"]
         )
 
@@ -15,6 +16,19 @@ final class RemoteHookConfigurationTests: XCTestCase {
         XCTAssertTrue(command.contains("PingIslandBridge"))
         XCTAssertTrue(command.contains("rm -f "))
         XCTAssertTrue(command.contains("PingIslandBridge.tmp"))
+    }
+
+    func testRemoteBootstrapPrepareCommandResolvesClaudeDirectoryAgainstHome() {
+        let command = RemoteConnectorManager.remoteBootstrapPrepareCommand(
+            installRoot: "/home/dev/.ping-island",
+            controlSocketPath: "/home/dev/.ping-island/run/agent-control.sock",
+            hookSocketPath: "/home/dev/.ping-island/run/agent-hook.sock",
+            homeDirectory: "/home/dev",
+            configDirectoryPaths: ["/home/dev/.codex"]
+        )
+
+        XCTAssertTrue(command.contains("'/home/dev/.claude'"))
+        XCTAssertFalse(command.contains("$HOME"))
     }
 
     func testRemoteBootstrapInstallCommandPromotesStagedBridgeAtomically() {


### PR DESCRIPTION
## Problem
When connecting to an SSH remote, a literal `$HOME` directory is created under the user's home, e.g. `/home/user/$HOME/.claude`, instead of writing into the real `~/.claude`.

## Cause
In `remoteBootstrapPrepareCommand`, the directory list included the string `"$HOME/.claude"`, but every entry is wrapped with `shellQuote` (single quotes) before being passed to `mkdir -p`. Single quotes stop the remote shell from expanding `$HOME`, so it creates a directory literally named `$HOME`.

## Fix
Resolve `.claude` against the already-probed remote home directory via `remoteConfigurationPath(relativePath:homeDirectory:)`, consistent with how the other managed config directories are resolved. No more literal `$HOME`.

## Tests
Updated `RemoteHookConfigurationTests` and added a case asserting the resolved `<home>/.claude` path is used and the command contains no `$HOME`.