### PR TITLE
Preserve concurrent Qwen sessions in shared workspaces

### DIFF
--- a/PingIsland/Services/State/SessionStore.swift
+++ b/PingIsland/Services/State/SessionStore.swift
@@ -2604,6 +2604,11 @@ actor SessionStore {
         guard !cwd.isEmpty else { return }
         guard provider == .claude else { return }
         guard session.ingress != .nativeRuntime else { return }
+        // Qwen command hooks do not expose the owning CLI PID, while their stable
+        // session IDs explicitly support multiple sessions in the same workspace.
+        // Treating a second Qwen session as restart evidence would evict the first
+        // legitimate session as soon as both emit hooks.
+        guard !session.clientInfo.isQwenCodeClient else { return }
 
         var idsToArchive: [String] = []
         for (existingId, existing) in sessions {

--- a/PingIslandTests/QwenCodeIntegrationTests.swift
+++ b/PingIslandTests/QwenCodeIntegrationTests.swift
@@ -2,6 +2,58 @@ import XCTest
 @testable import Ping_Island
 
 final class QwenCodeIntegrationTests: XCTestCase {
+    func testConcurrentQwenSessionsInSameWorkspaceRemainIndependent() async {
+        let firstSessionId = "qwen-concurrent-first-\(UUID().uuidString)"
+        let secondSessionId = "qwen-concurrent-second-\(UUID().uuidString)"
+        let workspace = "/tmp/qwen-concurrent-workspace-\(UUID().uuidString)"
+        let store = SessionStore.shared
+        let clientInfo = SessionClientInfo(
+            kind: .custom,
+            profileID: "qwen-code",
+            name: "Qwen Code",
+            origin: "cli",
+            originator: "Qwen Code",
+            threadSource: "qwen-code-hooks"
+        )
+
+        func promptEvent(sessionId: String, message: String) -> HookEvent {
+            HookEvent(
+                sessionId: sessionId,
+                cwd: workspace,
+                event: "UserPromptSubmit",
+                status: "processing",
+                provider: .claude,
+                clientInfo: clientInfo,
+                pid: nil,
+                tty: nil,
+                tool: nil,
+                toolInput: nil,
+                toolUseId: nil,
+                notificationType: nil,
+                message: message
+            )
+        }
+
+        await store.process(.hookReceived(promptEvent(
+            sessionId: firstSessionId,
+            message: "First concurrent request"
+        )))
+        await store.process(.hookReceived(promptEvent(
+            sessionId: secondSessionId,
+            message: "Second concurrent request"
+        )))
+
+        let firstSession = await store.session(for: firstSessionId)
+        let secondSession = await store.session(for: secondSessionId)
+        XCTAssertNotNil(firstSession)
+        XCTAssertNotNil(secondSession)
+        XCTAssertEqual(firstSession?.latestHookMessage, "First concurrent request")
+        XCTAssertEqual(secondSession?.latestHookMessage, "Second concurrent request")
+
+        await store.process(.sessionArchived(sessionId: firstSessionId))
+        await store.process(.sessionArchived(sessionId: secondSessionId))
+    }
+
     func testQwenStopBridgeMessageFallsBackToLastAssistantMessage() {
         XCTAssertEqual(
             HookSocketServer.resolvedBridgeMessage(


### PR DESCRIPTION
## Summary

- keep multiple Qwen Code sessions in the same workspace registered independently
- exclude Qwen sessions from same-workspace orphan eviction because Qwen hook payloads do not expose an owning CLI PID
- add an app-level regression test covering two concurrent Qwen sessions with distinct session IDs

## Root cause

`SessionStore` treated a new Claude-provider hook session in the same working directory as evidence that an existing session had been orphaned. That heuristic relies on PID liveness when available, but Qwen command hooks provide stable `session_id` values without the owning CLI PID. As a result, the second Qwen session could evict the first even though both were valid and active.

## User impact

Qwen Code sessions running concurrently from the same project directory now remain separate, so hook activity from one session no longer removes or replaces the other session in Ping Island.

## Verification

- `QwenCodeIntegrationTests`: 13/13 passed
- `SessionStoreLivenessSweepTests`: 4/4 passed
- `swift test --package-path Prototype`: 129/129 passed
- `git diff --cached --check`: passed

Closes #257