### PR TITLE
fix: avoid creating unrelated agent directories on first run

### DIFF
--- a/PingIsland/App/AppDelegate.swift
+++ b/PingIsland/App/AppDelegate.swift
@@ -125,16 +125,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 #endif
             case .customize:
 #if APP_STORE
+                HookInstaller.clearPreferredTargets()
                 AppSettings.hookInstallOnboardingPending = true
                 self.shouldRunHookWalkthroughAfterOnboarding = false
                 SettingsWindowController.shared.present(category: .integration)
 #else
-                HookInstaller.performFirstRunDefaultInstall()
+                HookInstaller.clearPreferredTargets()
                 AppSettings.hookInstallOnboardingPending = false
                 self.shouldRunHookWalkthroughAfterOnboarding = false
                 SettingsWindowController.shared.present()
 #endif
             case .skip:
+                HookInstaller.clearPreferredTargets()
                 AppSettings.hookInstallOnboardingPending = false
                 self.startHookWalkthroughAfterOnboardingIfNeeded()
             }

--- a/PingIsland/Models/ClientProfile.swift
+++ b/PingIsland/Models/ClientProfile.swift
@@ -181,6 +181,7 @@ struct ManagedHookClientProfile: Identifiable, Sendable {
         bridgeSource: String,
         bridgeExtraArguments: [String],
         defaultEnabled: Bool,
+        autoInstallOnFirstRun: Bool = true,
         brand: SessionClientBrand,
         events: [HookInstallEventDescriptor]
     ) {
@@ -200,6 +201,7 @@ struct ManagedHookClientProfile: Identifiable, Sendable {
             bridgeSource: bridgeSource,
             bridgeExtraArguments: bridgeExtraArguments,
             defaultEnabled: defaultEnabled,
+            autoInstallOnFirstRun: autoInstallOnFirstRun,
             brand: brand,
             events: events
         )

--- a/PingIsland/Models/ClientProfile.swift
+++ b/PingIsland/Models/ClientProfile.swift
@@ -161,6 +161,7 @@ struct ManagedHookClientProfile: Identifiable, Sendable {
     let bridgeSource: String
     let bridgeExtraArguments: [String]
     let defaultEnabled: Bool
+    let autoInstallOnFirstRun: Bool
     let brand: SessionClientBrand
     let events: [HookInstallEventDescriptor]
 
@@ -220,6 +221,7 @@ struct ManagedHookClientProfile: Identifiable, Sendable {
         bridgeSource: String,
         bridgeExtraArguments: [String],
         defaultEnabled: Bool,
+        autoInstallOnFirstRun: Bool = true,
         brand: SessionClientBrand,
         events: [HookInstallEventDescriptor]
     ) {
@@ -238,6 +240,7 @@ struct ManagedHookClientProfile: Identifiable, Sendable {
         self.bridgeSource = bridgeSource
         self.bridgeExtraArguments = bridgeExtraArguments
         self.defaultEnabled = defaultEnabled
+        self.autoInstallOnFirstRun = autoInstallOnFirstRun
         self.brand = brand
         self.events = events
     }
@@ -587,6 +590,7 @@ enum ClientProfileRegistry {
             bridgeSource: "codex",
             bridgeExtraArguments: [],
             defaultEnabled: true,
+            autoInstallOnFirstRun: false,
             brand: .codex,
             events: [
                 HookInstallEventDescriptor(name: "SessionStart", templates: [.matcher("*")]),
@@ -726,6 +730,7 @@ enum ClientProfileRegistry {
                 "--thread-source", "openclaw-hooks"
             ],
             defaultEnabled: false,
+            autoInstallOnFirstRun: false,
             brand: .neutral,
             events: [
                 HookInstallEventDescriptor(name: "command:new", templates: []),
@@ -867,6 +872,7 @@ enum ClientProfileRegistry {
             bridgeSource: "claude",
             bridgeExtraArguments: ["--client-kind", "qoder"],
             defaultEnabled: true,
+            autoInstallOnFirstRun: false,
             brand: .qoder,
             events: [
                 HookInstallEventDescriptor(name: "UserPromptSubmit", templates: [.plain]),
@@ -923,6 +929,7 @@ enum ClientProfileRegistry {
                 "--client-name", "QoderWork"
             ],
             defaultEnabled: true,
+            autoInstallOnFirstRun: false,
             brand: .qoder,
             events: [
                 HookInstallEventDescriptor(name: "UserPromptSubmit", templates: [.plain]),

--- a/PingIsland/Services/Hooks/HookInstaller.swift
+++ b/PingIsland/Services/Hooks/HookInstaller.swift
@@ -406,7 +406,7 @@ struct HookInstaller {
     private static var defaultPreferredTargets: Set<String> {
         Set(
             ClientProfileRegistry.managedHookProfiles
-                .filter { $0.defaultEnabled && canManage($0) }
+                .filter { $0.defaultEnabled && $0.autoInstallOnFirstRun && canManage($0) }
                 .map(\.id)
         )
     }
@@ -470,11 +470,13 @@ struct HookInstaller {
 #endif
     }
 
-    /// Run the default first-run install for every defaultEnabled profile.
+    /// Run the default first-run install for every auto-installable profile.
     static func performFirstRunDefaultInstall() {
         let qoderCLISupportsClaudeHooks = qoderCLIUsesClaudeCompatibleHooks()
         installBridgeLauncherIfNeeded()
-        for profile in ClientProfileRegistry.managedHookProfiles where profile.defaultEnabled {
+        for profile in ClientProfileRegistry.managedHookProfiles
+            where profile.defaultEnabled && profile.autoInstallOnFirstRun
+        {
             let canManageProfile = canManage(profile)
                 || (profile.id == "qoder-cli-hooks" && qoderCLISupportsClaudeHooks)
             guard canManageProfile else { continue }
@@ -653,7 +655,7 @@ struct HookInstaller {
     static func defaultEnabledManageableProfiles() -> [ManagedHookClientProfile] {
         let qoderCLISupportsClaudeHooks = qoderCLIUsesClaudeCompatibleHooks()
         return ClientProfileRegistry.managedHookProfiles.filter { profile in
-            guard profile.defaultEnabled else { return false }
+            guard profile.defaultEnabled && profile.autoInstallOnFirstRun else { return false }
             return canManage(profile)
                 || (profile.id == "qoder-cli-hooks" && qoderCLISupportsClaudeHooks)
         }
@@ -1116,12 +1118,16 @@ struct HookInstaller {
             UserDefaults.standard.set(true, forKey: qoderWorkMigrationDefaultsKey)
         }
 
-        return targets.isEmpty ? [] : targets
+        return targets
     }
 
     private static func persistPreferredTargets(_ targets: Set<String>) {
         let values = targets.sorted()
         UserDefaults.standard.set(values, forKey: preferredTargetsDefaultsKey)
+    }
+
+    static func clearPreferredTargets() {
+        UserDefaults.standard.set([], forKey: preferredTargetsDefaultsKey)
     }
 
     private static func installationTargets(for profile: ManagedHookClientProfile) -> [URL] {

--- a/PingIslandTests/HookInstallerAutoInstallTests.swift
+++ b/PingIslandTests/HookInstallerAutoInstallTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import Ping_Island
+
+final class HookInstallerAutoInstallTests: XCTestCase {
+    func testDefaultEnabledManageableProfilesOnlyIncludesAutoInstallProfiles() {
+        let profileIDs = Set(HookInstaller.defaultEnabledManageableProfiles().map { $0.id })
+
+        XCTAssertTrue(profileIDs.contains("claude-hooks"))
+        XCTAssertFalse(profileIDs.contains("codex-hooks"))
+        XCTAssertFalse(profileIDs.contains("qoder-hooks"))
+        XCTAssertFalse(profileIDs.contains("qoderwork-hooks"))
+        XCTAssertFalse(profileIDs.contains("openclaw-hooks"))
+    }
+
+    func testOptionalAgentProfilesDoNotAutoInstallOnFirstRun() {
+        XCTAssertFalse(ClientProfileRegistry.managedHookProfile(id: "codex-hooks")?.autoInstallOnFirstRun ?? true)
+        XCTAssertFalse(ClientProfileRegistry.managedHookProfile(id: "qoder-hooks")?.autoInstallOnFirstRun ?? true)
+        XCTAssertFalse(ClientProfileRegistry.managedHookProfile(id: "qoderwork-hooks")?.autoInstallOnFirstRun ?? true)
+        XCTAssertFalse(ClientProfileRegistry.managedHookProfile(id: "openclaw-hooks")?.autoInstallOnFirstRun ?? true)
+    }
+}


### PR DESCRIPTION
Restrict first-run hook installation to auto-installable profiles only, preventing PingIsland from initializing unnecessary agent directories such as ~/.codex, ~/.qoder, and ~/.openclaw by default.

Clear preferred targets when onboarding is skipped or customized so default integrations are not restored implicitly.

closes #249