### PR TITLE
Prevent Codex parsing regressions and background scroll capture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ This file is a routing layer for coding agents working in this repo. Keep it sho
   - State-only hook delivery is acknowledged by the app after envelope decoding and routing; keep bridge socket writes complete and do not report `deliveryOutcome=delivered` without a matching app acknowledgement
 - Codex ingress: `PingIsland/Services/Codex/`, `PingIsland/UI/Views/CodexSessionView.swift`
   - Hook-less fallback parsing for Codex sessions lives in `PingIsland/Services/Codex/CodexRolloutParser.swift`
+  - The fallback parser tails append-only rollout JSONL incrementally, rebuilds after file replacement/truncation, skips pathological oversized records, and retains a bounded recent history. Keep the full content of each retained item, and do not return to whole-file reparsing for ordinary appends.
 - Terminal and focus control: `PingIsland/Services/Tmux/`, `PingIsland/Services/Window/`, `PingIsland/Utilities/TerminalVisibilityDetector.swift`
   - Terminal focus flows currently cover iTerm2, Ghostty, Terminal.app, tmux, and IDE-hosted terminals
 - Remote SSH forwarding and remote-host management: `PingIsland/Services/Remote/`
@@ -110,7 +111,7 @@ This file is a routing layer for coding agents working in this repo. Keep it sho
 - If you change tmux or terminal focusing, trace through `Services/Tmux`, `Services/Window`, and `TerminalVisibilityDetector`.
 - If you change IDE terminal jump behavior, inspect both `TerminalSessionFocuser` and `IDEExtensionInstaller`, plus the integration settings UI so install state and URI schemes stay aligned.
 - If you change Codex behavior, verify both the monitor layer under `PingIsland/Services/Codex/` and the UI under `PingIsland/UI/Views/CodexSessionView.swift`.
-  - Long Codex/subagent prompts, results, tool details, and transcript rows must keep full data in `SessionStore` / snapshots and apply bounded display text only at SwiftUI rendering boundaries. Prefer `SessionTextSanitizer.boundedDisplayText` for inline `Text` / Markdown content, add or preserve tests for truncation behavior, and avoid passing unbounded transcripts directly into expanded Island detail views.
+  - Long Codex/subagent prompts, results, tool details, and retained transcript rows must keep their full item data in `SessionStore` / snapshots and apply bounded display text only at SwiftUI rendering boundaries. Prefer `SessionTextSanitizer.boundedDisplayText` for inline `Text` / Markdown content, add or preserve tests for truncation behavior, and avoid passing unbounded transcripts directly into expanded Island detail views.
 - If you change app updates or release notes, trace through `PingIsland/Services/Update/`, `PingIsland/Info.plist`, the settings UI, and `scripts/create-release.sh` so appcast assets, runtime config, and update messaging stay aligned.
 - If you change Sparkle configuration keys or hosting assumptions, update `Config/App.xcconfig`, `Config/LocalSecrets.example.xcconfig`, `scripts/generate-keys.sh`, and `docs/sparkle-release.md` together.
 - If you change App Store distribution behavior, keep the `PingIslandAppStore` target isolated from the regular `PingIsland` Developer ID/Sparkle lane, and update `docs/mac-app-store-submission.md` plus `scripts/build-app-store.sh` together.

