### PR TITLE
Support Antigravity CLI sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file is a routing layer for coding agents working in this repo. Keep it sho
 
 ## Mission
 
-- `PingIsland` is a macOS menu bar app that surfaces Dynamic Island-style status for Claude Code, Codex, Gemini CLI, Hermes Agent, Qwen Code, Kimi CLI, and compatible hook-driven agent sessions.
+- `PingIsland` is a macOS menu bar app that surfaces Dynamic Island-style status for Claude Code, Codex, Gemini CLI, Antigravity CLI, Hermes Agent, Qwen Code, Kimi CLI, and compatible hook-driven agent sessions.
 - The main runtime path is:
   - hook or app-server events
   - monitoring and service layers
@@ -81,6 +81,7 @@ This file is a routing layer for coding agents working in this repo. Keep it sho
 - If you change provider/client detection or click-through behavior, trace through `HookSocketServer`, `SessionStore`, `SessionState`, `SessionLauncher`, and the session list / hover UI so labels and launch targets stay in sync.
 - If you add a Claude-compatible hook client, start in `PingIsland/Models/ClientProfile.swift` and wire any truly client-specific behavior from there before adding new ad-hoc switches elsewhere.
   - Gemini CLI hooks are managed through `~/.gemini/settings.json`; its `BeforeTool` / `AfterTool` matchers are regex-based, so use `.*` rather than Claude-style `*`.
+  - Antigravity CLI is managed as a generated native plugin under `~/.gemini/antigravity-cli/plugins/ping-island/`, with `plugin.json` plus namespaced `hooks.json`. Its camelCase hook payloads use `conversationId`, `workspacePaths`, and `toolCall`; keep those normalized at the bridge boundary. Ping Island's observational `PreToolUse` hook must return `ask` so Antigravity's native permission engine remains authoritative, including when the Island socket is unavailable.
   - Hermes Agent CLI integration must use plugin hooks under `~/.hermes/plugins/ping_island/`; `~/.hermes/hooks/` is gateway-only and will not fire in the Hermes CLI, so keep Ping Island on `ctx.register_hook()`-based plugin registration instead of gateway hook directories.
   - Qwen Code hooks are managed through `~/.qwen/settings.json`; follow the official Qwen Code hook event names (`PreToolUse`, `PostToolUseFailure`, `Notification`, `Stop`, etc.) and remember that `Notification` matcher values are exact notification types such as `permission_prompt`, `idle_prompt`, and `auth_success`.
   - OpenClaw hooks are managed as a generated internal hook directory under `~/.openclaw/hooks/<hook-name>/` and require the paired enablement entry in `~/.openclaw/openclaw.json`; treat it as a directory-discovery integration, not a JSON hook list.

