### PR TITLE
Restore live VS Code Codex status without hooks

### DIFF
--- a/PingIsland/Services/Codex/CodexAppServerMonitor.swift
+++ b/PingIsland/Services/Codex/CodexAppServerMonitor.swift
@@ -50,9 +50,13 @@ actor CodexAppServerMonitor {
     private var pendingResponses: [String: CheckedContinuation<[String: Any], Error>] = [:]
     private var pendingRequestsByThread: [String: PendingRequest] = [:]
     private var threadApprovalModes: [String: String] = [:]  // threadId → approvalMode
+    private var recoveredNotLoadedThreadVersions: [String: String] = [:]
     private var resolvedClientBundleIdentifier: String?
     private var resolvedClientName: String?
     private var lastThreadDiagnostics: [ThreadDiagnosticsSnapshot] = []
+
+    private nonisolated static let notLoadedRecoveryWindow: TimeInterval = 10 * 60
+    private nonisolated static let maximumFutureActivitySkew: TimeInterval = 60
 
     private init() {}
 
@@ -110,6 +114,7 @@ actor CodexAppServerMonitor {
         process = nil
         pendingRequestsByThread.removeAll()
         threadApprovalModes.removeAll()
+        recoveredNotLoadedThreadVersions.removeAll()
         lastThreadDiagnostics.removeAll()
 
         for (_, continuation) in pendingResponses {
@@ -611,6 +616,7 @@ actor CodexAppServerMonitor {
         case "thread/archived":
             guard let threadId = params["threadId"] as? String else { return }
             logger.info("Codex thread archived thread=\(threadId, privacy: .public)")
+            recoveredNotLoadedThreadVersions.removeValue(forKey: threadId)
             removeThreadDiagnostics(threadId: threadId)
             await SessionStore.shared.process(.sessionEnded(sessionId: threadId))
 
@@ -907,6 +913,75 @@ actor CodexAppServerMonitor {
         for thread in visibleThreads {
             await ingestThread(thread)
         }
+        await recoverRecentNotLoadedThreads(visibleThreads)
+    }
+
+    private func recoverRecentNotLoadedThreads(_ threads: [[String: Any]]) async {
+        let referenceDate = Date()
+
+        for thread in threads {
+            guard let threadId = thread["id"] as? String,
+                  let version = Self.notLoadedRecoveryVersion(
+                    from: thread,
+                    referenceDate: referenceDate
+                  ),
+                  recoveredNotLoadedThreadVersions[threadId] != version else {
+                continue
+            }
+
+            recoveredNotLoadedThreadVersions[threadId] = version
+            let clientInfo = makeClientInfo(from: thread, threadId: threadId)
+            // thread/read intentionally preserves notLoaded for stored threads.
+            // The rollout is the cross-process source of truth when VS Code owns
+            // the live app-server instance.
+            let snapshot = await CodexRolloutParser.shared.parseThread(
+                threadId: threadId,
+                fallbackCwd: thread["cwd"] as? String ?? "/",
+                clientInfo: clientInfo
+            )
+
+            guard recoveredNotLoadedThreadVersions[threadId] == version else {
+                continue
+            }
+            guard let snapshot else {
+                recoveredNotLoadedThreadVersions.removeValue(forKey: threadId)
+                logger.debug(
+                    "Codex notLoaded rollout recovery unavailable thread=\(threadId, privacy: .public)"
+                )
+                continue
+            }
+
+            await SessionStore.shared.syncCodexThreadSnapshot(snapshot)
+            logger.debug(
+                "Codex notLoaded rollout recovered thread=\(threadId, privacy: .public) phase=\(String(describing: snapshot.phase), privacy: .public)"
+            )
+        }
+    }
+
+    nonisolated static func notLoadedRecoveryVersion(
+        from thread: [String: Any],
+        referenceDate: Date = Date()
+    ) -> String? {
+        guard (thread["status"] as? [String: Any])?["type"] as? String == "notLoaded" else {
+            return nil
+        }
+
+        let updatedAt = date(fromUnixTimestamp: thread["updatedAt"])
+        let recencyAt = date(fromUnixTimestamp: thread["recencyAt"])
+        guard let activityAt = [updatedAt, recencyAt].compactMap({ $0 }).max() else {
+            return nil
+        }
+
+        let activityAge = referenceDate.timeIntervalSince(activityAt)
+        guard activityAge >= -maximumFutureActivitySkew,
+              activityAge <= notLoadedRecoveryWindow else {
+            return nil
+        }
+
+        return [
+            updatedAt.map { String($0.timeIntervalSince1970) } ?? "missing",
+            recencyAt.map { String($0.timeIntervalSince1970) } ?? "missing"
+        ].joined(separator: "|")
     }
 
     private static func threadListRequestParams(limit: Int = 30) -> [String: Any] {
@@ -921,8 +996,12 @@ actor CodexAppServerMonitor {
         guard let threadId = thread["id"] as? String else { return }
         if Self.shouldIgnoreAuxiliaryThread(thread) {
             logger.notice("Ignoring auxiliary Codex thread=\(threadId, privacy: .public)")
+            recoveredNotLoadedThreadVersions.removeValue(forKey: threadId)
             removeThreadDiagnostics(threadId: threadId)
             return
+        }
+        if (thread["status"] as? [String: Any])?["type"] as? String != "notLoaded" {
+            recoveredNotLoadedThreadVersions.removeValue(forKey: threadId)
         }
 
         // Cache approvalMode from app-server data so approval-policy checks
@@ -1043,6 +1122,17 @@ actor CodexAppServerMonitor {
             .replacingOccurrences(of: "\r", with: "\n")
             .trimmingCharacters(in: .whitespacesAndNewlines)
         return collapsed.isEmpty ? nil : collapsed
+    }
+
+    nonisolated static func rolloutPath(from thread: [String: Any]) -> String? {
+        [
+            thread["rolloutPath"] as? String,
+            thread["sessionFilePath"] as? String,
+            thread["rollout_path"] as? String,
+            thread["path"] as? String
+        ]
+        .compactMap(sanitizedThreadText(_:))
+        .first(where: { $0.hasSuffix(".jsonl") })
     }
 
     private func parseThreadSnapshot(_ thread: [String: Any]) -> CodexThreadSnapshot? {
@@ -1415,9 +1505,7 @@ actor CodexAppServerMonitor {
         let threadSource = sanitizedText(thread["threadSource"] as? String)
             ?? sanitizedText(thread["source"] as? String)
             ?? sanitizedText(thread["sessionStartSource"] as? String)
-        let sessionFilePath = sanitizedText(thread["rolloutPath"] as? String)
-            ?? sanitizedText(thread["sessionFilePath"] as? String)
-            ?? sanitizedText(thread["rollout_path"] as? String)
+        let sessionFilePath = Self.rolloutPath(from: thread)
 
         let resolvedOrigin = origin ?? "desktop"
 

--- a/PingIslandTests/CodexAppServerMonitorTests.swift
+++ b/PingIslandTests/CodexAppServerMonitorTests.swift
@@ -85,4 +85,91 @@ final class CodexAppServerMonitorTests: XCTestCase {
         XCTAssertEqual(questions.first?.options.map(\.title), ["Tests", "UI"])
         XCTAssertTrue(questions.first?.allowsOther ?? false)
     }
+
+    func testRecentNotLoadedThreadRequestsRolloutRecovery() {
+        let referenceDate = Date(timeIntervalSince1970: 1_784_812_800)
+        let thread: [String: Any] = [
+            "id": "vscode-thread",
+            "updatedAt": referenceDate.addingTimeInterval(-15).timeIntervalSince1970,
+            "recencyAt": referenceDate.addingTimeInterval(-30).timeIntervalSince1970,
+            "status": ["type": "notLoaded"]
+        ]
+
+        XCTAssertNotNil(CodexAppServerMonitor.notLoadedRecoveryVersion(
+            from: thread,
+            referenceDate: referenceDate
+        ))
+    }
+
+    func testNotLoadedThreadRecoveryUsesRecencyTimestampWhenUpdatedTimestampIsMissing() {
+        let referenceDate = Date(timeIntervalSince1970: 1_784_812_800)
+        let thread: [String: Any] = [
+            "id": "vscode-thread",
+            "recencyAt": referenceDate.addingTimeInterval(-15).timeIntervalSince1970,
+            "status": ["type": "notLoaded"]
+        ]
+
+        XCTAssertNotNil(CodexAppServerMonitor.notLoadedRecoveryVersion(
+            from: thread,
+            referenceDate: referenceDate
+        ))
+    }
+
+    func testLoadedAndStaleThreadsDoNotRequestRolloutRecovery() {
+        let referenceDate = Date(timeIntervalSince1970: 1_784_812_800)
+        let recentTimestamp = referenceDate.addingTimeInterval(-15).timeIntervalSince1970
+        let staleTimestamp = referenceDate.addingTimeInterval(-(11 * 60)).timeIntervalSince1970
+
+        XCTAssertNil(CodexAppServerMonitor.notLoadedRecoveryVersion(
+            from: [
+                "id": "loaded-thread",
+                "updatedAt": recentTimestamp,
+                "status": ["type": "active"]
+            ],
+            referenceDate: referenceDate
+        ))
+        XCTAssertNil(CodexAppServerMonitor.notLoadedRecoveryVersion(
+            from: [
+                "id": "stale-thread",
+                "updatedAt": staleTimestamp,
+                "status": ["type": "notLoaded"]
+            ],
+            referenceDate: referenceDate
+        ))
+    }
+
+    func testNotLoadedRecoveryVersionChangesWhenActivityAdvances() throws {
+        let referenceDate = Date(timeIntervalSince1970: 1_784_812_800)
+        var thread: [String: Any] = [
+            "id": "vscode-thread",
+            "updatedAt": referenceDate.addingTimeInterval(-30).timeIntervalSince1970,
+            "status": ["type": "notLoaded"]
+        ]
+        let initialVersion = try XCTUnwrap(CodexAppServerMonitor.notLoadedRecoveryVersion(
+            from: thread,
+            referenceDate: referenceDate
+        ))
+
+        thread["updatedAt"] = referenceDate.addingTimeInterval(-5).timeIntervalSince1970
+
+        XCTAssertNotEqual(
+            initialVersion,
+            CodexAppServerMonitor.notLoadedRecoveryVersion(
+                from: thread,
+                referenceDate: referenceDate
+            )
+        )
+    }
+
+    func testRolloutPathAcceptsJSONLPathWithoutTreatingWorkspaceAsSessionFile() {
+        XCTAssertEqual(
+            CodexAppServerMonitor.rolloutPath(from: [
+                "path": "/tmp/codex/rollout-vscode-thread.jsonl"
+            ]),
+            "/tmp/codex/rollout-vscode-thread.jsonl"
+        )
+        XCTAssertNil(CodexAppServerMonitor.rolloutPath(from: [
+            "path": "/tmp/codex-workspace"
+        ]))
+    }
 }


### PR DESCRIPTION
## Summary

- recover recent `notLoaded` Codex threads from their persisted rollout snapshots after `thread/list` discovery
- version-gate recovery with `updatedAt` and `recencyAt` so unchanged threads are not reparsed every polling cycle
- preserve direct rollout paths when app-server metadata exposes a JSONL path

## Root cause

VS Code runs its embedded Codex app-server in a separate process and does not emit Ping Island's hook events. Ping Island's own app-server therefore sees the active thread only as a stored `notLoaded` entry. The Codex protocol's `thread/read` method reads stored history without loading or resuming the thread, so it cannot provide the other process's in-memory active status.

The fallback now reads the recent rollout, whose persisted `task_started`, tool-call, completion, and interruption events already map to Ping Island's processing/idle phases.

## Verification

- `CodexAppServerMonitorTests`: 9/9 passed
- `CodexRolloutParserTests`, `SessionStoreCodexInterventionTests`, and `SessionMonitorCodexWatcherTests`: 29/29 passed
- Debug app build with `CODE_SIGNING_ALLOWED=NO`: passed
- `git diff --check`: passed

## Remaining validation

- physical VS Code Codex extension end-to-end activity was not available in this environment

Fixes #261