--- a/PingIsland/Models/SessionProvider.swift
+++ b/PingIsland/Models/SessionProvider.swift
@@ -556,6 +556,33 @@ struct SessionClientInfo: Codable, Equatable, Sendable {
     nonisolated func normalizedForCodexRouting(sessionId: String? = nil) -> SessionClientInfo {
         var normalized = self
 
+        let normalizedProfileID = normalized.profileID?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        let normalizedOrigin = normalized.origin?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        let normalizedThreadSource = normalized.threadSource?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        let hasCodexAppIdentity = normalizedProfileID == "codex-app"
+            || normalized.bundleIdentifier == "com.openai.codex"
+            || normalized.launchURL?.lowercased().hasPrefix("codex://") == true
+        let hasInteractiveTerminalRouting = normalized.terminalBundleIdentifier?.nonEmpty != nil
+            || normalized.terminalProgram?.nonEmpty != nil
+            || normalized.terminalSessionIdentifier?.nonEmpty != nil
+            || normalized.iTermSessionIdentifier?.nonEmpty != nil
+            || normalized.tmuxSessionIdentifier?.nonEmpty != nil
+            || normalized.tmuxPaneIdentifier?.nonEmpty != nil
+        let isExplicitCLIOrigin = normalizedOrigin == "cli" || normalizedThreadSource == "cli"
+
+        if normalized.kind == .codexCLI,
+           hasCodexAppIdentity,
+           !hasInteractiveTerminalRouting,
+           !isExplicitCLIOrigin {
+            normalized.kind = .codexApp
+        }
+
         switch normalized.kind {
         case .codexCLI:
             if normalized.profileID == nil {

--- a/PingIsland/Services/Codex/CodexAppServerMonitor.swift
+++ b/PingIsland/Services/Codex/CodexAppServerMonitor.swift
@@ -1184,6 +1184,33 @@ actor CodexAppServerMonitor {
         .first(where: { $0.hasSuffix(".jsonl") })
     }
 
+    nonisolated static func hasExplicitSubagentMetadata(in thread: [String: Any]) -> Bool {
+        let topLevelValues = [
+            thread["parentThreadId"],
+            thread["parent_thread_id"],
+            thread["subagentDepth"],
+            thread["depth"],
+            thread["agentNickname"],
+            thread["agent_nickname"],
+            thread["agentRole"],
+            thread["agent_role"]
+        ]
+        if topLevelValues.contains(where: { value in
+            if let text = value as? String {
+                return sanitizedThreadText(text) != nil
+            }
+            return value is NSNumber
+        }) {
+            return true
+        }
+
+        guard let source = thread["source"] as? [String: Any],
+              let subagent = source["subagent"] as? [String: Any] else {
+            return false
+        }
+        return subagent["thread_spawn"] is [String: Any]
+    }
+
     private func parseThreadSnapshot(_ thread: [String: Any]) -> CodexThreadSnapshot? {
         guard let threadId = thread["id"] as? String else { return nil }
         guard !Self.shouldIgnoreAuxiliaryThread(thread) else { return nil }
@@ -1349,22 +1376,23 @@ actor CodexAppServerMonitor {
     }
 
     private func parseSubagentMetadata(from thread: [String: Any]) -> ParsedSubagentMetadata? {
+        guard Self.hasExplicitSubagentMetadata(in: thread) else {
+            return nil
+        }
+
         let topLevelNickname = sanitizedText(thread["agentNickname"] as? String)
             ?? sanitizedText(thread["agent_nickname"] as? String)
         let topLevelRole = sanitizedText(thread["agentRole"] as? String)
             ?? sanitizedText(thread["agent_role"] as? String)
-        let topLevelParent = sanitizedText(thread["parentThreadId"] as? String)
+        let explicitTopLevelParent = sanitizedText(thread["parentThreadId"] as? String)
             ?? sanitizedText(thread["parent_thread_id"] as? String)
-            ?? sanitizedText(thread["forkedFromId"] as? String)
+        let forkedFromId = sanitizedText(thread["forkedFromId"] as? String)
             ?? sanitizedText(thread["forked_from_id"] as? String)
         let topLevelDepth = intValue(thread["subagentDepth"]) ?? intValue(thread["depth"])
 
         guard let source = thread["source"] as? [String: Any] else {
-            guard topLevelParent != nil || topLevelDepth != nil || topLevelNickname != nil || topLevelRole != nil else {
-                return nil
-            }
             return ParsedSubagentMetadata(
-                parentThreadId: topLevelParent,
+                parentThreadId: explicitTopLevelParent ?? forkedFromId,
                 depth: topLevelDepth,
                 nickname: topLevelNickname,
                 role: topLevelRole
@@ -1374,7 +1402,9 @@ actor CodexAppServerMonitor {
         let subagent = source["subagent"] as? [String: Any]
         let threadSpawn = subagent?["thread_spawn"] as? [String: Any]
 
-        let parentThreadId = sanitizedText(threadSpawn?["parent_thread_id"] as? String) ?? topLevelParent
+        let parentThreadId = sanitizedText(threadSpawn?["parent_thread_id"] as? String)
+            ?? explicitTopLevelParent
+            ?? forkedFromId
         let depth = intValue(threadSpawn?["depth"]) ?? topLevelDepth
         let nickname = sanitizedText(threadSpawn?["agent_nickname"] as? String) ?? topLevelNickname
         let role = sanitizedText(threadSpawn?["agent_role"] as? String) ?? topLevelRole

--- a/PingIsland/Services/Codex/CodexRolloutParser.swift
+++ b/PingIsland/Services/Codex/CodexRolloutParser.swift
@@ -10,10 +10,38 @@ actor CodexRolloutParser {
         let role: String?
     }
 
+    struct DebugReadMetrics: Equatable {
+        let fullRebuildCount: Int
+        let incrementalReadCount: Int
+        let lastReadByteCount: Int
+    }
+
     private struct CachedSnapshot {
         let modificationDate: Date
-        let snapshot: CodexThreadSnapshot
+        let fileIdentifier: UInt64?
+        let fileSize: UInt64
+        let readOffset: UInt64
+        let pendingData: Data
+        let isDiscardingOversizedLine: Bool
+        let nextLineIndex: Int
+        let parsedSnapshot: CodexThreadSnapshot
+        let visibleSnapshot: CodexThreadSnapshot?
+        let metrics: DebugReadMetrics
     }
+
+    private struct ReadResult {
+        let parsedSnapshot: CodexThreadSnapshot?
+        let pendingData: Data
+        let isDiscardingOversizedLine: Bool
+        let nextLineIndex: Int
+        let bytesRead: Int
+    }
+
+    static let maximumRetainedHistoryItems = 500
+    private static let readChunkSize = 64 * 1024
+    private static let maximumBatchLineCount = 128
+    private static let maximumBatchBytes = 512 * 1024
+    private static let maximumJSONLineBytes = 8 * 1024 * 1024
 
     private let fractionalTimestampFormatter: ISO8601DateFormatter = {
         let formatter = ISO8601DateFormatter()
@@ -36,34 +64,216 @@ actor CodexRolloutParser {
     ) -> CodexThreadSnapshot? {
         guard let fileURL = resolveRolloutURL(threadId: threadId, clientInfo: clientInfo),
               let attributes = try? FileManager.default.attributesOfItem(atPath: fileURL.path),
-              let modificationDate = attributes[.modificationDate] as? Date else {
+              let modificationDate = attributes[.modificationDate] as? Date,
+              let fileSizeNumber = attributes[.size] as? NSNumber else {
             return nil
         }
 
-        if let cached = cache[fileURL.path], cached.modificationDate == modificationDate {
-            return cached.snapshot
+        let fileSize = fileSizeNumber.uint64Value
+        let fileIdentifier = (attributes[.systemFileNumber] as? NSNumber)?.uint64Value
+
+        if let cached = cache[fileURL.path],
+           cached.modificationDate == modificationDate,
+           cached.fileSize == fileSize {
+            return cached.visibleSnapshot
         }
 
-        guard let raw = try? String(contentsOf: fileURL, encoding: .utf8) else {
-            return nil
-        }
+        let previous = cache[fileURL.path]
+        let canReadIncrementally = previous.map {
+            $0.fileIdentifier == fileIdentifier && fileSize > $0.readOffset
+        } ?? false
+        let startOffset = canReadIncrementally ? (previous?.readOffset ?? 0) : 0
+        let seedSnapshot = canReadIncrementally ? previous?.parsedSnapshot : nil
+        let pendingData = canReadIncrementally ? (previous?.pendingData ?? Data()) : Data()
+        let isDiscardingOversizedLine = canReadIncrementally
+            ? (previous?.isDiscardingOversizedLine ?? false)
+            : false
+        let startingLineIndex = canReadIncrementally ? (previous?.nextLineIndex ?? 0) : 0
 
-        let snapshot = parseRollout(
-            raw,
+        guard let readResult = readRollout(
             fileURL: fileURL,
+            throughOffset: fileSize,
+            startingAt: startOffset,
+            pendingData: pendingData,
+            isDiscardingOversizedLine: isDiscardingOversizedLine,
+            startingLineIndex: startingLineIndex,
+            seedSnapshot: seedSnapshot,
             fallbackThreadId: threadId,
             fallbackCwd: fallbackCwd,
             clientInfo: clientInfo
-        )
-
-        if let snapshot {
-            cache[fileURL.path] = CachedSnapshot(
-                modificationDate: modificationDate,
-                snapshot: snapshot
-            )
+        ), let parsedSnapshot = readResult.parsedSnapshot else {
+            return nil
         }
 
-        return snapshot
+        let visibleSnapshot = parseRollout(
+            "",
+            fileURL: fileURL,
+            fallbackThreadId: threadId,
+            fallbackCwd: fallbackCwd,
+            clientInfo: clientInfo,
+            seedSnapshot: parsedSnapshot,
+            startingLineIndex: readResult.nextLineIndex,
+            applyAuxiliaryFilter: true
+        )
+
+        let previousMetrics = previous?.metrics
+        let metrics = DebugReadMetrics(
+            fullRebuildCount: (previousMetrics?.fullRebuildCount ?? 0) + (canReadIncrementally ? 0 : 1),
+            incrementalReadCount: (previousMetrics?.incrementalReadCount ?? 0) + (canReadIncrementally ? 1 : 0),
+            lastReadByteCount: readResult.bytesRead
+        )
+        cache[fileURL.path] = CachedSnapshot(
+            modificationDate: modificationDate,
+            fileIdentifier: fileIdentifier,
+            fileSize: fileSize,
+            readOffset: fileSize,
+            pendingData: readResult.pendingData,
+            isDiscardingOversizedLine: readResult.isDiscardingOversizedLine,
+            nextLineIndex: readResult.nextLineIndex,
+            parsedSnapshot: parsedSnapshot,
+            visibleSnapshot: visibleSnapshot,
+            metrics: metrics
+        )
+
+        return visibleSnapshot
+    }
+
+    func debugReadMetrics(forFilePath filePath: String) -> DebugReadMetrics? {
+        cache[filePath]?.metrics
+    }
+
+    private func readRollout(
+        fileURL: URL,
+        throughOffset targetOffset: UInt64,
+        startingAt startOffset: UInt64,
+        pendingData initialPendingData: Data,
+        isDiscardingOversizedLine initialDiscardingState: Bool,
+        startingLineIndex: Int,
+        seedSnapshot: CodexThreadSnapshot?,
+        fallbackThreadId: String,
+        fallbackCwd: String,
+        clientInfo: SessionClientInfo?
+    ) -> ReadResult? {
+        guard let handle = try? FileHandle(forReadingFrom: fileURL) else {
+            return nil
+        }
+        defer { try? handle.close() }
+
+        do {
+            try handle.seek(toOffset: startOffset)
+        } catch {
+            return nil
+        }
+
+        var parsedSnapshot = seedSnapshot
+        var pendingData = initialPendingData
+        var isDiscardingOversizedLine = initialDiscardingState
+        var nextLineIndex = startingLineIndex
+        var currentOffset = startOffset
+        var bytesRead = 0
+        var batch: [String] = []
+        var batchBytes = 0
+        var batchStartIndex = nextLineIndex
+
+        func flushBatch() {
+            guard !batch.isEmpty else { return }
+            parsedSnapshot = parseRollout(
+                batch.joined(separator: "\n"),
+                fileURL: fileURL,
+                fallbackThreadId: fallbackThreadId,
+                fallbackCwd: fallbackCwd,
+                clientInfo: clientInfo,
+                seedSnapshot: parsedSnapshot,
+                startingLineIndex: batchStartIndex,
+                applyAuxiliaryFilter: false
+            )
+            batch.removeAll(keepingCapacity: true)
+            batchBytes = 0
+            batchStartIndex = nextLineIndex
+        }
+
+        func appendLine(_ lineData: Data, at index: Int) {
+            guard lineData.count <= Self.maximumJSONLineBytes else {
+                flushBatch()
+                batchStartIndex = nextLineIndex
+                return
+            }
+            if batch.isEmpty {
+                batchStartIndex = index
+            }
+            batch.append(String(decoding: lineData, as: UTF8.self))
+            batchBytes += lineData.count
+            if batch.count >= Self.maximumBatchLineCount || batchBytes >= Self.maximumBatchBytes {
+                flushBatch()
+            }
+        }
+
+        while currentOffset < targetOffset {
+            let remaining = targetOffset - currentOffset
+            let requestedCount = Int(min(UInt64(Self.readChunkSize), remaining))
+            guard requestedCount > 0 else {
+                break
+            }
+
+            let chunk: Data
+            do {
+                guard let nextChunk = try handle.read(upToCount: requestedCount),
+                      !nextChunk.isEmpty else {
+                    break
+                }
+                chunk = nextChunk
+            } catch {
+                return nil
+            }
+
+            currentOffset += UInt64(chunk.count)
+            bytesRead += chunk.count
+            var chunkRemainder = chunk
+
+            if isDiscardingOversizedLine {
+                guard let newlineIndex = chunkRemainder.firstIndex(of: 0x0A) else {
+                    continue
+                }
+                chunkRemainder.removeSubrange(chunkRemainder.startIndex...newlineIndex)
+                isDiscardingOversizedLine = false
+                nextLineIndex += 1
+                batchStartIndex = nextLineIndex
+            }
+
+            pendingData.append(chunkRemainder)
+            while let newlineIndex = pendingData.firstIndex(of: 0x0A) {
+                let lineData = Data(pendingData[..<newlineIndex])
+                pendingData.removeSubrange(pendingData.startIndex...newlineIndex)
+                let lineIndex = nextLineIndex
+                nextLineIndex += 1
+                appendLine(lineData, at: lineIndex)
+            }
+
+            if pendingData.count > Self.maximumJSONLineBytes {
+                pendingData.removeAll(keepingCapacity: false)
+                isDiscardingOversizedLine = true
+                flushBatch()
+                batchStartIndex = nextLineIndex
+            }
+        }
+
+        if !isDiscardingOversizedLine,
+           !pendingData.isEmpty,
+           (try? JSONSerialization.jsonObject(with: pendingData)) is [String: Any] {
+            let lineIndex = nextLineIndex
+            nextLineIndex += 1
+            appendLine(pendingData, at: lineIndex)
+            pendingData.removeAll(keepingCapacity: false)
+        }
+
+        flushBatch()
+        return ReadResult(
+            parsedSnapshot: parsedSnapshot,
+            pendingData: pendingData,
+            isDiscardingOversizedLine: isDiscardingOversizedLine,
+            nextLineIndex: nextLineIndex,
+            bytesRead: bytesRead
+        )
     }
 
     private func parseRollout(
@@ -71,43 +281,53 @@ actor CodexRolloutParser {
         fileURL: URL,
         fallbackThreadId: String,
         fallbackCwd: String,
-        clientInfo: SessionClientInfo?
+        clientInfo: SessionClientInfo?,
+        seedSnapshot: CodexThreadSnapshot? = nil,
+        startingLineIndex: Int = 0,
+        applyAuxiliaryFilter: Bool = true
     ) -> CodexThreadSnapshot? {
-        let lines = content.split(separator: "\n")
-        guard !lines.isEmpty else { return nil }
+        let lines = content.split(separator: "\n", omittingEmptySubsequences: false)
 
-        var resolvedThreadId = fallbackThreadId
-        var resolvedCwd = fallbackCwd.nonEmpty ?? "/"
-        var createdAt: Date?
-        var updatedAt: Date?
-        var latestTurnId: String?
+        var resolvedThreadId = seedSnapshot?.threadId ?? fallbackThreadId
+        var resolvedCwd = seedSnapshot?.cwd ?? fallbackCwd.nonEmpty ?? "/"
+        var createdAt: Date? = seedSnapshot?.createdAt
+        var updatedAt: Date? = seedSnapshot?.updatedAt
+        var latestTurnId: String? = seedSnapshot?.latestTurnId
 
-        var historyItems: [ChatHistoryItem] = []
-        var toolIndexes: [String: Int] = [:]
-        var firstUserMessage: String?
-        var lastMessage: String?
-        var lastMessageRole: String?
-        var lastUserMessageDate: Date?
-        var latestUserText: String?
-        var latestAgentText: String?
-        var latestAgentPhase: String?
-        var latestFinalText: String?
-        var latestFinalPhase: String?
-        var phase: SessionPhase = .idle
-        var isTurnInterrupted = false
-        var intervention: SessionIntervention?
-        var sessionName: String?
-        var origin: String?
-        var originator: String?
-        var threadSource: String?
+        var historyItems: [ChatHistoryItem] = seedSnapshot?.historyItems ?? []
+        var toolIndexes: [String: Int] = Dictionary(uniqueKeysWithValues: historyItems.enumerated().compactMap { index, item in
+            guard case .toolCall = item.type else { return nil }
+            return (item.id, index)
+        })
+        var firstUserMessage: String? = seedSnapshot?.conversationInfo.firstUserMessage
+        var lastMessage: String? = seedSnapshot?.conversationInfo.lastMessage
+        var lastMessageRole: String? = seedSnapshot?.conversationInfo.lastMessageRole
+        var lastUserMessageDate: Date? = seedSnapshot?.conversationInfo.lastUserMessageDate
+        var latestUserText: String? = seedSnapshot?.latestUserText
+        var latestAgentText: String? = seedSnapshot?.latestResponseText
+        var latestAgentPhase: String? = seedSnapshot?.latestResponsePhase
+        var latestFinalText: String? = seedSnapshot?.latestResponsePhase == "commentary"
+            ? nil
+            : seedSnapshot?.latestResponseText
+        var latestFinalPhase: String? = seedSnapshot?.latestResponsePhase == "commentary"
+            ? nil
+            : seedSnapshot?.latestResponsePhase
+        var phase: SessionPhase = seedSnapshot?.phase ?? .idle
+        var isTurnInterrupted = seedSnapshot?.isTurnInterrupted ?? false
+        var intervention: SessionIntervention? = seedSnapshot?.intervention
+        var sessionName: String? = seedSnapshot?.name
+        var origin: String? = seedSnapshot?.clientInfo?.origin
+        var originator: String? = seedSnapshot?.clientInfo?.originator
+        var threadSource: String? = seedSnapshot?.clientInfo?.threadSource
         var subagentMetadata = ParsedSubagentMetadata(
-            parentThreadId: nil,
-            depth: nil,
-            nickname: nil,
-            role: nil
+            parentThreadId: seedSnapshot?.parentThreadId,
+            depth: seedSnapshot?.subagentDepth,
+            nickname: seedSnapshot?.subagentNickname,
+            role: seedSnapshot?.subagentRole
         )
 
-        for (index, line) in lines.enumerated() {
+        for (lineOffset, line) in lines.enumerated() {
+            let index = startingLineIndex + lineOffset
             guard let data = line.data(using: .utf8),
                   let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
                 continue
@@ -147,6 +367,8 @@ actor CodexRolloutParser {
                 case "user_message":
                     guard let text = normalizedText(payload["message"]) else { continue }
                     isTurnInterrupted = false
+                    latestFinalText = nil
+                    latestFinalPhase = nil
                     if firstUserMessage == nil {
                         firstUserMessage = text
                     }
@@ -186,6 +408,8 @@ actor CodexRolloutParser {
 
                 case "task_started":
                     isTurnInterrupted = false
+                    latestFinalText = nil
+                    latestFinalPhase = nil
                     phase = .processing
 
                 case "task_complete":
@@ -330,6 +554,10 @@ actor CodexRolloutParser {
             }
         }
 
+        if historyItems.count > Self.maximumRetainedHistoryItems {
+            historyItems.removeFirst(historyItems.count - Self.maximumRetainedHistoryItems)
+        }
+
         if intervention?.kind == .question {
             phase = .waitingForInput
         } else if isTurnInterrupted {
@@ -342,12 +570,14 @@ actor CodexRolloutParser {
         }
 
         let preview = latestFinalText ?? latestAgentText ?? latestUserText ?? firstUserMessage
-        guard !CodexAuxiliaryHookFilter.isCodexMemoryMaintenanceThread(
-            cwd: resolvedCwd,
-            title: sessionName,
-            preview: preview
-        ) else {
-            return nil
+        if applyAuxiliaryFilter {
+            guard !CodexAuxiliaryHookFilter.isCodexMemoryMaintenanceThread(
+                cwd: resolvedCwd,
+                title: sessionName,
+                preview: preview
+            ) else {
+                return nil
+            }
         }
 
         let conversationInfo = ConversationInfo(
@@ -359,13 +589,14 @@ actor CodexRolloutParser {
             lastUserMessageDate: lastUserMessageDate
         )
 
-        let prefersCLIContext = clientInfo?.kind == .codexCLI
+        let normalizedClientInfo = clientInfo?.normalizedForCodexRouting(sessionId: resolvedThreadId)
+        let prefersCLIContext = normalizedClientInfo?.kind == .codexCLI
             || origin == "cli"
             || threadSource == "cli"
-            || (clientInfo?.terminalBundleIdentifier?.isEmpty == false
-                && clientInfo?.terminalBundleIdentifier != "com.openai.codex")
-            || clientInfo?.terminalSessionIdentifier?.isEmpty == false
-            || clientInfo?.iTermSessionIdentifier?.isEmpty == false
+            || (normalizedClientInfo?.terminalBundleIdentifier?.isEmpty == false
+                && normalizedClientInfo?.terminalBundleIdentifier != "com.openai.codex")
+            || normalizedClientInfo?.terminalSessionIdentifier?.isEmpty == false
+            || normalizedClientInfo?.iTermSessionIdentifier?.isEmpty == false
 
         if prefersCLIContext,
            let inferredIntervention = Self.pendingMCPApprovalIntervention(from: historyItems) {
@@ -379,28 +610,28 @@ actor CodexRolloutParser {
 
         let resolvedClientInfo = baseClientInfo.merged(with: SessionClientInfo(
             kind: prefersCLIContext ? .codexCLI : .codexApp,
-            name: originator ?? clientInfo?.name,
-            bundleIdentifier: prefersCLIContext ? clientInfo?.bundleIdentifier : (clientInfo?.bundleIdentifier ?? "com.openai.codex"),
+            name: originator ?? normalizedClientInfo?.name,
+            bundleIdentifier: prefersCLIContext ? normalizedClientInfo?.bundleIdentifier : (normalizedClientInfo?.bundleIdentifier ?? "com.openai.codex"),
             launchURL: prefersCLIContext
-                ? clientInfo?.launchURL
-                : (clientInfo?.launchURL ?? SessionClientInfo.appLaunchURL(
-                    bundleIdentifier: clientInfo?.bundleIdentifier ?? "com.openai.codex",
+                ? normalizedClientInfo?.launchURL
+                : (normalizedClientInfo?.launchURL ?? SessionClientInfo.appLaunchURL(
+                    bundleIdentifier: normalizedClientInfo?.bundleIdentifier ?? "com.openai.codex",
                     sessionId: resolvedThreadId,
                     workspacePath: resolvedCwd
                 )),
-            origin: origin ?? clientInfo?.origin ?? (prefersCLIContext ? "cli" : "desktop"),
-            originator: originator ?? clientInfo?.originator,
-            threadSource: threadSource ?? clientInfo?.threadSource,
-            transport: clientInfo?.transport,
-            remoteHost: clientInfo?.remoteHost,
+            origin: origin ?? normalizedClientInfo?.origin ?? (prefersCLIContext ? "cli" : "desktop"),
+            originator: originator ?? normalizedClientInfo?.originator,
+            threadSource: threadSource ?? normalizedClientInfo?.threadSource,
+            transport: normalizedClientInfo?.transport,
+            remoteHost: normalizedClientInfo?.remoteHost,
             sessionFilePath: fileURL.path,
-            terminalBundleIdentifier: clientInfo?.terminalBundleIdentifier,
-            terminalProgram: clientInfo?.terminalProgram,
-            terminalSessionIdentifier: clientInfo?.terminalSessionIdentifier,
-            iTermSessionIdentifier: clientInfo?.iTermSessionIdentifier,
-            tmuxSessionIdentifier: clientInfo?.tmuxSessionIdentifier,
-            tmuxPaneIdentifier: clientInfo?.tmuxPaneIdentifier,
-            processName: clientInfo?.processName
+            terminalBundleIdentifier: normalizedClientInfo?.terminalBundleIdentifier,
+            terminalProgram: normalizedClientInfo?.terminalProgram,
+            terminalSessionIdentifier: normalizedClientInfo?.terminalSessionIdentifier,
+            iTermSessionIdentifier: normalizedClientInfo?.iTermSessionIdentifier,
+            tmuxSessionIdentifier: normalizedClientInfo?.tmuxSessionIdentifier,
+            tmuxPaneIdentifier: normalizedClientInfo?.tmuxPaneIdentifier,
+            processName: normalizedClientInfo?.processName
         ))
 
         return CodexThreadSnapshot(
@@ -465,7 +696,7 @@ actor CodexRolloutParser {
         let forkedFromId = stringValue(payload["forked_from_id"])
 
         guard let sourceObject = sourceValue as? [String: Any] else {
-            if forkedFromId == nil, topLevelNickname == nil, topLevelRole == nil {
+            if topLevelNickname == nil, topLevelRole == nil {
                 return nil
             }
 
@@ -479,6 +710,10 @@ actor CodexRolloutParser {
 
         let subagent = sourceObject["subagent"] as? [String: Any]
         let threadSpawn = subagent?["thread_spawn"] as? [String: Any]
+
+        guard threadSpawn != nil || topLevelNickname != nil || topLevelRole != nil else {
+            return nil
+        }
 
         let parentThreadId = stringValue(threadSpawn?["parent_thread_id"]) ?? forkedFromId
         let depth = intValue(threadSpawn?["depth"])

--- a/PingIsland/Services/Usage/CodexUsage.swift
+++ b/PingIsland/Services/Usage/CodexUsage.swift
@@ -180,14 +180,20 @@ enum CodexUsageLoader {
             return nil
         }
 
+        var legacySnapshot: CodexUsageSnapshot?
         for line in contents.split(separator: "\n", omittingEmptySubsequences: false).reversed() {
             if line.contains("\"token_count\""),
                line.contains("\"rate_limits\""),
                let snapshot = snapshot(from: String(line), filePath: fileURL.path, fallbackTimestamp: modifiedAt) {
-                return snapshot
+                if snapshot.limitID == "codex" {
+                    return snapshot
+                }
+                if snapshot.limitID == nil, case nil = legacySnapshot {
+                    legacySnapshot = snapshot
+                }
             }
         }
-        return nil
+        return legacySnapshot
     }
 
     private nonisolated static func readSuffixText(from fileURL: URL, fileSize: UInt64, maxBytes: Int) -> String? {

--- a/PingIsland/UI/Window/NotchWindow.swift
+++ b/PingIsland/UI/Window/NotchWindow.swift
@@ -11,6 +11,8 @@ import AppKit
 
 // Use NSPanel subclass for non-activating behavior
 class NotchPanel: NSPanel {
+    var shouldAcceptMouseEvents: () -> Bool = { false }
+
     override init(
         contentRect: NSRect,
         styleMask style: NSWindow.StyleMask,
@@ -66,30 +68,55 @@ class NotchPanel: NSPanel {
 
     // MARK: - Click-through for areas outside the panel content
 
+    static func shouldPassThroughEvent(
+        _ type: NSEvent.EventType,
+        hitsInteractiveContent: Bool
+    ) -> Bool {
+        guard !hitsInteractiveContent else { return false }
+
+        switch type {
+        case .leftMouseDown, .leftMouseUp, .rightMouseDown, .rightMouseUp, .scrollWheel:
+            return true
+        default:
+            return false
+        }
+    }
+
     override func sendEvent(_ event: NSEvent) {
-        // For mouse events, check if we should pass through
-        if event.type == .leftMouseDown || event.type == .leftMouseUp ||
-           event.type == .rightMouseDown || event.type == .rightMouseUp {
-            // Get the location in window coordinates
-            let locationInWindow = event.locationInWindow
-
-            // Check if any view wants to handle this event
-            if let contentView = self.contentView,
-               contentView.hitTest(locationInWindow) == nil {
-                // No view wants this event - pass it through to windows behind
-                // by temporarily ignoring mouse events and re-posting
-                let screenLocation = convertPoint(toScreen: locationInWindow)
-                ignoresMouseEvents = true
-
-                // Re-post the event after a tiny delay
-                DispatchQueue.main.async { [weak self] in
-                    self?.repostMouseEvent(event, at: screenLocation)
-                }
-                return
-            }
+        let locationInWindow = event.locationInWindow
+        let hitsInteractiveContent = contentView?.hitTest(locationInWindow) != nil
+        guard Self.shouldPassThroughEvent(
+            event.type,
+            hitsInteractiveContent: hitsInteractiveContent
+        ) else {
+            super.sendEvent(event)
+            return
         }
 
-        super.sendEvent(event)
+        if event.type == .scrollWheel {
+            guard let copiedEvent = event.cgEvent?.copy() else {
+                super.sendEvent(event)
+                return
+            }
+            ignoresMouseEvents = true
+            MouseEventReplay.mark(copiedEvent)
+            copiedEvent.post(tap: .cghidEventTap)
+
+            // Keep the transparent window out of hit testing while Quartz routes
+            // the copied wheel event, then restore interaction if the Island is
+            // still open. State changes during the delay remain authoritative.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
+                guard let self, self.shouldAcceptMouseEvents() else { return }
+                self.ignoresMouseEvents = false
+            }
+            return
+        }
+
+        ignoresMouseEvents = true
+        let screenLocation = convertPoint(toScreen: locationInWindow)
+        DispatchQueue.main.async { [weak self] in
+            self?.repostMouseEvent(event, at: screenLocation)
+        }
     }
 
     private func repostMouseEvent(_ event: NSEvent, at screenLocation: NSPoint) {

--- a/PingIsland/UI/Window/NotchWindowController.swift
+++ b/PingIsland/UI/Window/NotchWindowController.swift
@@ -41,6 +41,10 @@ class NotchWindowController: NSWindowController {
             backing: .buffered,
             defer: false
         )
+        notchWindow.shouldAcceptMouseEvents = { [weak viewModel] in
+            guard let viewModel else { return false }
+            return viewModel.status == .opened && !viewModel.shouldHideWindowPresentation
+        }
 
         super.init(window: notchWindow)
 

--- a/PingIslandTests/AppLaunchConfigurationTests.swift
+++ b/PingIslandTests/AppLaunchConfigurationTests.swift
@@ -350,4 +350,25 @@ final class AppLaunchConfigurationTests: XCTestCase {
         XCTAssertFalse(MouseEventReplay.isReplayed(originalNSEvent))
         XCTAssertEqual(replayedNSEvent.type, .leftMouseDown)
     }
+
+    func testNotchPanelPassesBackgroundScrollWithoutStealingInteractiveScroll() {
+        XCTAssertTrue(
+            NotchPanel.shouldPassThroughEvent(
+                .scrollWheel,
+                hitsInteractiveContent: false
+            )
+        )
+        XCTAssertFalse(
+            NotchPanel.shouldPassThroughEvent(
+                .scrollWheel,
+                hitsInteractiveContent: true
+            )
+        )
+        XCTAssertFalse(
+            NotchPanel.shouldPassThroughEvent(
+                .mouseMoved,
+                hitsInteractiveContent: false
+            )
+        )
+    }
 }

--- a/PingIslandTests/CodexAppServerMonitorTests.swift
+++ b/PingIslandTests/CodexAppServerMonitorTests.swift
@@ -217,4 +217,26 @@ final class CodexAppServerMonitorTests: XCTestCase {
             "path": "/tmp/codex-workspace"
         ]))
     }
+
+    func testUserForkDoesNotCountAsAppServerSubagentWithoutExplicitMetadata() {
+        XCTAssertFalse(CodexAppServerMonitor.hasExplicitSubagentMetadata(in: [
+            "id": "user-fork",
+            "forkedFromId": "parent-thread",
+            "source": "vscode",
+            "threadSource": "user"
+        ]))
+
+        XCTAssertTrue(CodexAppServerMonitor.hasExplicitSubagentMetadata(in: [
+            "id": "spawned-agent",
+            "forkedFromId": "parent-thread",
+            "source": [
+                "subagent": [
+                    "thread_spawn": [
+                        "parent_thread_id": "parent-thread",
+                        "depth": 1
+                    ]
+                ]
+            ]
+        ]))
+    }
 }

--- a/PingIslandTests/CodexRolloutParserTests.swift
+++ b/PingIslandTests/CodexRolloutParserTests.swift
@@ -280,4 +280,164 @@ final class CodexRolloutParserTests: XCTestCase {
         XCTAssertEqual(snapshot?.subagentRole, "explorer")
         XCTAssertEqual(snapshot?.isSubagent, true)
     }
+
+    func testRolloutParserKeepsUserForkAsRegularThread() async throws {
+        let tempDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDirectory) }
+
+        let parentThreadId = "019da119-db3a-7532-8355-5ba0ecf56640"
+        let threadId = "019da11a-353a-79e3-8a52-5f051d2e00b0"
+        let rolloutURL = tempDirectory.appendingPathComponent("rollout-\(threadId).jsonl")
+        let rollout = """
+        {"timestamp":"2026-08-04T10:00:00Z","type":"session_meta","payload":{"id":"\(threadId)","forked_from_id":"\(parentThreadId)","cwd":"/tmp/ping-island-project","originator":"Codex Desktop","source":"vscode","thread_source":"user","title":"User fork"}}
+        {"timestamp":"2026-08-04T10:00:01Z","type":"event_msg","payload":{"type":"user_message","message":"continue from here"}}
+        """
+        try rollout.write(to: rolloutURL, atomically: true, encoding: .utf8)
+
+        let snapshot = await CodexRolloutParser.shared.parseThread(
+            threadId: threadId,
+            fallbackCwd: "/tmp/ping-island-project",
+            clientInfo: SessionClientInfo(
+                kind: .codexApp,
+                profileID: "codex-app",
+                name: "Codex App",
+                bundleIdentifier: "com.openai.codex",
+                sessionFilePath: rolloutURL.path
+            )
+        )
+
+        XCTAssertEqual(snapshot?.name, "User fork")
+        XCTAssertNil(snapshot?.parentThreadId)
+        XCTAssertNil(snapshot?.subagentDepth)
+        XCTAssertFalse(snapshot?.isSubagent ?? true)
+    }
+
+    func testRolloutParserReadsOnlyAppendedBytesAndRebuildsAfterTruncation() async throws {
+        let tempDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDirectory) }
+
+        let threadId = "019fdd31-9f64-7533-8f52-7ac4ed96f001"
+        let rolloutURL = tempDirectory.appendingPathComponent("rollout-\(threadId).jsonl")
+        let initialRollout = """
+        {"timestamp":"2026-08-11T08:00:00Z","type":"session_meta","payload":{"id":"\(threadId)","cwd":"/tmp/ping-island-project","source":"desktop"}}
+        {"timestamp":"2026-08-11T08:00:01Z","type":"event_msg","payload":{"type":"user_message","message":"first request"}}
+
+        """
+        let initialData = try XCTUnwrap(initialRollout.data(using: .utf8))
+        try initialData.write(to: rolloutURL)
+
+        let clientInfo = SessionClientInfo(
+            kind: .codexApp,
+            profileID: "codex-app",
+            name: "Codex App",
+            bundleIdentifier: "com.openai.codex",
+            sessionFilePath: rolloutURL.path
+        )
+
+        let initialSnapshot = await CodexRolloutParser.shared.parseThread(
+            threadId: threadId,
+            fallbackCwd: "/tmp/ping-island-project",
+            clientInfo: clientInfo
+        )
+        let initialMetrics = await CodexRolloutParser.shared.debugReadMetrics(forFilePath: rolloutURL.path)
+
+        XCTAssertEqual(initialSnapshot?.latestUserText, "first request")
+        XCTAssertEqual(initialMetrics?.fullRebuildCount, 1)
+        XCTAssertEqual(initialMetrics?.incrementalReadCount, 0)
+        XCTAssertEqual(initialMetrics?.lastReadByteCount, initialData.count)
+
+        let appendedRollout = """
+        {"timestamp":"2026-08-11T08:00:02Z","type":"event_msg","payload":{"type":"agent_message","phase":"final","message":"first response"}}
+
+        """
+        let appendedData = try XCTUnwrap(appendedRollout.data(using: .utf8))
+        let appendHandle = try FileHandle(forWritingTo: rolloutURL)
+        try appendHandle.seekToEnd()
+        try appendHandle.write(contentsOf: appendedData)
+        try appendHandle.close()
+
+        let appendedSnapshot = await CodexRolloutParser.shared.parseThread(
+            threadId: threadId,
+            fallbackCwd: "/tmp/ping-island-project",
+            clientInfo: clientInfo
+        )
+        let appendedMetrics = await CodexRolloutParser.shared.debugReadMetrics(forFilePath: rolloutURL.path)
+
+        XCTAssertEqual(appendedSnapshot?.latestResponseText, "first response")
+        XCTAssertEqual(appendedSnapshot?.historyItems.count, 2)
+        XCTAssertEqual(appendedMetrics?.fullRebuildCount, 1)
+        XCTAssertEqual(appendedMetrics?.incrementalReadCount, 1)
+        XCTAssertEqual(appendedMetrics?.lastReadByteCount, appendedData.count)
+
+        let replacementRollout = """
+        {"timestamp":"2026-08-11T09:00:00Z","type":"session_meta","payload":{"id":"\(threadId)","cwd":"/tmp/new-project"}}
+        {"timestamp":"2026-08-11T09:00:01Z","type":"event_msg","payload":{"type":"user_message","message":"replacement"}}
+
+        """
+        let replacementData = try XCTUnwrap(replacementRollout.data(using: .utf8))
+        let replacementHandle = try FileHandle(forWritingTo: rolloutURL)
+        try replacementHandle.truncate(atOffset: 0)
+        try replacementHandle.write(contentsOf: replacementData)
+        try replacementHandle.close()
+
+        let replacementSnapshot = await CodexRolloutParser.shared.parseThread(
+            threadId: threadId,
+            fallbackCwd: "/tmp/ping-island-project",
+            clientInfo: clientInfo
+        )
+        let replacementMetrics = await CodexRolloutParser.shared.debugReadMetrics(forFilePath: rolloutURL.path)
+
+        XCTAssertEqual(replacementSnapshot?.cwd, "/tmp/new-project")
+        XCTAssertEqual(replacementSnapshot?.latestUserText, "replacement")
+        XCTAssertNil(replacementSnapshot?.latestResponseText)
+        XCTAssertEqual(replacementSnapshot?.historyItems.count, 1)
+        XCTAssertEqual(replacementMetrics?.fullRebuildCount, 2)
+        XCTAssertEqual(replacementMetrics?.incrementalReadCount, 1)
+        XCTAssertEqual(replacementMetrics?.lastReadByteCount, replacementData.count)
+    }
+
+    func testRolloutParserBoundsRetainedHistoryWhilePreservingLatestState() async throws {
+        let tempDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDirectory) }
+
+        let threadId = "019fdd31-9f64-7533-8f52-7ac4ed96f002"
+        let rolloutURL = tempDirectory.appendingPathComponent("rollout-\(threadId).jsonl")
+        var lines = [
+            "{\"timestamp\":\"2026-08-11T08:00:00Z\",\"type\":\"session_meta\",\"payload\":{\"id\":\"\(threadId)\",\"cwd\":\"/tmp/ping-island-project\",\"source\":\"desktop\"}}"
+        ]
+        lines.append(contentsOf: (0..<650).map { index in
+            "{\"timestamp\":\"2026-08-11T08:00:01Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"user_message\",\"message\":\"request \(index)\"}}"
+        })
+        try (lines.joined(separator: "\n") + "\n").write(
+            to: rolloutURL,
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let snapshot = await CodexRolloutParser.shared.parseThread(
+            threadId: threadId,
+            fallbackCwd: "/tmp/ping-island-project",
+            clientInfo: SessionClientInfo(
+                kind: .codexApp,
+                profileID: "codex-app",
+                name: "Codex App",
+                bundleIdentifier: "com.openai.codex",
+                sessionFilePath: rolloutURL.path
+            )
+        )
+
+        XCTAssertEqual(snapshot?.historyItems.count, CodexRolloutParser.maximumRetainedHistoryItems)
+        XCTAssertEqual(snapshot?.conversationInfo.firstUserMessage, "request 0")
+        XCTAssertEqual(snapshot?.latestUserText, "request 649")
+        guard case .user(let oldestRetainedText) = snapshot?.historyItems.first?.type else {
+            return XCTFail("Expected retained user history")
+        }
+        XCTAssertEqual(oldestRetainedText, "request 150")
+    }
 }

--- a/PingIslandTests/CodexUsageLoaderTests.swift
+++ b/PingIslandTests/CodexUsageLoaderTests.swift
@@ -146,6 +146,57 @@ final class CodexUsageLoaderTests: XCTestCase {
         XCTAssertEqual(snapshot?.windows.first?.roundedUsedPercentage, 13)
     }
 
+    func testLoadPrefersGeneralCodexBucketOverNewerModelSpecificBucket() throws {
+        let rootURL = temporaryRootURL(named: "codex-usage-general-bucket")
+        let rolloutURL = rootURL
+            .appendingPathComponent("2026/08/05", isDirectory: true)
+            .appendingPathComponent("rollout-multiple-limit-buckets.jsonl")
+
+        defer {
+            try? FileManager.default.removeItem(at: rootURL)
+        }
+
+        try writeRollout(
+            [
+                rolloutLine(
+                    timestamp: "2026-08-05T11:30:00.000Z",
+                    type: "event_msg",
+                    payload: [
+                        "type": "token_count",
+                        "rate_limits": [
+                            "limit_id": "codex",
+                            "primary": [
+                                "used_percent": 37.0,
+                                "window_minutes": 10_080,
+                            ],
+                        ],
+                    ]
+                ),
+                rolloutLine(
+                    timestamp: "2026-08-05T11:31:00.000Z",
+                    type: "event_msg",
+                    payload: [
+                        "type": "token_count",
+                        "rate_limits": [
+                            "limit_id": "codex_bengalfox",
+                            "limit_name": "GPT-5.3-Codex-Spark",
+                            "primary": [
+                                "used_percent": 0.0,
+                                "window_minutes": 10_080,
+                            ],
+                        ],
+                    ]
+                ),
+            ],
+            to: rolloutURL
+        )
+
+        let snapshot = try CodexUsageLoader.load(fromRootURL: rootURL)
+
+        XCTAssertEqual(snapshot?.limitID, "codex")
+        XCTAssertEqual(snapshot?.windows.first?.roundedUsedPercentage, 37)
+    }
+
     func testLoadFormatsNonStandardWindowLengths() throws {
         let rootURL = temporaryRootURL(named: "codex-usage-labels")
         let rolloutURL = rootURL

--- a/PingIslandTests/SessionStateTests.swift
+++ b/PingIslandTests/SessionStateTests.swift
@@ -2061,6 +2061,33 @@ final class SessionStateTests: XCTestCase {
         )
     }
 
+    func testRemoteCodexAppIdentityOverridesStaleCLIKind() {
+        let conflictingRemoteIdentity = SessionClientInfo(
+            kind: .codexCLI,
+            profileID: "codex-app",
+            name: "Codex App",
+            origin: "desktop",
+            transport: "ssh-remote",
+            remoteHost: "remote-devbox"
+        )
+
+        let normalized = conflictingRemoteIdentity.normalizedForCodexRouting(
+            sessionId: "019fcb5b-244a-78f3-8727-503dc00ed157"
+        )
+
+        XCTAssertEqual(normalized.kind, .codexApp)
+        XCTAssertEqual(normalized.profileID, "codex-app")
+        XCTAssertEqual(normalized.bundleIdentifier, "com.openai.codex")
+        XCTAssertEqual(normalized.launchURL, "codex://threads/019fcb5b-244a-78f3-8727-503dc00ed157")
+        XCTAssertTrue(normalized.prefersAppNavigation)
+        XCTAssertTrue(
+            SessionLauncher.allowsAppFallback(
+                provider: .codex,
+                clientInfo: normalized
+            )
+        )
+    }
+
     func testTerminalHostedQoderCLIDoesNotFallBackToQoderAppNavigation() {
         let terminalHostedQoderCLI = SessionClientInfo(
             kind: .qoder,


### PR DESCRIPTION
## What

- tail Codex rollout JSONL incrementally instead of reparsing the full file after every append
- rebuild safely after truncation/replacement, skip pathological records above 8 MiB, and retain the latest 500 full-content history items
- require explicit spawned-agent metadata before presenting a Codex thread as a subagent
- prefer the general `codex` rate-limit bucket over newer model-specific buckets
- normalize stale Codex CLI metadata when Codex App identity is explicit and terminal evidence is absent
- replay scroll-wheel events that land in transparent, non-interactive parts of the opened notch panel

## Why

The affected issues had reproducible parser/routing/input-boundary causes:

- large rollout files were repeatedly loaded and parsed in full
- user-created forks share `forked_from` metadata with some agent flows
- reverse scanning could stop at a model-specific quota record
- stale client metadata could override stronger Codex App identity
- the full-width opened panel only passed through outside clicks, not wheel events

## Impact

This reduces rollout polling from whole-file work to appended-byte work, prevents false Subagent rows and false Spark 100% quota badges, repairs a stale Codex App routing case, and lets background applications continue scrolling outside the visible Island content.

## Checks

- `swift test --package-path Prototype`: 140 passed
- PingIsland scheme: 787 logic tests passed
- Debug clean/build passed
- targeted regression tests cover incremental append/truncation, bounded history, user forks, quota bucket selection, stale Codex App identity, and scroll pass-through policy
- `git diff --check` passed
- UI automation runner could not initialize on this Mac: `Timed out while enabling automation mode`; no logic test failed
- not manually verified on a physical remote Codex App session or by cross-app scrolling

Fixes #270
Fixes #276
Fixes #277
Fixes #278
Refs #273