--- a/PingIsland/Models/ClientProfile.swift
+++ b/PingIsland/Models/ClientProfile.swift
@@ -628,6 +628,34 @@ enum ClientProfileRegistry {
             ]
         ),
         ManagedHookClientProfile(
+            id: "antigravity-hooks",
+            title: "Antigravity CLI",
+            subtitle: "管理 ~/.gemini/antigravity-cli/plugins/ping-island，按 Antigravity 官方 plugin hooks 协议接入 Island",
+            installationKind: .pluginDirectory,
+            alwaysVisibleInSettings: true,
+            logoAssetName: "GeminiLogo",
+            prefersBundledLogoOverAppIcon: true,
+            iconSymbolName: "sparkles",
+            configurationRelativePath: ".gemini/antigravity-cli/plugins/ping-island",
+            bridgeSource: "gemini",
+            bridgeExtraArguments: [
+                "--client-kind", "antigravity",
+                "--client-name", "Antigravity CLI",
+                "--client-origin", "cli",
+                "--client-originator", "Antigravity CLI",
+                "--thread-source", "antigravity-hooks"
+            ],
+            defaultEnabled: false,
+            brand: .gemini,
+            events: [
+                HookInstallEventDescriptor(name: "PreToolUse", templates: [.matcher(".*")]),
+                HookInstallEventDescriptor(name: "PostToolUse", templates: [.matcher(".*")]),
+                HookInstallEventDescriptor(name: "PreInvocation", templates: [.direct]),
+                HookInstallEventDescriptor(name: "PostInvocation", templates: [.direct]),
+                HookInstallEventDescriptor(name: "Stop", templates: [.direct]),
+            ]
+        ),
+        ManagedHookClientProfile(
             id: "hermes-hooks",
             title: "Hermes",
             subtitle: "管理 ~/.hermes/plugins/ping_island，按 Hermes 官方 plugin hooks 协议接入 Island",
@@ -1344,6 +1372,21 @@ enum ClientProfileRegistry {
             recognizedKinds: ["gemini", "gemini-cli", "gemini_cli", "gemini cli"],
             exactAliases: ["gemini", "gemini-cli", "gemini cli"],
             keywordAliases: ["gemini", "gemini cli"],
+            bundleIdentifiers: []
+        ),
+        SessionClientProfile(
+            id: "antigravity",
+            provider: .gemini,
+            family: .geminiHooks,
+            kind: .custom,
+            displayName: "Antigravity CLI",
+            assistantLabelMode: .badgeLabel,
+            brand: .gemini,
+            defaultBundleIdentifier: nil,
+            defaultOrigin: "cli",
+            recognizedKinds: ["antigravity", "antigravity-cli", "antigravity_cli", "antigravity cli", "agy"],
+            exactAliases: ["antigravity", "antigravity-cli", "antigravity cli", "agy"],
+            keywordAliases: ["antigravity", "antigravity cli"],
             bundleIdentifiers: []
         ),
         SessionClientProfile(

--- a/PingIsland/Models/SessionProvider.swift
+++ b/PingIsland/Models/SessionProvider.swift
@@ -286,9 +286,13 @@ struct SessionClientInfo: Codable, Equatable, Sendable {
 
     nonisolated var isGeminiClient: Bool {
         profileID == "gemini"
+            || profileID == "antigravity"
             || threadSource?.lowercased() == "gemini-hooks"
+            || threadSource?.lowercased() == "antigravity-hooks"
             || name?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "gemini cli"
+            || name?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "antigravity cli"
             || originator?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "gemini cli"
+            || originator?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "antigravity cli"
     }
 
     nonisolated var prefersHookMessageAsLastMessageFallback: Bool {

--- a/PingIsland/Resources/en.lproj/Localizable.strings
+++ b/PingIsland/Resources/en.lproj/Localizable.strings
@@ -163,6 +163,7 @@
 "管理 ~/.claude/settings.json，使用统一 PingIslandBridge hooks 入口" = "Manage ~/.claude/settings.json using the unified PingIslandBridge hooks entrypoint";
 "管理 ~/.codex/hooks.json" = "Manage ~/.codex/hooks.json";
 "管理 ~/.gemini/settings.json，按 Gemini CLI 官方 hooks 协议接入 Island" = "Manage ~/.gemini/settings.json using Gemini CLI's official hooks protocol for Island";
+"管理 ~/.gemini/antigravity-cli/plugins/ping-island，按 Antigravity 官方 plugin hooks 协议接入 Island" = "Manage ~/.gemini/antigravity-cli/plugins/ping-island using Antigravity's official plugin hooks protocol for Island";
 "管理 ~/.hermes/plugins/ping_island，按 Hermes 官方 plugin hooks 协议接入 Island" = "Manage ~/.hermes/plugins/ping_island using Hermes' official plugin hooks protocol for Island";
 "管理 ~/.qwen/settings.json，按 Qwen Code 官方 hooks 协议接入 Island" = "Manage ~/.qwen/settings.json using Qwen Code's official hooks protocol for Island";
 "管理 ~/.openclaw/hooks/ping-island-openclaw，并自动启用内部 hook" = "Manage ~/.openclaw/hooks/ping-island-openclaw and automatically enable the internal hook";

--- a/PingIsland/Resources/zh-Hans.lproj/Localizable.strings
+++ b/PingIsland/Resources/zh-Hans.lproj/Localizable.strings
@@ -163,6 +163,7 @@
 "管理 ~/.claude/settings.json，使用统一 PingIslandBridge hooks 入口" = "管理 ~/.claude/settings.json，使用统一 PingIslandBridge hooks 入口";
 "管理 ~/.codex/hooks.json" = "管理 ~/.codex/hooks.json";
 "管理 ~/.gemini/settings.json，按 Gemini CLI 官方 hooks 协议接入 Island" = "管理 ~/.gemini/settings.json，按 Gemini CLI 官方 hooks 协议接入 Island";
+"管理 ~/.gemini/antigravity-cli/plugins/ping-island，按 Antigravity 官方 plugin hooks 协议接入 Island" = "管理 ~/.gemini/antigravity-cli/plugins/ping-island，按 Antigravity 官方 plugin hooks 协议接入 Island";
 "管理 ~/.codebuddy/settings.json，按 CodeBuddy Hooks 协议接入 Island" = "管理 ~/.codebuddy/settings.json，按 CodeBuddy Hooks 协议接入 Island";
 "管理 ~/.codebuddy/settings.json，支持 CodeBuddy IDE hooks" = "管理 ~/.codebuddy/settings.json，支持 CodeBuddy IDE hooks";
 "管理 ~/.codebuddy/settings.json，按 CodeBuddy CLI Claude-compatible hooks 协议接入 Island" = "管理 ~/.codebuddy/settings.json，按 CodeBuddy CLI Claude-compatible hooks 协议接入 Island";

--- a/PingIsland/Services/Diagnostics/DiagnosticsExporter.swift
+++ b/PingIsland/Services/Diagnostics/DiagnosticsExporter.swift
@@ -464,6 +464,8 @@ actor DiagnosticsExporter {
             (fileManager.homeDirectoryForCurrentUser.appendingPathComponent(".codex/session_index.jsonl"), "configs/codex-session-index.jsonl"),
             (fileManager.homeDirectoryForCurrentUser.appendingPathComponent(".hermes/plugins/ping_island/plugin.yaml"), "configs/hermes-plugin/plugin.yaml"),
             (fileManager.homeDirectoryForCurrentUser.appendingPathComponent(".hermes/plugins/ping_island/__init__.py"), "configs/hermes-plugin/__init__.py"),
+            (fileManager.homeDirectoryForCurrentUser.appendingPathComponent(".gemini/antigravity-cli/plugins/ping-island/plugin.json"), "configs/antigravity-plugin/plugin.json"),
+            (fileManager.homeDirectoryForCurrentUser.appendingPathComponent(".gemini/antigravity-cli/plugins/ping-island/hooks.json"), "configs/antigravity-plugin/hooks.json"),
         ]
 
         for item in copiedFiles {
@@ -492,6 +494,17 @@ actor DiagnosticsExporter {
             )
         } catch {
             warnings.append("Failed to export Gemini CLI hook debug summaries: \(error.localizedDescription)")
+        }
+
+        do {
+            try copyRecentDirectoryContentsIfPresent(
+                from: fileManager.homeDirectoryForCurrentUser
+                    .appendingPathComponent(".ping-island-debug/antigravity-hooks", isDirectory: true),
+                toRelativeDirectory: "debug/antigravity-hooks",
+                under: exportRoot
+            )
+        } catch {
+            warnings.append("Failed to export Antigravity CLI hook debug summaries: \(error.localizedDescription)")
         }
 
         do {

--- a/PingIsland/Services/Hooks/HookInstaller.swift
+++ b/PingIsland/Services/Hooks/HookInstaller.swift
@@ -1857,6 +1857,8 @@ struct HookInstaller {
         let marker = managedMarker(for: profile)
         let candidates = [
             url.appendingPathComponent("plugin.yaml"),
+            url.appendingPathComponent("plugin.json"),
+            url.appendingPathComponent("hooks.json"),
             url.appendingPathComponent("__init__.py"),
             url.appendingPathComponent("index.ts")
         ]
@@ -2637,7 +2639,19 @@ struct HookInstaller {
         """
     }
 
-    static func managedPluginDirectoryFiles(for profile: ManagedHookClientProfile) -> [String: String] {
+    static func managedPluginDirectoryFiles(
+        for profile: ManagedHookClientProfile,
+        bridgeArguments: [String]? = nil,
+        bridgeEnvironment: [String: String] = [:]
+    ) -> [String: String] {
+        if profile.id == "antigravity-hooks" {
+            return managedAntigravityPluginFiles(
+                for: profile,
+                bridgeArguments: bridgeArguments,
+                bridgeEnvironment: bridgeEnvironment
+            )
+        }
+
         if profile.id == "pi-hooks" {
             return ["index.ts": managedPiExtensionSource(for: profile)]
         }
@@ -3071,6 +3085,49 @@ struct HookInstaller {
         return [
             "plugin.yaml": pluginYAML,
             "__init__.py": initPy,
+        ]
+    }
+
+    private static func managedAntigravityPluginFiles(
+        for profile: ManagedHookClientProfile,
+        bridgeArguments: [String]?,
+        bridgeEnvironment: [String: String]
+    ) -> [String: String] {
+        let marker = managedMarker(for: profile)
+        let resolvedBridgeArguments = bridgeArguments ?? bridgeCommandArguments(for: profile)
+        let environmentPrefix = bridgeEnvironment
+            .sorted { $0.key < $1.key }
+            .map { "\($0.key)=\(shellQuoted($0.value))" }
+
+        var eventHooks: [String: Any] = [:]
+        for event in profile.events {
+            let command = (
+                environmentPrefix
+                + (resolvedBridgeArguments + ["--event", event.name]).map(shellQuotedIfNeeded)
+            ).joined(separator: " ")
+            eventHooks[event.name] = makeHookEntries(command: command, event: event)
+        }
+
+        let manifest: [String: Any] = [
+            "$schema": "https://antigravity.google/schemas/v1/plugin.json",
+            "name": "ping-island",
+            "description": "\(marker). Forward Antigravity CLI activity to Ping Island."
+        ]
+        let hooks: [String: Any] = ["ping-island": eventHooks]
+
+        func jsonString(_ object: Any) -> String {
+            guard let data = try? JSONSerialization.data(
+                withJSONObject: object,
+                options: [.prettyPrinted, .sortedKeys]
+            ) else {
+                return "{}"
+            }
+            return String(data: data, encoding: .utf8) ?? "{}"
+        }
+
+        return [
+            "plugin.json": jsonString(manifest),
+            "hooks.json": jsonString(hooks),
         ]
     }
 
@@ -3938,6 +3995,22 @@ struct HookInstaller {
         case .tomlHooks:
             return baseDirectory.appendingPathComponent(profile.primaryConfigurationURL.lastPathComponent)
         case .pluginDirectory:
+            if profile.id == "antigravity-hooks" {
+                if baseDirectory.lastPathComponent == "antigravity-cli" {
+                    return baseDirectory
+                        .appendingPathComponent("plugins", isDirectory: true)
+                        .appendingPathComponent(
+                            profile.primaryConfigurationURL.lastPathComponent,
+                            isDirectory: true
+                        )
+                }
+                if baseDirectory.lastPathComponent == "plugins" {
+                    return baseDirectory.appendingPathComponent(
+                        profile.primaryConfigurationURL.lastPathComponent,
+                        isDirectory: true
+                    )
+                }
+            }
             if baseDirectory.lastPathComponent == ".hermes" {
                 return baseDirectory
                     .appendingPathComponent("plugins", isDirectory: true)

--- a/PingIsland/Services/Remote/RemoteConnectorManager.swift
+++ b/PingIsland/Services/Remote/RemoteConnectorManager.swift
@@ -875,7 +875,16 @@ final class RemoteConnectorManager: ObservableObject {
                     relativePath: profile.configurationRelativePaths[0],
                     homeDirectory: probe.homeDirectory
                 )
-                let remoteFiles = HookInstaller.managedPluginDirectoryFiles(for: profile)
+                let remoteFiles = HookInstaller.managedPluginDirectoryFiles(
+                    for: profile,
+                    bridgeArguments: Self.remoteManagedBridgeArguments(
+                        for: profile,
+                        installRoot: endpoint.remoteInstallRoot
+                    ),
+                    bridgeEnvironment: Self.remoteManagedBridgeEnvironment(
+                        hookSocketPath: endpoint.remoteHookSocketPath
+                    )
+                )
                 logger.debug(
                     "Remote bootstrap preparing plugin directory endpoint=\(endpoint.id.uuidString, privacy: .public) profile=\(profile.id, privacy: .public) remotePath=\(remoteDirectoryPath, privacy: .public) fileCount=\(remoteFiles.count, privacy: .public)"
                 )
@@ -1552,6 +1561,7 @@ final class RemoteConnectorManager: ObservableObject {
         let supportedProfileIDs: Set<String> = [
             "claude-hooks",
             "codex-hooks",
+            "antigravity-hooks",
             "hermes-hooks",
             "pi-hooks",
             "qwen-code-hooks",

--- a/PingIslandTests/AntigravityIntegrationTests.swift
+++ b/PingIslandTests/AntigravityIntegrationTests.swift
@@ -1,0 +1,119 @@
+import XCTest
+@testable import Ping_Island
+
+final class AntigravityIntegrationTests: XCTestCase {
+    func testManagedProfileUsesNativePluginDirectory() throws {
+        let profile = try XCTUnwrap(
+            ClientProfileRegistry.managedHookProfile(id: "antigravity-hooks")
+        )
+
+        XCTAssertEqual(profile.title, "Antigravity CLI")
+        XCTAssertEqual(profile.installationKind, .pluginDirectory)
+        XCTAssertEqual(profile.brand, .gemini)
+        XCTAssertEqual(profile.logoAssetName, "GeminiLogo")
+        XCTAssertTrue(profile.prefersBundledLogoOverAppIcon)
+        XCTAssertEqual(
+            profile.primaryConfigurationURL.path,
+            NSHomeDirectory() + "/.gemini/antigravity-cli/plugins/ping-island"
+        )
+        XCTAssertEqual(
+            Set(profile.events.map(\.name)),
+            ["PreToolUse", "PostToolUse", "PreInvocation", "PostInvocation", "Stop"]
+        )
+    }
+
+    func testGeneratedPluginUsesOfficialManifestAndNamespacedHookSchema() throws {
+        let profile = try XCTUnwrap(
+            ClientProfileRegistry.managedHookProfile(id: "antigravity-hooks")
+        )
+        let files = HookInstaller.managedPluginDirectoryFiles(for: profile)
+        let manifestData = try XCTUnwrap(files["plugin.json"]?.data(using: .utf8))
+        let hooksData = try XCTUnwrap(files["hooks.json"]?.data(using: .utf8))
+        let manifest = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: manifestData) as? [String: Any]
+        )
+        let hooksRoot = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: hooksData) as? [String: Any]
+        )
+        let hooks = try XCTUnwrap(hooksRoot["ping-island"] as? [String: Any])
+
+        XCTAssertEqual(Set(files.keys), ["plugin.json", "hooks.json"])
+        XCTAssertEqual(manifest["name"] as? String, "ping-island")
+        XCTAssertEqual(
+            manifest["$schema"] as? String,
+            "https://antigravity.google/schemas/v1/plugin.json"
+        )
+        XCTAssertTrue(
+            (manifest["description"] as? String)?
+                .contains("Ping Island managed integration: antigravity-hooks") == true
+        )
+
+        let preToolEntries = try XCTUnwrap(hooks["PreToolUse"] as? [[String: Any]])
+        let preToolEntry = try XCTUnwrap(preToolEntries.first)
+        XCTAssertEqual(preToolEntry["matcher"] as? String, ".*")
+        let preToolCommands = try XCTUnwrap(preToolEntry["hooks"] as? [[String: Any]])
+        let preToolCommand = try XCTUnwrap(preToolCommands.first?["command"] as? String)
+        XCTAssertTrue(preToolCommand.contains("--client-kind antigravity"))
+        XCTAssertTrue(preToolCommand.contains("--event PreToolUse"))
+
+        let invocationEntries = try XCTUnwrap(hooks["PreInvocation"] as? [[String: Any]])
+        let invocationCommand = try XCTUnwrap(invocationEntries.first?["command"] as? String)
+        XCTAssertTrue(invocationCommand.contains("--event PreInvocation"))
+        XCTAssertNil(invocationEntries.first?["hooks"])
+    }
+
+    func testRemotePluginUsesRemoteBridgeAndSocket() throws {
+        let profile = try XCTUnwrap(
+            ClientProfileRegistry.managedHookProfile(id: "antigravity-hooks")
+        )
+        let files = HookInstaller.managedPluginDirectoryFiles(
+            for: profile,
+            bridgeArguments: [
+                "/root/.ping-island/bin/ping-island-bridge",
+                "--source", "gemini",
+                "--client-kind", "antigravity"
+            ],
+            bridgeEnvironment: [
+                "ISLAND_SOCKET_PATH": "/root/.ping-island/run/agent-hook.sock"
+            ]
+        )
+        let hooks = try XCTUnwrap(files["hooks.json"])
+
+        XCTAssertTrue(hooks.contains("/root/.ping-island/bin/ping-island-bridge"))
+        XCTAssertTrue(hooks.contains("ISLAND_SOCKET_PATH="))
+        XCTAssertTrue(hooks.contains("/root/.ping-island/run/agent-hook.sock"))
+        XCTAssertFalse(hooks.contains(NSHomeDirectory() + "/.ping-island/bin"))
+    }
+
+    func testRuntimeProfileKeepsAntigravityIdentityWithGeminiMascot() {
+        let profile = ClientProfileRegistry.matchRuntimeProfile(
+            provider: .gemini,
+            explicitKind: "agy",
+            explicitName: "Antigravity CLI",
+            explicitBundleIdentifier: nil,
+            terminalBundleIdentifier: nil,
+            origin: "cli",
+            originator: "Antigravity CLI",
+            threadSource: "antigravity-hooks",
+            processName: "agy"
+        )
+
+        XCTAssertEqual(profile?.id, "antigravity")
+        XCTAssertEqual(profile?.displayName, "Antigravity CLI")
+        XCTAssertEqual(profile?.brand, .gemini)
+
+        let clientInfo = SessionClientInfo(
+            kind: .custom,
+            profileID: "antigravity",
+            name: "Antigravity CLI",
+            origin: "cli",
+            originator: "Antigravity CLI",
+            threadSource: "antigravity-hooks"
+        )
+
+        XCTAssertTrue(clientInfo.isGeminiClient)
+        XCTAssertTrue(clientInfo.prefersHookMessageAsLastMessageFallback)
+        XCTAssertEqual(clientInfo.badgeLabel(for: .gemini), "Antigravity CLI")
+        XCTAssertEqual(MascotKind(clientInfo: clientInfo, provider: .gemini), .gemini)
+    }
+}

--- a/PingIslandTests/ClientProfileIconTests.swift
+++ b/PingIslandTests/ClientProfileIconTests.swift
@@ -7,6 +7,7 @@ final class ClientProfileIconTests: XCTestCase {
             "claude-hooks": "ClaudeLogo",
             "codex-hooks": "CodexLogo",
             "gemini-hooks": "GeminiLogo",
+            "antigravity-hooks": "GeminiLogo",
             "openclaw-hooks": "OpenClawLogo",
             "pi-hooks": "PiLogo",
             "codebuddy-hooks": "CodeBuddyLogo",

--- a/PingIslandTests/RemoteHookConfigurationTests.swift
+++ b/PingIslandTests/RemoteHookConfigurationTests.swift
@@ -127,6 +127,7 @@ final class RemoteHookConfigurationTests: XCTestCase {
         XCTAssertEqual(profileIDs, [
             "claude-hooks",
             "codex-hooks",
+            "antigravity-hooks",
             "hermes-hooks",
             "pi-hooks",
             "qwen-code-hooks",
@@ -148,6 +149,8 @@ final class RemoteHookConfigurationTests: XCTestCase {
 
         XCTAssertTrue(directories.contains("/root/.claude"))
         XCTAssertTrue(directories.contains("/root/.codex"))
+        XCTAssertTrue(directories.contains("/root/.gemini/antigravity-cli/plugins"))
+        XCTAssertTrue(directories.contains("/root/.gemini/antigravity-cli/plugins/ping-island"))
         XCTAssertTrue(directories.contains("/root/.hermes/plugins"))
         XCTAssertTrue(directories.contains("/root/.hermes/plugins/ping_island"))
         XCTAssertTrue(directories.contains("/root/.pi/agent/extensions"))

--- a/Prototype/Sources/IslandBridge/main.swift
+++ b/Prototype/Sources/IslandBridge/main.swift
@@ -52,6 +52,10 @@ struct IslandBridgeMain {
                 )
 
                 let socketPath = environment["ISLAND_SOCKET_PATH"] ?? "/tmp/island.sock"
+                let fallbackStdoutPayload = HookPayloadMapper.fallbackStdoutPayload(
+                    eventType: envelope.eventType,
+                    metadata: envelope.metadata
+                )
                 guard HookPayloadMapper.shouldDeliverEnvelope(envelope) else {
                     try? BridgeDebugLogger.logDeliveryIfNeeded(
                         envelope: envelope,
@@ -84,6 +88,10 @@ struct IslandBridgeMain {
                         outcome: "connection_failed",
                         policy: runtimeConfig.debugLogPolicy
                     )
+                    if let fallbackStdoutPayload {
+                        FileHandle.standardOutput.write(Data(fallbackStdoutPayload.utf8))
+                        return
+                    }
                     throw BridgeError.connectionFailed
                 }
 
@@ -95,6 +103,8 @@ struct IslandBridgeMain {
                         metadata: envelope.metadata
                     )
                     FileHandle.standardOutput.write(Data(payload.utf8))
+                } else if let fallbackStdoutPayload {
+                    FileHandle.standardOutput.write(Data(fallbackStdoutPayload.utf8))
                 }
             case .remoteAgentService:
                 let hookSocket = try requiredArgument("--hook-socket", arguments: CommandLine.arguments)
@@ -471,6 +481,8 @@ private enum BridgeDebugLogger {
             return "kimi-hooks"
         case "gemini":
             return "gemini-hooks"
+        case "antigravity", "antigravity-cli", "antigravity_cli", "antigravity cli", "agy":
+            return "antigravity-hooks"
         default:
             break
         }

--- a/Prototype/Sources/IslandShared/HookPayloadMapper.swift
+++ b/Prototype/Sources/IslandShared/HookPayloadMapper.swift
@@ -114,6 +114,9 @@ public enum HookPayloadMapper {
         switch provider {
         case .claude, .gemini:
             let clientKind = normalizedClientKind(from: metadata)
+            if isAntigravityHookClient(clientKind) {
+                return antigravityStdoutPayload(response: response, decision: decision)
+            }
             if isQoderCLIClientKind(clientKind),
                isQoderCLIPlanExitApproval(
                    eventType: eventType,
@@ -260,6 +263,45 @@ public enum HookPayloadMapper {
                 }
                 return String(data: data, encoding: .utf8) ?? #"{"permissionDecision":"allow"}"#
             }
+        }
+    }
+
+    public static func fallbackStdoutPayload(
+        eventType: String,
+        metadata: [String: String]
+    ) -> String? {
+        let clientKind = normalizedClientKind(from: metadata)
+        guard isAntigravityHookClient(clientKind) else {
+            return nil
+        }
+
+        switch eventType.lowercased() {
+        case "pretooluse":
+            // Preserve Antigravity's native permission evaluation instead of
+            // allowing an observational Ping Island hook to auto-approve tools.
+            return #"{"decision":"ask"}"#
+        case "stop":
+            // Any value other than "continue" allows Antigravity to stop.
+            return #"{"decision":"stop"}"#
+        default:
+            return "{}"
+        }
+    }
+
+    private static func antigravityStdoutPayload(
+        response: BridgeResponse,
+        decision: InterventionDecision
+    ) -> String {
+        switch decision {
+        case .approve, .approveForSession:
+            return #"{"decision":"allow"}"#
+        case .deny, .cancel:
+            let reason = BridgeCodec.jsonString(
+                for: response.reason ?? "Denied from Ping Island"
+            ) ?? #""Denied from Ping Island""#
+            return #"{"decision":"deny","reason":\#(reason)}"#
+        case .answer:
+            return #"{"decision":"ask"}"#
         }
     }
 
@@ -1024,11 +1066,36 @@ public enum HookPayloadMapper {
         var normalized = payload
 
         if source == .gemini {
+            if normalized["session_id"] == nil,
+               let conversationID = payload["conversationId"] as? String {
+                normalized["session_id"] = conversationID
+            }
+            if normalized["cwd"] == nil,
+               let workspacePaths = payload["workspacePaths"] as? [String],
+               let workspacePath = workspacePaths.first {
+                normalized["cwd"] = workspacePath
+            }
+            if normalized["transcript_path"] == nil,
+               let transcriptPath = payload["transcriptPath"] as? String {
+                normalized["transcript_path"] = transcriptPath
+            }
+            if let toolCall = payload["toolCall"] as? [String: Any] {
+                if normalized["tool_name"] == nil {
+                    normalized["tool_name"] = toolCall["name"]
+                }
+                if normalized["tool_input"] == nil {
+                    normalized["tool_input"] = toolCall["args"]
+                }
+            }
             if normalized["message"] == nil {
                 if let promptResponse = payload["prompt_response"] as? String {
                     normalized["message"] = promptResponse
                 } else if let prompt = payload["prompt"] as? String {
                     normalized["message"] = prompt
+                } else if let error = payload["error"] as? String, !error.isEmpty {
+                    normalized["message"] = error
+                } else if let terminationReason = payload["terminationReason"] as? String {
+                    normalized["message"] = terminationReason
                 }
             }
             if normalized["last_assistant_message"] == nil, let promptResponse = payload["prompt_response"] as? String {
@@ -1530,7 +1597,18 @@ public enum HookPayloadMapper {
     private static func isGeminiHookClient(_ clientKind: String?) -> Bool {
         guard let clientKind else { return false }
         switch clientKind {
-        case "gemini", "gemini-cli", "gemini_cli", "gemini cli":
+        case "gemini", "gemini-cli", "gemini_cli", "gemini cli",
+             "antigravity", "antigravity-cli", "antigravity_cli", "antigravity cli", "agy":
+            return true
+        default:
+            return false
+        }
+    }
+
+    private static func isAntigravityHookClient(_ clientKind: String?) -> Bool {
+        guard let clientKind else { return false }
+        switch clientKind {
+        case "antigravity", "antigravity-cli", "antigravity_cli", "antigravity cli", "agy":
             return true
         default:
             return false
@@ -1542,17 +1620,27 @@ public enum HookPayloadMapper {
         payload: [String: Any]
     ) -> SessionStatus {
         switch eventType.lowercased() {
-        case "beforetool":
+        case "beforetool", "pretooluse":
             return SessionStatus(kind: .runningTool)
-        case "aftertool":
+        case "aftertool", "posttooluse":
+            if let error = payload["error"] as? String, !error.isEmpty {
+                return SessionStatus(kind: .error)
+            }
             if let toolResponse = payload["tool_response"] as? [String: Any],
                toolResponse["error"] != nil {
                 return SessionStatus(kind: .error)
             }
             return SessionStatus(kind: .active)
-        case "beforeagent", "beforetoolselection":
+        case "beforeagent", "beforetoolselection", "preinvocation":
             return SessionStatus(kind: .thinking)
         case "afteragent", "aftermodel":
+            return SessionStatus(kind: .waitingForInput)
+        case "postinvocation":
+            return SessionStatus(kind: .active)
+        case "stop":
+            if let error = payload["error"] as? String, !error.isEmpty {
+                return SessionStatus(kind: .error)
+            }
             return SessionStatus(kind: .waitingForInput)
         case "sessionstart":
             return SessionStatus(kind: .waitingForInput)

--- a/Prototype/Tests/IslandTests/HookPayloadMapperTests.swift
+++ b/Prototype/Tests/IslandTests/HookPayloadMapperTests.swift
@@ -2684,6 +2684,118 @@ func geminiNotificationStaysObservabilityOnly() throws {
 }
 
 @Test
+func antigravityPreToolUseNormalizesOfficialCamelCasePayload() throws {
+    let payload = """
+    {
+      "toolCall": {
+        "name": "run_command",
+        "args": {
+          "CommandLine": "swift test",
+          "Cwd": "/workspace/project"
+        }
+      },
+      "stepIdx": 4,
+      "conversationId": "agy-conversation-1",
+      "workspacePaths": ["/workspace/project"],
+      "transcriptPath": "/tmp/antigravity-cli/brain/agy-conversation-1/transcript.jsonl",
+      "artifactDirectoryPath": "/tmp/antigravity-cli/brain/agy-conversation-1"
+    }
+    """.data(using: .utf8)!
+
+    let envelope = HookPayloadMapper.makeEnvelope(
+        source: .gemini,
+        arguments: [
+            "ping-island-bridge",
+            "--source", "gemini",
+            "--client-kind", "antigravity",
+            "--client-name", "Antigravity CLI",
+            "--client-origin", "cli",
+            "--client-originator", "Antigravity CLI",
+            "--thread-source", "antigravity-hooks",
+            "--event", "PreToolUse"
+        ],
+        environment: ["TERM_PROGRAM": "ghostty"],
+        stdinData: payload
+    )
+
+    #expect(envelope.eventType == "PreToolUse")
+    #expect(envelope.sessionKey == "gemini:agy-conversation-1")
+    #expect(envelope.cwd == "/workspace/project")
+    #expect(envelope.title == "run_command")
+    #expect(envelope.preview?.contains("swift test") == true)
+    #expect(envelope.status?.kind == .runningTool)
+    #expect(envelope.intervention == nil)
+    #expect(envelope.expectsResponse == false)
+    #expect(envelope.metadata["client_kind"] == "antigravity")
+    #expect(envelope.metadata["tool_name"] == "run_command")
+    #expect(envelope.metadata["transcript_path"]?.contains("agy-conversation-1") == true)
+}
+
+@Test
+func antigravityFallbackOutputPreservesNativePermissionHandling() throws {
+    let preToolPayload = try #require(
+        HookPayloadMapper.fallbackStdoutPayload(
+            eventType: "PreToolUse",
+            metadata: ["client_kind": "antigravity"]
+        )
+    )
+    let preToolJSON = try #require(
+        JSONSerialization.jsonObject(with: Data(preToolPayload.utf8)) as? [String: String]
+    )
+    #expect(preToolJSON["decision"] == "ask")
+
+    let stopPayload = try #require(
+        HookPayloadMapper.fallbackStdoutPayload(
+            eventType: "Stop",
+            metadata: ["client_kind": "agy"]
+        )
+    )
+    let stopJSON = try #require(
+        JSONSerialization.jsonObject(with: Data(stopPayload.utf8)) as? [String: String]
+    )
+    #expect(stopJSON["decision"] == "stop")
+
+    #expect(
+        HookPayloadMapper.fallbackStdoutPayload(
+            eventType: "PreToolUse",
+            metadata: ["client_kind": "gemini"]
+        ) == nil
+    )
+}
+
+@Test
+func antigravityStopMapsToWaitingForInput() throws {
+    let payload = """
+    {
+      "executionNum": 1,
+      "terminationReason": "model_stop",
+      "error": "",
+      "fullyIdle": true,
+      "conversationId": "agy-conversation-2",
+      "workspacePaths": ["/workspace/project"],
+      "transcriptPath": "/tmp/antigravity-cli/brain/agy-conversation-2/transcript.jsonl",
+      "artifactDirectoryPath": "/tmp/antigravity-cli/brain/agy-conversation-2"
+    }
+    """.data(using: .utf8)!
+
+    let envelope = HookPayloadMapper.makeEnvelope(
+        source: .gemini,
+        arguments: [
+            "ping-island-bridge",
+            "--source", "gemini",
+            "--client-kind", "antigravity",
+            "--event", "Stop"
+        ],
+        environment: [:],
+        stdinData: payload
+    )
+
+    #expect(envelope.sessionKey == "gemini:agy-conversation-2")
+    #expect(envelope.status?.kind == .waitingForInput)
+    #expect(envelope.expectsResponse == false)
+}
+
+@Test
 func qwenCodeNotificationMapsFromOfficialHookFields() throws {
     let payload = """
     {

--- a/Prototype/Tests/IslandTests/IslandBridgeE2ETests.swift
+++ b/Prototype/Tests/IslandTests/IslandBridgeE2ETests.swift
@@ -78,6 +78,45 @@ func islandBridgeAllowsStateOnlyEventsWhenAppIsUnavailable() throws {
 }
 
 @Test
+func islandBridgePreservesAntigravityPermissionFlowWhenAppIsUnavailable() throws {
+    let executable = try TestRuntime.executableURL(named: "PingIslandBridge")
+    let process = try RunningProcess(
+        executableURL: executable,
+        arguments: [
+            "--source", "gemini",
+            "--client-kind", "antigravity",
+            "--event", "PreToolUse",
+        ],
+        environment: bridgeTestEnvironment([
+            "ISLAND_SOCKET_PATH": "/tmp/ping-island-missing-\(UUID().uuidString).sock",
+        ]),
+        stdin: """
+        {
+          "conversationId": "antigravity-e2e",
+          "workspacePaths": ["/tmp/antigravity-demo"],
+          "toolCall": {
+            "name": "run_shell_command",
+            "args": {
+              "command": "swift test"
+            }
+          }
+        }
+        """
+    )
+
+    let result = process.waitForExit()
+
+    #expect(result.terminationStatus == 0)
+    #expect(result.stderr.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+
+    let stdoutData = Data(result.stdout.utf8)
+    let stdout = try #require(
+        JSONSerialization.jsonObject(with: stdoutData) as? [String: String]
+    )
+    #expect(stdout == ["decision": "ask"])
+}
+
+@Test
 func islandBridgeDoesNotWaitForStdinEOFWhenPayloadAlreadyArrived() async throws {
     let executable = try TestRuntime.executableURL(named: "PingIslandBridge")
     let process = try RunningProcess(

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@
   <img src="docs/images/mascots/copilot.gif" width="36" alt="GitHub Copilot mascot" title="GitHub Copilot">
 </p>
 <p align="center">
-  <sub>Claude Code · Codex · Gemini CLI · Hermes Agent · Pi Agent · Qwen Code · Kimi CLI · OpenClaw · OpenCode · Cursor · Qoder · Qoder CN · CodeBuddy · GitHub Copilot</sub>
+  <sub>Claude Code · Codex · Gemini CLI · Antigravity CLI · Hermes Agent · Pi Agent · Qwen Code · Kimi CLI · OpenClaw · OpenCode · Cursor · Qoder · Qoder CN · CodeBuddy · GitHub Copilot</sub>
 </p>
 
 <a id="lets-try-it"></a>
@@ -127,7 +127,7 @@ For the full notarized release flow and the GitHub Releases backed Sparkle appca
 
 ## What is Ping Island?
 
-Ping Island is a macOS menu bar app that expands into a compact session surface when your coding agents need attention. It listens to Claude-style hooks, Codex hooks, Gemini CLI hooks, Hermes Agent plugin hooks, Pi Agent extension hooks, Qwen Code hooks, Kimi CLI hooks, OpenClaw internal hooks plus session transcripts, the Codex app-server, OpenCode plugins, and compatible IDE integrations so approvals, input requests, completions, and session summaries show up without babysitting terminal tabs.
+Ping Island is a macOS menu bar app that expands into a compact session surface when your coding agents need attention. It listens to Claude-style hooks, Codex hooks, Gemini CLI hooks, Antigravity CLI plugin hooks, Hermes Agent plugin hooks, Pi Agent extension hooks, Qwen Code hooks, Kimi CLI hooks, OpenClaw internal hooks plus session transcripts, the Codex app-server, OpenCode plugins, and compatible IDE integrations so approvals, input requests, completions, and session summaries show up without babysitting terminal tabs.
 
 If you have seen [Vibe Island](https://vibeisland.app/), Ping Island is positioned as an independent open-source alternative in the same category: a native macOS notch/menu bar surface for monitoring and controlling AI coding sessions.
 
@@ -140,7 +140,7 @@ Ping Island focuses on the moments that actually interrupt coding flow, then kee
 - **Claude Code auto-approve** - Turn on per-session auto-approval when you want Claude Code to stop pausing on every permission request.
 - **One-click return** - Jump back to the right iTerm2, Ghostty, Terminal.app, tmux pane, or IDE window.
 - **SSH terminal support** - Bootstrap a remote PingIslandBridge over SSH, rewrite remote hooks to point back at your Mac, forward remote Codex app-server activity, and keep remote terminal activity visible in the same local Island UI.
-- **Multi-agent coverage** - Track Claude Code, Codex, Gemini CLI, Hermes Agent, Pi Agent, Qwen Code, Kimi CLI, OpenClaw, OpenCode, Cursor, Qoder, Qoder CN, CodeBuddy, WorkBuddy, GitHub Copilot, and other compatible sessions in one place.
+- **Multi-agent coverage** - Track Claude Code, Codex, Gemini CLI, Antigravity CLI, Hermes Agent, Pi Agent, Qwen Code, Kimi CLI, OpenClaw, OpenCode, Cursor, Qoder, Qoder CN, CodeBuddy, WorkBuddy, GitHub Copilot, and other compatible sessions in one place.
 - **OpenClaw gateway support** - Follow OpenClaw sessions from managed internal hooks, then refill the conversation from OpenClaw's local session transcripts so the Island UI can show the actual back-and-forth instead of a single inbound message.
 - **Codex hook + app-server sync** - Support Codex CLI hooks, live app-server threads, and rollout parsing fallback when needed.
 - **Custom sounds** - Pick per-event macOS sounds or import local sound packs for your own notification style.
@@ -159,6 +159,7 @@ Ping Island focuses on the moments that actually interrupt coding flow, then kee
 | Claude Code | Claude-compatible hooks through `PingIslandBridge` | Terminal.app, iTerm2, Ghostty, tmux, and IDE terminals | Tool approvals, AskUserQuestion replies, compaction alerts, completion popups, auto-approve |
 | Codex App + Codex CLI | Codex CLI hooks, live `codex app-server`, rollout parsing fallback | Codex app, terminal, tmux, and IDE terminals | Approval/input requests, live thread sync, usage snapshots, remote app-server forwarding |
 | Gemini CLI | Gemini CLI hooks in `~/.gemini/settings.json` | Compatible terminal hosts | Session lifecycle, tool activity, notifications, pre-compaction events |
+| Antigravity CLI | Generated native plugin under `~/.gemini/antigravity-cli/plugins/ping-island/` | Compatible terminal hosts and remote SSH sessions | Model invocation, tool activity, errors, and turn-stop status while preserving Antigravity's native permission prompts |
 | Hermes Agent | Official plugin hooks in `~/.hermes/plugins/ping_island/` | Hermes CLI terminal host | User prompts, tool activity, assistant replies, session-end notifications |
 | Pi Agent | Official extension under `~/.pi/agent/extensions/ping_island/` | Pi Agent terminal host | Extension event forwarding, client-aware session tracking, terminal-cloud mascot |
 | Qwen Code | Official hooks in `~/.qwen/settings.json` | Compatible terminal hosts and remote SSH sessions | Permission prompts, notification popups, stop/session-end handling, remote hook forwarding |
@@ -283,7 +284,7 @@ Sound packs can use `.wav`, `.mp3`, or `.ogg` files. If a selected pack does not
 ## How It Works
 
 ```text
-Claude / Codex / Gemini CLI / Hermes Agent / Pi Agent / Qwen Code / Kimi CLI / OpenCode / Cursor / Qoder / Qoder CN / CodeBuddy / WorkBuddy / Copilot / ...
+Claude / Codex / Gemini CLI / Antigravity CLI / Hermes Agent / Pi Agent / Qwen Code / Kimi CLI / OpenCode / Cursor / Qoder / Qoder CN / CodeBuddy / WorkBuddy / Copilot / ...
   -> hook or app-server event
     -> Ping Island monitor + normalization layer
       -> SessionStore
@@ -296,6 +297,7 @@ Implementation details worth knowing:
 - Claude-family tools enter through managed hook files plus the embedded `PingIslandBridge` launcher.
 - Codex sessions can come from hook events or the live `codex app-server` websocket monitor.
 - Gemini CLI hooks are installed into `~/.gemini/settings.json`; tool matchers use Gemini's regex-based hook matcher syntax.
+- Antigravity CLI uses a generated native plugin under `~/.gemini/antigravity-cli/plugins/ping-island/`; Ping Island returns `ask` from its observational `PreToolUse` hook so Antigravity's own permission engine remains authoritative.
 - Pi Agent is wired through a generated TypeScript extension under `~/.pi/agent/extensions/ping_island/` and forwards events through the Claude-compatible bridge with Pi-specific client metadata.
 - Qwen Code hooks are installed into `~/.qwen/settings.json`; the bridge follows the official event names and uses `Stop` / `SessionEnd` / `Notification` messages to surface popup-ready summaries in Island.
 - Kimi CLI hooks are installed into `~/.kimi/config.toml`; Ping Island preserves unrelated TOML content and maps Kimi `Stop` to turn completion while `SessionEnd` closes the session.


### PR DESCRIPTION
## Summary

- add an Antigravity CLI managed integration using its native plugin directory, `plugin.json`, and namespaced `hooks.json`
- normalize Antigravity's camelCase hook payloads into the existing Gemini-family session pipeline
- keep `PreToolUse` observational by returning `ask`, including when Ping Island is unavailable, so Antigravity remains responsible for permissions
- support remote SSH bootstrap, diagnostics export, settings branding, documentation, and regression coverage

## Why

Antigravity CLI has a separate customization root and hook contract from Gemini CLI. Reusing the existing Gemini `settings.json` integration would not install or interpret Antigravity hooks correctly.

Closes #253

## Validation

- `swift test --package-path Prototype` — 136 tests passed
- focused Xcode validation compiled the app and unit-test targets, including the new Antigravity tests
- `git diff --cached --check`

## Known validation gap

- `agy` is not installed on this Mac, so a live CLI plugin round trip was not available
- focused Xcode test execution was cancelled after the host volume ran out of space; this was an infrastructure failure after compilation, not a test assertion failure

## Protocol references

- https://www.antigravity.google/docs/hooks
- https://antigravity.google/docs/cli/plugins
