### PR TITLE
Fix type-check timeout in settings localization test

### DIFF
--- a/PingIslandTests/SettingsWindowControllerTests.swift
+++ b/PingIslandTests/SettingsWindowControllerTests.swift
@@ -15,15 +15,16 @@ final class SettingsWindowControllerTests: XCTestCase {
 
     func testSettingsOptionsAndMascotCopyHaveEnglishTranslations() throws {
         let english = try localizationDictionary(named: "en")
-        let keys = SettingsCategory.allCases.flatMap { [$0.title, $0.subtitle] }
-            + UsageValueMode.allCases.map(\.title)
-            + AutoRoutePromptsIdleDelay.allCases.map(\.title)
-            + FloatingPetSizeMode.allCases.flatMap { [$0.title, $0.subtitle] }
-            + SubagentVisibilityMode.allCases.flatMap { [$0.title, $0.subtitle] }
-            + NotchPetStyle.allCases.flatMap { [$0.title, $0.subtitle] }
-            + MascotClient.allCases.flatMap { [$0.title, $0.subtitle] }
-            + MascotKind.allCases.flatMap { [$0.title, $0.subtitle] }
-            + MascotStatus.allCases.map(\.displayName)
+        var keys: [String] = []
+        keys.append(contentsOf: SettingsCategory.allCases.flatMap { [$0.title, $0.subtitle] })
+        keys.append(contentsOf: UsageValueMode.allCases.map(\.title))
+        keys.append(contentsOf: AutoRoutePromptsIdleDelay.allCases.map(\.title))
+        keys.append(contentsOf: FloatingPetSizeMode.allCases.flatMap { [$0.title, $0.subtitle] })
+        keys.append(contentsOf: SubagentVisibilityMode.allCases.flatMap { [$0.title, $0.subtitle] })
+        keys.append(contentsOf: NotchPetStyle.allCases.flatMap { [$0.title, $0.subtitle] })
+        keys.append(contentsOf: MascotClient.allCases.flatMap { [$0.title, $0.subtitle] })
+        keys.append(contentsOf: MascotKind.allCases.flatMap { [$0.title, $0.subtitle] })
+        keys.append(contentsOf: MascotStatus.allCases.map(\.displayName))
 
         for key in Set(keys).filter(containsHanCharacter) {
             let translation = try XCTUnwrap(english[key], "Missing English translation for \(key)")


### PR DESCRIPTION
## Background

 - GitHub Actions PR checks fail while compiling SettingsWindowControllerTests.swift on a macOS 15 runner with Xcode 16.4.
 - The Swift compiler cannot type-check the chained `map` and `flatMap` array expression in a reasonable amount of time.
 - Because the test target does not compile, the Xcode unit tests never start.

## Changes

 - Give the collected localization keys an explicit `[String]` type.
 - Append each group of settings and mascot keys in a separate statement.
 - Preserve the same keys, ordering, and translation assertions.
 - Keep the change limited to test code.
