### PR TITLE
Fix Claude Code AskUserQuestion permission routing

### DIFF
--- a/PingIsland/Models/SessionEvent.swift
+++ b/PingIsland/Models/SessionEvent.swift
@@ -281,6 +281,12 @@ extension HookEvent {
                 && !(questionPayloads?.isEmpty ?? true)
         }
 
+        if clientInfo.isPlainClaudeCodeRouting {
+            return event == "PermissionRequest"
+                && Self.questionToolNames.contains(normalizedToolNameForIntervention ?? "")
+                && !(questionPayloads?.isEmpty ?? true)
+        }
+
         return event == "PreToolUse"
             && Self.questionToolNames.contains(normalizedToolNameForIntervention ?? "")
             && !(questionPayloads?.isEmpty ?? true)

--- a/PingIsland/Models/SessionProvider.swift
+++ b/PingIsland/Models/SessionProvider.swift
@@ -252,6 +252,18 @@ struct SessionClientInfo: Codable, Equatable, Sendable {
             || normalized.kind == .claudeCode
     }
 
+    nonisolated var isPlainClaudeCodeRouting: Bool {
+        let normalized = normalizedForClaudeRouting()
+        guard normalized.kind == .claudeCode else { return false }
+        let profile = normalized.profileID?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased() ?? ""
+        return profile.isEmpty
+            || profile == "claude-code"
+            || profile == "claude_code"
+            || profile == "claude"
+    }
+
     nonisolated var isHermesClient: Bool {
         profileID == "hermes"
             || threadSource?.lowercased() == "hermes-plugin"

--- a/PingIsland/Services/Hooks/HookSocketServer.swift
+++ b/PingIsland/Services/Hooks/HookSocketServer.swift
@@ -183,6 +183,7 @@ struct HookEvent: Sendable {
         if suppressInAppPrompt, !isPermissionRequest {
             return false
         }
+        let isPlainClaudeCodeClient = clientInfo.isPlainClaudeCodeRouting
 
         return isPermissionRequest
             || (event == "Notification" && status == "waiting_for_approval"
@@ -198,6 +199,14 @@ struct HookEvent: Sendable {
                     && normalizedTool == "askuserquestion"
                     && toolInput?["questions"] != nil
                     && !isAnsweredAskUserQuestionEvent
+                    && !isPlainClaudeCodeClient
+            )
+            || (
+                event == "PermissionRequest"
+                    && normalizedTool == "askuserquestion"
+                    && toolInput?["questions"] != nil
+                    && !isAnsweredAskUserQuestionEvent
+                    && isPlainClaudeCodeClient
             )
             || (
                 event == "PreToolUse"

--- a/PingIsland/Services/State/SessionStore.swift
+++ b/PingIsland/Services/State/SessionStore.swift
@@ -428,6 +428,8 @@ actor SessionStore {
         }
 
         let tree = (event.pid != nil || event.tty != nil) ? ProcessTreeBuilder.shared.buildTree() : [:]
+        let hadActiveClaudeQuestion = session.intervention?.kind == .question
+            && session.clientInfo.isPlainClaudeCodeRouting
 
         session.provider = event.provider
         session.clientInfo = session.clientInfo.merged(with: event.clientInfo)
@@ -513,7 +515,8 @@ actor SessionStore {
             cancelOrphanedPendingHookResponse(
                 previousPendingHookResponse,
                 in: &session,
-                reason: event.event
+                reason: event.event,
+                preserveClaudeQuestion: false
             )
             sessions[sessionId] = session
             syncLinkedQoderChildSessions(for: session)
@@ -569,11 +572,13 @@ actor SessionStore {
             for: event,
             session: session
         )
-        let shouldClearCurrentIntervention = shouldClearIntervention(
-            for: event,
-            newPhase: newPhase,
-            currentIntervention: session.intervention
-        )
+        let shouldClearCurrentIntervention = (hadActiveClaudeQuestion && event.event == "Notification")
+            ? false
+            : shouldClearIntervention(
+                for: event,
+                newPhase: newPhase,
+                currentIntervention: session.intervention
+            )
         let hasIncomingIntervention: Bool
         if case .some = intervention {
             hasIncomingIntervention = true
@@ -679,7 +684,8 @@ actor SessionStore {
         cancelOrphanedPendingHookResponse(
             previousPendingHookResponse,
             in: &session,
-            reason: event.event
+            reason: event.event,
+            preserveClaudeQuestion: hadActiveClaudeQuestion
         )
 
         sessions[sessionId] = session
@@ -1313,10 +1319,15 @@ actor SessionStore {
     private func cancelOrphanedPendingHookResponse(
         _ previous: PendingHookResponse?,
         in session: inout SessionState,
-        reason: String
+        reason: String,
+        preserveClaudeQuestion: Bool
     ) {
         guard let previous,
               !isPendingHookResponseVisible(previous, in: session) else {
+            return
+        }
+
+        if reason == "Notification", preserveClaudeQuestion {
             return
         }
 
@@ -4764,6 +4775,10 @@ actor SessionStore {
 
         let normalizedClientInfo = event.clientInfo.normalizedForClaudeRouting()
         let profileID = normalizedClientInfo.profileID?.lowercased()
+        if normalizedClientInfo.isPlainClaudeCodeRouting {
+            return false
+        }
+
         if profileID == "qoder-cli"
             || profileID == "codebuddy-cli"
             || profileID == "qwen-code"

--- a/PingIslandTests/ClaudeAskUserQuestionSessionTests.swift
+++ b/PingIslandTests/ClaudeAskUserQuestionSessionTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import Ping_Island
 
 final class ClaudeAskUserQuestionSessionTests: XCTestCase {
-    func testPreToolUseQuestionImmediatelyEntersWaitingForInput() async {
+    func testPermissionRequestQuestionImmediatelyEntersWaitingForInput() async {
         let sessionId = "claude-question-\(UUID().uuidString)"
         let store = SessionStore.shared
 
@@ -15,6 +15,13 @@ final class ClaudeAskUserQuestionSessionTests: XCTestCase {
         XCTAssertTrue(session?.intervention?.resolvedQuestions.first?.allowsOther ?? false)
 
         await store.process(.sessionArchived(sessionId: sessionId))
+    }
+
+    func testPreToolUseQuestionDoesNotBlockPlainClaudeCode() {
+        let event = makeClaudePreToolUseQuestionEvent(sessionId: "claude-pretool-\(UUID().uuidString)")
+
+        XCTAssertFalse(event.expectsResponse)
+        XCTAssertFalse(event.isAskUserQuestionRequest)
     }
 
     func testDuplicatePermissionRequestKeepsClaudeQuestionInWaitingForInput() async {
@@ -494,8 +501,8 @@ final class ClaudeAskUserQuestionSessionTests: XCTestCase {
         HookEvent(
             sessionId: sessionId,
             cwd: "/tmp/project",
-            event: "PreToolUse",
-            status: "waiting_for_input",
+            event: "PermissionRequest",
+            status: "waiting_for_approval",
             provider: .claude,
             clientInfo: SessionClientInfo(
                 kind: .claudeCode,
@@ -520,6 +527,41 @@ final class ClaudeAskUserQuestionSessionTests: XCTestCase {
                 ])
             ],
             toolUseId: toolUseId ?? "toolu_\(sessionId)",
+            notificationType: nil,
+            message: nil
+        )
+    }
+
+    private func makeClaudePreToolUseQuestionEvent(sessionId: String) -> HookEvent {
+        HookEvent(
+            sessionId: sessionId,
+            cwd: "/tmp/project",
+            event: "PreToolUse",
+            status: "waiting_for_input",
+            provider: .claude,
+            clientInfo: SessionClientInfo(
+                kind: .claudeCode,
+                profileID: "claude_code",
+                name: "Claude Code",
+                bundleIdentifier: "com.anthropic.claudecode"
+            ),
+            pid: nil,
+            tty: nil,
+            tool: "AskUserQuestion",
+            toolInput: [
+                "questions": AnyCodable([
+                    [
+                        "id": "project",
+                        "header": "方向",
+                        "question": "你想先处理哪个模块？",
+                        "options": [
+                            ["label": "会话层"],
+                            ["label": "UI 层"]
+                        ]
+                    ]
+                ])
+            ],
+            toolUseId: "toolu_\(sessionId)",
             notificationType: nil,
             message: nil
         )

--- a/Prototype/Sources/IslandShared/HookPayloadMapper.swift
+++ b/Prototype/Sources/IslandShared/HookPayloadMapper.swift
@@ -1620,6 +1620,10 @@ public enum HookPayloadMapper {
                 || isQoderWorkPermissionQuestionEvent(eventType: eventType, payload: payload)
         }
 
+        if clientKind == nil {
+            return eventType == "PermissionRequest" || eventType == "UserInputRequest"
+        }
+
         return eventType == "PreToolUse" || eventType == "UserInputRequest"
     }
 

--- a/Prototype/Sources/IslandShared/HookPayloadMapper.swift
+++ b/Prototype/Sources/IslandShared/HookPayloadMapper.swift
@@ -770,6 +770,17 @@ public enum HookPayloadMapper {
             )
         }
 
+        if questionPayloads(from: payload)?.isEmpty == false,
+           questionToolNames.contains(normalizedToolName(from: payload) ?? ""),
+           !shouldSurfaceQuestionIntervention(
+                provider: provider,
+                eventType: eventType,
+                payload: payload,
+                clientKind: clientKind
+           ) {
+            return nil
+        }
+
         if let questions = questionPayloads(from: payload), !questions.isEmpty,
            shouldSurfaceQuestionIntervention(
                 provider: provider,

--- a/Prototype/Sources/IslandShared/HookPayloadMapper.swift
+++ b/Prototype/Sources/IslandShared/HookPayloadMapper.swift
@@ -400,7 +400,8 @@ public enum HookPayloadMapper {
         if isQoderWorkNotifyOnlyPermissionRequest(eventType: eventType, payload: payload, clientKind: clientKind) {
             return SessionStatus(kind: .active)
         }
-        if isQoderQuestionToolEvent(eventType: eventType, payload: payload) {
+        if clientKind != nil,
+           isQoderQuestionToolEvent(eventType: eventType, payload: payload) {
             return SessionStatus(kind: .waitingForInput)
         }
         if clientKind == "codebuddy-cli",

--- a/Prototype/Sources/IslandShared/HookPayloadMapper.swift
+++ b/Prototype/Sources/IslandShared/HookPayloadMapper.swift
@@ -770,15 +770,13 @@ public enum HookPayloadMapper {
             )
         }
 
-        if let questions = questionPayloads(from: payload), !questions.isEmpty {
-            guard shouldSurfaceQuestionIntervention(
+        if let questions = questionPayloads(from: payload), !questions.isEmpty,
+           shouldSurfaceQuestionIntervention(
                 provider: provider,
                 eventType: eventType,
                 payload: payload,
                 clientKind: clientKind
-            ) else {
-                return nil
-            }
+           ) {
             if clientKind == "qoder",
                isQoderQuestionToolEvent(eventType: eventType, payload: payload) {
                 return nil
@@ -1628,10 +1626,11 @@ public enum HookPayloadMapper {
 
         if clientKind == nil {
             if provider == .claude {
-                return eventType == "PermissionRequest" || eventType == "UserInputRequest"
+                return eventType == "UserInputRequest"
+                    || isQoderWorkPermissionQuestionEvent(eventType: eventType, payload: payload)
             }
-            return eventType == "PreToolUse"
-                || eventType == "PermissionRequest"
+            return isQoderWorkPreToolQuestionEvent(eventType: eventType, payload: payload)
+                || isQoderWorkPermissionQuestionEvent(eventType: eventType, payload: payload)
                 || eventType == "UserInputRequest"
         }
 

--- a/Prototype/Sources/IslandShared/HookPayloadMapper.swift
+++ b/Prototype/Sources/IslandShared/HookPayloadMapper.swift
@@ -61,6 +61,7 @@ public enum HookPayloadMapper {
         let expectsResponse = runtimeConfig.routePromptsToTerminal
             ? false
             : detectExpectsResponse(
+                provider: source,
                 eventType: eventType,
                 payload: payload,
                 clientKind: clientKind,
@@ -462,6 +463,7 @@ public enum HookPayloadMapper {
     }
 
     private static func detectExpectsResponse(
+        provider: AgentProvider,
         eventType: String,
         payload: [String: Any],
         clientKind: String?,
@@ -481,6 +483,7 @@ public enum HookPayloadMapper {
                 return true
             case .question:
                 return shouldSurfaceQuestionIntervention(
+                    provider: provider,
                     eventType: eventType,
                     payload: payload,
                     clientKind: clientKind
@@ -768,6 +771,7 @@ public enum HookPayloadMapper {
 
         if let questions = questionPayloads(from: payload), !questions.isEmpty {
             guard shouldSurfaceQuestionIntervention(
+                provider: provider,
                 eventType: eventType,
                 payload: payload,
                 clientKind: clientKind
@@ -1602,6 +1606,7 @@ public enum HookPayloadMapper {
     }
 
     private static func shouldSurfaceQuestionIntervention(
+        provider: AgentProvider,
         eventType: String,
         payload: [String: Any],
         clientKind: String?
@@ -1621,7 +1626,12 @@ public enum HookPayloadMapper {
         }
 
         if clientKind == nil {
-            return eventType == "PermissionRequest" || eventType == "UserInputRequest"
+            if provider == .claude {
+                return eventType == "PermissionRequest" || eventType == "UserInputRequest"
+            }
+            return eventType == "PreToolUse"
+                || eventType == "PermissionRequest"
+                || eventType == "UserInputRequest"
         }
 
         return eventType == "PreToolUse" || eventType == "UserInputRequest"

--- a/Prototype/Tests/IslandTests/HookPayloadMapperTests.swift
+++ b/Prototype/Tests/IslandTests/HookPayloadMapperTests.swift
@@ -2098,6 +2098,60 @@ func claudePostToolUseResolvedQuestionDoesNotKeepSocketOpen() throws {
 }
 
 @Test
+func claudeCodePreToolUseAskUserQuestionIsNonBlocking() throws {
+    let payload = """
+    {
+      "hook_event_name": "PreToolUse",
+      "tool_name": "AskUserQuestion",
+      "tool_input": {
+        "questions": [
+          {"id": "q1", "question": "Pick one", "options": [{"label": "A"}, {"label": "B"}]}
+        ]
+      },
+      "session_id": "claude-aq"
+    }
+    """.data(using: .utf8)!
+
+    let envelope = HookPayloadMapper.makeEnvelope(
+        source: .claude,
+        arguments: ["island-bridge", "--source", "claude"],
+        environment: ["PWD": "/tmp/demo"],
+        stdinData: payload
+    )
+
+    #expect(envelope.eventType == "PreToolUse")
+    #expect(envelope.expectsResponse == false)
+    #expect(envelope.intervention == nil)
+}
+
+@Test
+func claudeCodePermissionRequestAskUserQuestionSurfacesAnswerableQuestion() throws {
+    let payload = """
+    {
+      "hook_event_name": "PermissionRequest",
+      "tool_name": "AskUserQuestion",
+      "tool_input": {
+        "questions": [
+          {"id": "q1", "header": "Scope", "question": "Pick one", "options": [{"label": "A"}, {"label": "B"}]}
+        ]
+      },
+      "session_id": "claude-aq"
+    }
+    """.data(using: .utf8)!
+
+    let envelope = HookPayloadMapper.makeEnvelope(
+        source: .claude,
+        arguments: ["island-bridge", "--source", "claude"],
+        environment: ["PWD": "/tmp/demo"],
+        stdinData: payload
+    )
+
+    #expect(envelope.eventType == "PermissionRequest")
+    #expect(envelope.expectsResponse)
+    #expect(envelope.intervention?.kind == .question)
+}
+
+@Test
 func qoderWorkPermissionRequestQuestionStillMapsToQuestionIntervention() throws {
     let payload = """
     {

--- a/Prototype/Tests/IslandTests/HookPayloadMapperTests.swift
+++ b/Prototype/Tests/IslandTests/HookPayloadMapperTests.swift
@@ -2152,6 +2152,33 @@ func claudeCodePermissionRequestAskUserQuestionSurfacesAnswerableQuestion() thro
 }
 
 @Test
+func codexPreToolUseAskUserQuestionStillSurfacesQuestion() throws {
+    let payload = """
+    {
+      "hook_event_name": "PreToolUse",
+      "tool_name": "AskUserQuestion",
+      "tool_input": {
+        "questions": [
+          {"id": "q1", "question": "Pick one", "options": [{"label": "A"}, {"label": "B"}]}
+        ]
+      },
+      "session_id": "codex-aq"
+    }
+    """.data(using: .utf8)!
+
+    let envelope = HookPayloadMapper.makeEnvelope(
+        source: .codex,
+        arguments: ["island-bridge", "--source", "codex"],
+        environment: ["PWD": "/tmp/demo"],
+        stdinData: payload
+    )
+
+    #expect(envelope.eventType == "PreToolUse")
+    #expect(envelope.expectsResponse)
+    #expect(envelope.intervention?.kind == .question)
+}
+
+@Test
 func qoderWorkPermissionRequestQuestionStillMapsToQuestionIntervention() throws {
     let payload = """
     {

--- a/Prototype/Tests/IslandTests/HookPayloadMapperTests.swift
+++ b/Prototype/Tests/IslandTests/HookPayloadMapperTests.swift
@@ -2153,6 +2153,34 @@ func claudeCodePermissionRequestAskUserQuestionSurfacesAnswerableQuestion() thro
 }
 
 @Test
+func claudeCodePermissionRequestWithNonQuestionToolQuestionsStaysApproval() throws {
+    let payload = """
+    {
+      "hook_event_name": "PermissionRequest",
+      "tool_name": "SurveyTool",
+      "tool_input": {
+        "questions": [
+          {"id": "q1", "question": "Internal tool argument", "options": [{"label": "A"}, {"label": "B"}]}
+        ]
+      },
+      "reason": "SurveyTool needs approval",
+      "session_id": "claude-approval"
+    }
+    """.data(using: .utf8)!
+
+    let envelope = HookPayloadMapper.makeEnvelope(
+        source: .claude,
+        arguments: ["island-bridge", "--source", "claude"],
+        environment: ["PWD": "/tmp/demo"],
+        stdinData: payload
+    )
+
+    #expect(envelope.eventType == "PermissionRequest")
+    #expect(envelope.expectsResponse)
+    #expect(envelope.intervention?.kind == .approval)
+}
+
+@Test
 func codexPreToolUseAskUserQuestionStillSurfacesQuestion() throws {
     let payload = """
     {

--- a/Prototype/Tests/IslandTests/HookPayloadMapperTests.swift
+++ b/Prototype/Tests/IslandTests/HookPayloadMapperTests.swift
@@ -2120,6 +2120,7 @@ func claudeCodePreToolUseAskUserQuestionIsNonBlocking() throws {
     )
 
     #expect(envelope.eventType == "PreToolUse")
+    #expect(envelope.status?.kind == .runningTool)
     #expect(envelope.expectsResponse == false)
     #expect(envelope.intervention == nil)
 }


### PR DESCRIPTION
Background

  - Claude Code now emits AskUserQuestion as a PermissionRequest.
  - The previous routing treated PreToolUse question hooks as the blocking prompt path.
  - This could make Claude Code question prompts show up as approval-style requests or lose the expected waiting-for-input state.
  - Other Claude-hook clients such as Qoder, Qwen, and CodeBuddy still rely on their existing question routing behavior.


Changes

  - Route plain Claude Code AskUserQuestion prompts through PermissionRequest.
  - Stop treating plain Claude Code PreToolUse question hooks as blocking question requests.
  - Preserve existing question routing for Codex/Qoder/Qwen/CodeBuddy paths.
  - Keep non-question permission requests as approval prompts, even if their payload contains a questions field.
  - Preserve an active Claude question across follow-up notification events.
  - Add mapper and session tests for the updated Claude Code question flow.
