### PR TITLE
Tail Claude-family transcripts incrementally instead of reparsing whole files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ This file is a routing layer for coding agents working in this repo. Keep it sho
 - Main state hub: `PingIsland/Services/State/SessionStore.swift`
 - Session association cache: `PingIsland/Services/State/SessionAssociationStore.swift`
 - Usage/quota snapshots for Claude status-line caches, Claude-family transcript token totals, and Codex rollout logs: `PingIsland/Services/Usage/`
+  - Claude-family transcript token totals are tailed incrementally by `ClaudeTranscriptUsageReader`, which skips reopening unchanged files, rebuilds only after replacement/truncation, defers half-written trailing records, and carries a streaming FNV-1a digest so `AgentUsageStore` deduplication stays stable. Keep cumulative totals for the whole transcript, and do not return to whole-file reparsing for ordinary appends.
 - Native runtime rollout scaffold: `PingIsland/Services/Runtime/`, `PingIsland/Core/FeatureFlags.swift`
 - Session bridge for UI: `PingIsland/Services/Session/SessionMonitor.swift`
 - Notch state and layout: `PingIsland/Core/NotchViewModel.swift`, `PingIsland/UI/Views/NotchView.swift`

--- a/PingIsland/Services/State/SessionStore.swift
+++ b/PingIsland/Services/State/SessionStore.swift
@@ -2858,7 +2858,9 @@ actor SessionStore {
         guard shouldRecordClaudeFamilyTranscriptUsage(for: session),
               let transcriptPath = session.clientInfo.sessionFilePath?.trimmingCharacters(in: .whitespacesAndNewlines),
               !transcriptPath.isEmpty,
-              let snapshot = try? ClaudeTranscriptUsageLoader.load(from: URL(fileURLWithPath: transcriptPath)) else {
+              let snapshot = await ClaudeTranscriptUsageReader.shared.snapshot(
+                  for: URL(fileURLWithPath: transcriptPath)
+              ) else {
             return
         }
 

--- a/PingIsland/Services/Usage/ClaudeTranscriptUsage.swift
+++ b/PingIsland/Services/Usage/ClaudeTranscriptUsage.swift
@@ -8,9 +8,287 @@ struct ClaudeTranscriptUsageSnapshot: Equatable, Sendable {
     let tokenTotals: AgentUsageTokenTotals
 }
 
+/// Running state for a transcript scan.
+///
+/// `hash` is an in-progress FNV-1a digest. FNV-1a is a streaming hash, so folding
+/// appended bytes into a carried state yields the same digest a whole-file pass would,
+/// which keeps `AgentUsageStore` deduplication stable across incremental reads.
+struct ClaudeTranscriptUsageAccumulator: Sendable {
+    static let initialHash: UInt64 = 0xcbf2_9ce4_8422_2325
+
+    var totals = AgentUsageTokenTotals()
+    var latestUsageDate: Date?
+    var hash: UInt64 = Self.initialHash
+
+    var contentHash: String {
+        String(format: "%016llx", hash)
+    }
+
+    /// Folds raw bytes into the digest. Every byte of the file must pass through here
+    /// exactly once, newlines included, so the digest matches a whole-file pass.
+    mutating func absorb(bytes: Data) {
+        var hash = self.hash
+        bytes.withUnsafeBytes { rawBuffer in
+            for byte in rawBuffer.bindMemory(to: UInt8.self) {
+                hash ^= UInt64(byte)
+                hash = hash &* 0x100_0000_01b3
+            }
+        }
+        self.hash = hash
+    }
+
+    /// Accumulates token totals and the newest usage timestamp from one JSONL line.
+    mutating func absorb(line: String) {
+        guard !line.isEmpty,
+              let object = ClaudeTranscriptUsageLoader.jsonObject(for: line),
+              let lineTotals = ClaudeTranscriptUsageLoader.usageTotals(from: object) else {
+            return
+        }
+
+        totals.add(lineTotals)
+        if let lineDate = ClaudeTranscriptUsageLoader.timestamp(from: object["timestamp"]),
+           latestUsageDate == nil || lineDate > latestUsageDate! {
+            latestUsageDate = lineDate
+        }
+    }
+}
+
+/// Reads Claude-family transcripts incrementally.
+///
+/// Claude Code appends to `~/.claude/projects/**/*.jsonl` on every message and
+/// `SessionStore` refreshes usage on a 100ms debounce, so a whole-file reparse costs
+/// O(file size) per appended line. This tails the append-only region instead, and
+/// rebuilds from scratch only when the file is replaced or truncated.
+actor ClaudeTranscriptUsageReader {
+    static let shared = ClaudeTranscriptUsageReader()
+
+    struct DebugReadMetrics: Equatable, Sendable {
+        let fullRebuildCount: Int
+        let incrementalReadCount: Int
+        let lastReadByteCount: Int
+    }
+
+    private struct CachedSnapshot {
+        let modificationDate: Date
+        let fileIdentifier: UInt64?
+        let fileSize: UInt64
+        let readOffset: UInt64
+        let pendingData: Data
+        let isDiscardingOversizedLine: Bool
+        let accumulator: ClaudeTranscriptUsageAccumulator
+        let snapshot: ClaudeTranscriptUsageSnapshot?
+        let metrics: DebugReadMetrics
+    }
+
+    private struct ReadResult {
+        let accumulator: ClaudeTranscriptUsageAccumulator
+        let pendingData: Data
+        let isDiscardingOversizedLine: Bool
+        let readOffset: UInt64
+        let bytesRead: Int
+    }
+
+    private static let readChunkSize = 64 * 1024
+    private static let maximumJSONLineBytes = 8 * 1024 * 1024
+
+    private var cache: [String: CachedSnapshot] = [:]
+
+    /// Returns cumulative usage for the whole transcript, reading only bytes appended
+    /// since the previous call when the file grew in place.
+    ///
+    /// - Parameters:
+    ///   - fileURL: Transcript to scan.
+    ///   - fileManager: Injection seam for tests.
+    ///   - maxBytesPerFile: Transcripts larger than this are skipped, matching the
+    ///     previous whole-file behaviour.
+    /// - Returns: A snapshot, or `nil` when the transcript is missing, oversized, or
+    ///   carries no token fields yet.
+    func snapshot(
+        for fileURL: URL,
+        fileManager: FileManager = .default,
+        maxBytesPerFile: Int = 64 * 1024 * 1024
+    ) -> ClaudeTranscriptUsageSnapshot? {
+        guard let attributes = try? fileManager.attributesOfItem(atPath: fileURL.path),
+              (attributes[.type] as? FileAttributeType) != .typeDirectory,
+              let modificationDate = attributes[.modificationDate] as? Date,
+              let fileSizeNumber = attributes[.size] as? NSNumber else {
+            cache.removeValue(forKey: fileURL.path)
+            return nil
+        }
+
+        let fileSize = fileSizeNumber.uint64Value
+        guard fileSize > 0, fileSize <= UInt64(max(0, maxBytesPerFile)) else {
+            cache.removeValue(forKey: fileURL.path)
+            return nil
+        }
+
+        let fileIdentifier = (attributes[.systemFileNumber] as? NSNumber)?.uint64Value
+        let previous = cache[fileURL.path]
+
+        /// Unchanged mtime and size means no append since the last scan, so the cached
+        /// result stands and the file is never opened.
+        if let cached = previous,
+           cached.modificationDate == modificationDate,
+           cached.fileSize == fileSize,
+           cached.fileIdentifier == fileIdentifier {
+            return cached.snapshot
+        }
+
+        /// Growth in place under the same inode is an append; anything else (rotation,
+        /// truncation, rewrite) invalidates the carried offset, digest, and totals.
+        let canReadIncrementally = previous.map {
+            $0.fileIdentifier == fileIdentifier && fileSize >= $0.readOffset
+        } ?? false
+
+        guard let readResult = readTranscript(
+            fileURL: fileURL,
+            throughOffset: fileSize,
+            startingAt: canReadIncrementally ? (previous?.readOffset ?? 0) : 0,
+            accumulator: canReadIncrementally
+                ? (previous?.accumulator ?? ClaudeTranscriptUsageAccumulator())
+                : ClaudeTranscriptUsageAccumulator(),
+            pendingData: canReadIncrementally ? (previous?.pendingData ?? Data()) : Data(),
+            isDiscardingOversizedLine: canReadIncrementally
+                ? (previous?.isDiscardingOversizedLine ?? false)
+                : false
+        ) else {
+            cache.removeValue(forKey: fileURL.path)
+            return nil
+        }
+
+        let accumulator = readResult.accumulator
+        let snapshot: ClaudeTranscriptUsageSnapshot? = accumulator.totals.hasTokens
+            ? ClaudeTranscriptUsageSnapshot(
+                sourceFilePath: fileURL.path,
+                capturedAt: accumulator.latestUsageDate ?? modificationDate,
+                fileSize: readResult.readOffset,
+                contentHash: accumulator.contentHash,
+                tokenTotals: accumulator.totals
+            )
+            : nil
+
+        let previousMetrics = previous?.metrics
+        cache[fileURL.path] = CachedSnapshot(
+            modificationDate: modificationDate,
+            fileIdentifier: fileIdentifier,
+            fileSize: fileSize,
+            readOffset: readResult.readOffset,
+            pendingData: readResult.pendingData,
+            isDiscardingOversizedLine: readResult.isDiscardingOversizedLine,
+            accumulator: accumulator,
+            snapshot: snapshot,
+            metrics: DebugReadMetrics(
+                fullRebuildCount: (previousMetrics?.fullRebuildCount ?? 0) + (canReadIncrementally ? 0 : 1),
+                incrementalReadCount: (previousMetrics?.incrementalReadCount ?? 0) + (canReadIncrementally ? 1 : 0),
+                lastReadByteCount: readResult.bytesRead
+            )
+        )
+
+        return snapshot
+    }
+
+    func debugReadMetrics(forFilePath filePath: String) -> DebugReadMetrics? {
+        cache[filePath]?.metrics
+    }
+
+    func resetCache() {
+        cache.removeAll()
+    }
+
+    private func readTranscript(
+        fileURL: URL,
+        throughOffset targetOffset: UInt64,
+        startingAt startOffset: UInt64,
+        accumulator initialAccumulator: ClaudeTranscriptUsageAccumulator,
+        pendingData initialPendingData: Data,
+        isDiscardingOversizedLine initialDiscardingState: Bool
+    ) -> ReadResult? {
+        guard let handle = try? FileHandle(forReadingFrom: fileURL) else {
+            return nil
+        }
+        defer { try? handle.close() }
+
+        do {
+            try handle.seek(toOffset: startOffset)
+        } catch {
+            return nil
+        }
+
+        var accumulator = initialAccumulator
+        var pendingData = initialPendingData
+        var isDiscardingOversizedLine = initialDiscardingState
+        var currentOffset = startOffset
+        var bytesRead = 0
+
+        while currentOffset < targetOffset {
+            let remaining = targetOffset - currentOffset
+            let requestedCount = Int(min(UInt64(Self.readChunkSize), remaining))
+            guard requestedCount > 0 else {
+                break
+            }
+
+            let chunk: Data
+            do {
+                guard let nextChunk = try handle.read(upToCount: requestedCount),
+                      !nextChunk.isEmpty else {
+                    break
+                }
+                chunk = nextChunk
+            } catch {
+                return nil
+            }
+
+            currentOffset += UInt64(chunk.count)
+            bytesRead += chunk.count
+            accumulator.absorb(bytes: chunk)
+
+            var chunkRemainder = chunk
+            if isDiscardingOversizedLine {
+                guard let newlineIndex = chunkRemainder.firstIndex(of: 0x0A) else {
+                    continue
+                }
+                chunkRemainder.removeSubrange(chunkRemainder.startIndex...newlineIndex)
+                isDiscardingOversizedLine = false
+            }
+
+            pendingData.append(chunkRemainder)
+            while let newlineIndex = pendingData.firstIndex(of: 0x0A) {
+                let lineData = Data(pendingData[..<newlineIndex])
+                pendingData.removeSubrange(pendingData.startIndex...newlineIndex)
+                accumulator.absorb(
+                    line: String(decoding: lineData, as: UTF8.self)
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                )
+            }
+
+            /// A single record this large is pathological; drop it rather than buffer it
+            /// until the next newline arrives.
+            if pendingData.count > Self.maximumJSONLineBytes {
+                pendingData.removeAll(keepingCapacity: false)
+                isDiscardingOversizedLine = true
+            }
+        }
+
+        /// The trailing bytes may be a record Claude Code has not finished writing.
+        /// They stay in `pendingData` for the next read; they are already folded into
+        /// the digest, so each byte is hashed exactly once.
+        return ReadResult(
+            accumulator: accumulator,
+            pendingData: pendingData,
+            isDiscardingOversizedLine: isDiscardingOversizedLine,
+            readOffset: currentOffset,
+            bytesRead: bytesRead
+        )
+    }
+}
+
 enum ClaudeTranscriptUsageLoader {
     private nonisolated static let defaultMaxBytesPerFile = 64 * 1024 * 1024
 
+    /// Scans a transcript in full.
+    ///
+    /// Prefer `ClaudeTranscriptUsageReader.shared` on repeated reads of a growing
+    /// transcript; this stays as the stateless single-shot path.
     nonisolated static func load(
         from fileURL: URL,
         fileManager: FileManager = .default,
@@ -31,39 +309,28 @@ enum ClaudeTranscriptUsageLoader {
         }
 
         let data = try Data(contentsOf: fileURL)
+        var accumulator = ClaudeTranscriptUsageAccumulator()
+        accumulator.absorb(bytes: data)
+
         let content = String(decoding: data, as: UTF8.self)
-        var totals = AgentUsageTokenTotals()
-        var latestUsageDate: Date?
-
         for rawLine in content.split(separator: "\n", omittingEmptySubsequences: false) {
-            let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !line.isEmpty,
-                  let object = jsonObject(for: line),
-                  let lineTotals = usageTotals(from: object) else {
-                continue
-            }
-
-            totals.add(lineTotals)
-            if let lineDate = timestamp(from: object["timestamp"]),
-               latestUsageDate == nil || lineDate > latestUsageDate! {
-                latestUsageDate = lineDate
-            }
+            accumulator.absorb(line: rawLine.trimmingCharacters(in: .whitespacesAndNewlines))
         }
 
-        guard totals.hasTokens else {
+        guard accumulator.totals.hasTokens else {
             return nil
         }
 
         return ClaudeTranscriptUsageSnapshot(
             sourceFilePath: fileURL.path,
-            capturedAt: latestUsageDate ?? resourceValues.contentModificationDate,
+            capturedAt: accumulator.latestUsageDate ?? resourceValues.contentModificationDate,
             fileSize: UInt64(data.count),
-            contentHash: fnv1aHashHex(for: data),
-            tokenTotals: totals
+            contentHash: accumulator.contentHash,
+            tokenTotals: accumulator.totals
         )
     }
 
-    private nonisolated static func usageTotals(from object: [String: Any]) -> AgentUsageTokenTotals? {
+    fileprivate nonisolated static func usageTotals(from object: [String: Any]) -> AgentUsageTokenTotals? {
         if let totals = tokenTotals(from: object["usage"])
             ?? tokenTotals(from: object["token_usage"])
             ?? tokenTotals(from: object["total_token_usage"]) {
@@ -130,7 +397,7 @@ enum ClaudeTranscriptUsageLoader {
         )
     }
 
-    private nonisolated static func jsonObject(for line: String) -> [String: Any]? {
+    fileprivate nonisolated static func jsonObject(for line: String) -> [String: Any]? {
         guard let data = line.data(using: .utf8),
               let object = try? JSONSerialization.jsonObject(with: data),
               let dictionary = object as? [String: Any] else {
@@ -150,7 +417,7 @@ enum ClaudeTranscriptUsageLoader {
         }
     }
 
-    private nonisolated static func timestamp(from value: Any?) -> Date? {
+    fileprivate nonisolated static func timestamp(from value: Any?) -> Date? {
         switch value {
         case let number as NSNumber:
             return Date(timeIntervalSince1970: number.doubleValue)
@@ -167,14 +434,5 @@ enum ClaudeTranscriptUsageLoader {
         default:
             return nil
         }
-    }
-
-    private nonisolated static func fnv1aHashHex(for data: Data) -> String {
-        var hash: UInt64 = 0xcbf29ce484222325
-        for byte in data {
-            hash ^= UInt64(byte)
-            hash = hash &* 0x100000001b3
-        }
-        return String(format: "%016llx", hash)
     }
 }

--- a/PingIslandTests/ClaudeTranscriptUsageReaderTests.swift
+++ b/PingIslandTests/ClaudeTranscriptUsageReaderTests.swift
@@ -1,0 +1,233 @@
+import XCTest
+@testable import Ping_Island
+
+final class ClaudeTranscriptUsageReaderTests: XCTestCase {
+    func testAppendOnlyGrowthMatchesWholeFileParse() async throws {
+        let transcriptURL = temporaryTranscriptURL(named: "incremental")
+        defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
+
+        try writeJSONLLines([usageLine(at: "2026-04-10T00:00:00.000Z", input: 7, output: 4, total: 11)], to: transcriptURL)
+
+        let reader = ClaudeTranscriptUsageReader()
+        let first = try await requireSnapshot(from: reader, at: transcriptURL)
+        XCTAssertEqual(first.tokenTotals, AgentUsageTokenTotals(input: 7, output: 4, total: 11))
+
+        try appendJSONLLine(usageLine(at: "2026-04-10T00:01:00.000Z", input: 5, output: 4, total: 9), to: transcriptURL)
+
+        let second = try await requireSnapshot(from: reader, at: transcriptURL)
+        let wholeFile = try XCTUnwrap(ClaudeTranscriptUsageLoader.load(from: transcriptURL))
+
+        /// Cumulative totals, not just the appended delta — `AgentUsageStore` derives
+        /// its own delta from these.
+        XCTAssertEqual(second.tokenTotals, AgentUsageTokenTotals(input: 12, output: 8, total: 20))
+        XCTAssertEqual(second.tokenTotals, wholeFile.tokenTotals)
+        XCTAssertEqual(second.fileSize, wholeFile.fileSize)
+        XCTAssertEqual(second.capturedAt, wholeFile.capturedAt)
+
+        /// The carried FNV-1a state must land on the same digest a whole-file pass
+        /// produces, or `AgentUsageStore` would treat every append as a new source.
+        XCTAssertEqual(second.contentHash, wholeFile.contentHash)
+    }
+
+    func testAppendReadsOnlyTheAppendedBytes() async throws {
+        let transcriptURL = temporaryTranscriptURL(named: "bytes")
+        defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
+
+        let padding = String(repeating: "x", count: 32 * 1024)
+        try writeJSONLLines(
+            [usageLine(at: "2026-04-10T00:00:00.000Z", input: 7, output: 4, total: 11, filler: padding)],
+            to: transcriptURL
+        )
+
+        let reader = ClaudeTranscriptUsageReader()
+        _ = await reader.snapshot(for: transcriptURL)
+        let afterFirst = try await requireMetrics(from: reader, at: transcriptURL)
+        XCTAssertEqual(afterFirst.fullRebuildCount, 1)
+        XCTAssertEqual(afterFirst.incrementalReadCount, 0)
+        XCTAssertGreaterThan(afterFirst.lastReadByteCount, 32 * 1024)
+
+        try appendJSONLLine(usageLine(at: "2026-04-10T00:01:00.000Z", input: 5, output: 4, total: 9), to: transcriptURL)
+
+        _ = await reader.snapshot(for: transcriptURL)
+        let afterAppend = try await requireMetrics(from: reader, at: transcriptURL)
+        XCTAssertEqual(afterAppend.fullRebuildCount, 1, "appending must not trigger a rebuild")
+        XCTAssertEqual(afterAppend.incrementalReadCount, 1)
+
+        /// The whole point: the second read touches only the appended record, not the
+        /// 32KB that preceded it.
+        XCTAssertLessThan(afterAppend.lastReadByteCount, 4 * 1024)
+    }
+
+    func testUnchangedFileIsNotReopened() async throws {
+        let transcriptURL = temporaryTranscriptURL(named: "unchanged")
+        defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
+
+        try writeJSONLLines([usageLine(at: "2026-04-10T00:00:00.000Z", input: 7, output: 4, total: 11)], to: transcriptURL)
+
+        let reader = ClaudeTranscriptUsageReader()
+        let first = try await requireSnapshot(from: reader, at: transcriptURL)
+        let second = try await requireSnapshot(from: reader, at: transcriptURL)
+
+        XCTAssertEqual(first, second)
+
+        let metrics = try await requireMetrics(from: reader, at: transcriptURL)
+        XCTAssertEqual(metrics.fullRebuildCount, 1)
+        XCTAssertEqual(metrics.incrementalReadCount, 0, "an unchanged transcript must not be read again")
+    }
+
+    func testTruncationRebuildsWithoutDoubleCounting() async throws {
+        let transcriptURL = temporaryTranscriptURL(named: "truncated")
+        defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
+
+        try writeJSONLLines(
+            [
+                usageLine(at: "2026-04-10T00:00:00.000Z", input: 7, output: 4, total: 11),
+                usageLine(at: "2026-04-10T00:01:00.000Z", input: 5, output: 4, total: 9),
+            ],
+            to: transcriptURL
+        )
+
+        let reader = ClaudeTranscriptUsageReader()
+        let first = try await requireSnapshot(from: reader, at: transcriptURL)
+        XCTAssertEqual(first.tokenTotals, AgentUsageTokenTotals(input: 12, output: 8, total: 20))
+
+        /// Rewriting the file shorter must discard the carried offset and totals rather
+        /// than stack a fresh scan on top of stale state.
+        try writeJSONLLines([usageLine(at: "2026-04-10T00:02:00.000Z", input: 3, output: 2, total: 5)], to: transcriptURL)
+
+        let second = try await requireSnapshot(from: reader, at: transcriptURL)
+        XCTAssertEqual(second.tokenTotals, AgentUsageTokenTotals(input: 3, output: 2, total: 5))
+
+        let wholeFile = try XCTUnwrap(ClaudeTranscriptUsageLoader.load(from: transcriptURL))
+        XCTAssertEqual(second.tokenTotals, wholeFile.tokenTotals)
+        XCTAssertEqual(second.contentHash, wholeFile.contentHash)
+    }
+
+    func testPartiallyWrittenTrailingRecordIsDeferredUntilComplete() async throws {
+        let transcriptURL = temporaryTranscriptURL(named: "partial")
+        defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
+
+        try writeJSONLLines([usageLine(at: "2026-04-10T00:00:00.000Z", input: 7, output: 4, total: 11)], to: transcriptURL)
+
+        let reader = ClaudeTranscriptUsageReader()
+        _ = try await requireSnapshot(from: reader, at: transcriptURL)
+
+        /// Claude Code can be mid-write when the 100ms debounce fires, so a trailing
+        /// fragment without its newline must not be parsed as a record.
+        let complete = try jsonLine(usageLine(at: "2026-04-10T00:01:00.000Z", input: 5, output: 4, total: 9))
+        let splitIndex = complete.index(complete.startIndex, offsetBy: complete.count / 2)
+        try appendRaw(String(complete[..<splitIndex]), to: transcriptURL)
+
+        let midWrite = try await requireSnapshot(from: reader, at: transcriptURL)
+        XCTAssertEqual(
+            midWrite.tokenTotals,
+            AgentUsageTokenTotals(input: 7, output: 4, total: 11),
+            "a half-written record must not contribute tokens"
+        )
+
+        try appendRaw(String(complete[splitIndex...]) + "\n", to: transcriptURL)
+
+        let completed = try await requireSnapshot(from: reader, at: transcriptURL)
+        XCTAssertEqual(completed.tokenTotals, AgentUsageTokenTotals(input: 12, output: 8, total: 20))
+
+        let wholeFile = try XCTUnwrap(ClaudeTranscriptUsageLoader.load(from: transcriptURL))
+        XCTAssertEqual(completed.tokenTotals, wholeFile.tokenTotals)
+        XCTAssertEqual(completed.contentHash, wholeFile.contentHash)
+    }
+
+    func testTranscriptWithoutTokenFieldsReturnsNil() async throws {
+        let transcriptURL = temporaryTranscriptURL(named: "notokens")
+        defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
+
+        try writeJSONLLines([
+            [
+                "timestamp": "2026-04-10T00:03:00.000Z",
+                "message": ["role": "assistant", "content": "No usage payload here."],
+            ],
+        ], to: transcriptURL)
+
+        let reader = ClaudeTranscriptUsageReader()
+        let snapshot = await reader.snapshot(for: transcriptURL)
+        XCTAssertNil(snapshot)
+
+        /// Offset progress is still cached so the next read tails rather than rescans.
+        let metrics = try await requireMetrics(from: reader, at: transcriptURL)
+        XCTAssertEqual(metrics.fullRebuildCount, 1)
+    }
+
+    func testOversizedTranscriptIsSkipped() async throws {
+        let transcriptURL = temporaryTranscriptURL(named: "oversized")
+        defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
+
+        try writeJSONLLines([usageLine(at: "2026-04-10T00:00:00.000Z", input: 7, output: 4, total: 11)], to: transcriptURL)
+
+        let reader = ClaudeTranscriptUsageReader()
+        let snapshot = await reader.snapshot(for: transcriptURL, maxBytesPerFile: 8)
+        XCTAssertNil(snapshot, "transcripts past the byte cap keep the previous skip behaviour")
+    }
+
+    private func requireSnapshot(
+        from reader: ClaudeTranscriptUsageReader,
+        at fileURL: URL
+    ) async throws -> ClaudeTranscriptUsageSnapshot {
+        let snapshot = await reader.snapshot(for: fileURL)
+        return try XCTUnwrap(snapshot)
+    }
+
+    private func requireMetrics(
+        from reader: ClaudeTranscriptUsageReader,
+        at fileURL: URL
+    ) async throws -> ClaudeTranscriptUsageReader.DebugReadMetrics {
+        let metrics = await reader.debugReadMetrics(forFilePath: fileURL.path)
+        return try XCTUnwrap(metrics)
+    }
+}
+
+private func usageLine(
+    at timestamp: String,
+    input: Int,
+    output: Int,
+    total: Int,
+    filler: String? = nil
+) -> [String: Any] {
+    var message: [String: Any] = [
+        "role": "assistant",
+        "usage": [
+            "inputTokens": input,
+            "outputTokens": output,
+            "totalTokens": total,
+        ],
+    ]
+    if let filler {
+        message["content"] = filler
+    }
+    return ["timestamp": timestamp, "message": message]
+}
+
+private func temporaryTranscriptURL(named name: String) -> URL {
+    FileManager.default.temporaryDirectory
+        .appendingPathComponent("ping-island-\(name)-reader-\(UUID().uuidString)", isDirectory: true)
+        .appendingPathComponent("session.jsonl")
+}
+
+private func writeJSONLLines(_ objects: [[String: Any]], to url: URL) throws {
+    try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+    let lines = try objects.map(jsonLine)
+    try lines.joined(separator: "\n").appending("\n").write(to: url, atomically: true, encoding: .utf8)
+}
+
+private func appendJSONLLine(_ object: [String: Any], to url: URL) throws {
+    try appendRaw(jsonLine(object).appending("\n"), to: url)
+}
+
+private func appendRaw(_ text: String, to url: URL) throws {
+    let handle = try FileHandle(forWritingTo: url)
+    defer { try? handle.close() }
+    try handle.seekToEnd()
+    handle.write(Data(text.utf8))
+}
+
+private func jsonLine(_ object: [String: Any]) throws -> String {
+    let data = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+    return String(decoding: data, as: UTF8.self)
+}


### PR DESCRIPTION
## Problem

`ClaudeTranscriptUsageLoader.load` reads the whole transcript on every call — `Data(contentsOf:)`, decode to `String`, JSON-parse every line, and hash every byte one at a time through `for byte in data`.

It is called from `SessionStore.recordClaudeFamilyTranscriptUsageIfAvailable`, at the tail of the file-sync path that runs on a **100 ms debounce**. Claude Code appends to `~/.claude/projects/**/*.jsonl` on every message, so each appended line costs a full re-read, re-parse, and re-hash of everything written before it — O(file size) per append, growing as the session grows.

This is the whole-file reparse class of problem already fixed for Codex in #278. `CodexRolloutParser` tails incrementally and `AGENTS.md` records the rule — *"do not return to whole-file reparsing for ordinary appends"* — but the Claude-family transcript path never got the same treatment, and unlike the Codex path it has no rate limiting either.

## What changed

Adds `ClaudeTranscriptUsageReader`, an actor modelled directly on `CodexRolloutParser` (same `CachedSnapshot` / `ReadResult` / `DebugReadMetrics` shape, same `readChunkSize`, same inode-based identity check).

| Case | Before | After |
| --- | --- | --- |
| No change since last read | full read + parse + hash | cached result, file never opened |
| Record appended | full read + parse + hash | seek to prior offset, read only new bytes |
| File replaced (inode change) | full read | full rebuild |
| File truncated / rewritten shorter | full read | full rebuild, carried state discarded |
| Trailing record half-written | parsed as a broken line | buffered, parsed once its newline lands |
| Single pathological record | buffered unbounded | dropped past `maximumJSONLineBytes` |

`SessionStore` now calls the reader; `ClaudeTranscriptUsageLoader.load` stays as the stateless single-shot path.

## Preserved semantics

The snapshot contract is unchanged, which matters because `AgentUsageStore` derives its own delta from these fields:

| Field | How it stays correct |
| --- | --- |
| `tokenTotals` | cumulative for the whole transcript, not the appended delta — totals are carried and added to |
| `contentHash` | FNV-1a is a streaming hash, so carrying its state across reads produces a digest **byte-identical** to a whole-file pass |
| `capturedAt` | newest usage timestamp, carried and maxed against new lines |
| `fileSize` | full file size, as before |

Every byte of the file passes through the digest exactly once, newlines included — the trailing partial record is hashed when read and parsed later, never hashed twice.

Behaviour deliberately left alone: transcripts past the 64 MB cap are still skipped. Tailing makes that cap safely raisable, but that is a separate decision from this fix.

## Measured impact

40 appends to a 3.78 MB / 2,000-record synthetic transcript:

| | Whole-file | Incremental | |
| --- | --- | --- | --- |
| Disk read | 152.8 MB | 3.86 MB | **39.6× less** |
| Wall time | 15.775 s | 0.385 s | **41× faster** |

The 3.86 MB is one initial full pass plus 40 small tails. Bytes-read is build-independent; the timing figure came from a Debug build, so treat it as directional — `-configuration Release` cannot build this repo's test target (pre-existing `#if DEBUG` test helpers such as `syncClosedWidthForTesting`).

## Tests

7 cases in `PingIslandTests/ClaudeTranscriptUsageReaderTests.swift`: append equals whole-file parse (totals, size, timestamp **and** hash), appends read only appended bytes via `debugReadMetrics`, unchanged file is not reopened, truncation rebuilds without double counting, half-written records are deferred, transcripts without token fields, and the size cap.

Full `PingIslandTests` suite passes. The pre-existing `testRecordTranscriptUsageDoesNotDoubleCountRepeatedReads` also passes — that is the one that breaks if the hash or cumulative-totals semantics drift.

## Verification

- Main Xcode scheme builds; `PingIslandTests` green.
- `AGENTS.md` updated alongside the existing Codex note, per the repo rule that docs upkeep is part of the change.
- Session ingestion: covered by the automated suite including `SessionStoreFileUpdateTests`. I have not manually exercised the running app's Claude usage UI, so a sanity check there is worth a reviewer's eye.
