### PR TITLE
显示 Claude Code 自己的会话标题，而不是第一条 prompt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,8 @@ This file is a routing layer for coding agents working in this repo. Keep it sho
   - One assistant response spans several transcript lines (one per content block) that each repeat the same `message.usage`; `ClaudeTranscriptUsageAccumulator` counts a `message.id` once per consecutive run. Those repeats are always adjacent, so keep this O(1) rather than introducing a seen-set that would grow with the transcript.
 - Native runtime rollout scaffold: `PingIsland/Services/Runtime/`, `PingIsland/Core/FeatureFlags.swift`
 - Session bridge for UI: `PingIsland/Services/Session/SessionMonitor.swift`
+- Claude-family transcript titles and last-message text: `PingIsland/Services/Session/ConversationParser.swift`
+  - Claude Code 2.x stopped writing `summary` records and now persists the title shown in its own UI as a `custom-title` record, rewritten on every turn. Take the newest one, keep the legacy `summary` path as a fallback for older transcripts and other Claude-compatible clients, and only fall back to the first user message when neither exists.
 - Notch state and layout: `PingIsland/Core/NotchViewModel.swift`, `PingIsland/UI/Views/NotchView.swift`
 - App-wide low-power policy for background polling, event monitoring, UI animation tiers, and silent update gating: `PingIsland/Core/EnergyGovernor.swift`
 - User idle protection for temporarily routing blocking approvals/questions back to terminals: `PingIsland/Core/UserIdleAutoProtection.swift`, `PingIsland/Core/Settings.swift`, `PingIsland/Services/Hooks/BridgeRuntimeConfigWriter.swift`

--- a/PingIsland/Models/SessionState.swift
+++ b/PingIsland/Models/SessionState.swift
@@ -248,7 +248,7 @@ struct SessionState: Equatable, Identifiable, Sendable {
         return sessionId
     }
 
-    /// Display title: summary > first user message > project name
+    /// Display title: session name > transcript title (Claude Code `custom-title`, legacy `summary`) > first user message > project name
     nonisolated var displayTitle: String {
         sessionName
             ?? SessionTextSanitizer.sanitizedDisplayText(conversationInfo.summary)

--- a/PingIsland/Services/Session/ConversationParser.swift
+++ b/PingIsland/Services/Session/ConversationParser.swift
@@ -124,6 +124,7 @@ actor ConversationParser {
         let lines = content.components(separatedBy: "\n").filter { !$0.isEmpty }
 
         var summary: String?
+        var customTitle: String?
         var lastMessage: String?
         var lastMessageRole: String?
         var lastToolName: String?
@@ -199,17 +200,26 @@ actor ConversationParser {
                 }
             }
 
+            // Claude Code 2.x no longer emits `summary` lines; it persists the title
+            // shown in its own UI as a `custom-title` record, rewritten on every turn.
+            // Reverse iteration means the first hit is the newest title.
+            if customTitle == nil, type == "custom-title",
+               let titleText = json["customTitle"] as? String,
+               !titleText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                customTitle = titleText
+            }
+
             if summary == nil, type == "summary", let summaryText = json["summary"] as? String {
                 summary = summaryText
             }
 
-            if summary != nil && lastMessage != nil && foundLastUserMessage {
+            if (customTitle != nil || summary != nil) && lastMessage != nil && foundLastUserMessage {
                 break
             }
         }
 
         return ConversationInfo(
-            summary: summary,
+            summary: customTitle ?? summary,
             lastMessage: Self.truncateMessage(lastMessage, maxLength: 80),
             lastMessageRole: lastMessageRole,
             lastToolName: lastToolName,

--- a/PingIslandTests/ConversationParserTests.swift
+++ b/PingIslandTests/ConversationParserTests.swift
@@ -1,0 +1,146 @@
+import XCTest
+@testable import Ping_Island
+
+final class ConversationParserTests: XCTestCase {
+    func testCustomTitleIsPreferredOverFirstUserMessage() async throws {
+        let transcriptURL = temporaryTranscriptURL(named: "custom-title")
+        defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
+
+        try writeJSONLLines(
+            [
+                userLine("修复一下窗口重复显示的问题", at: "2026-08-30T10:00:00.000Z"),
+                customTitleLine("双窗口重复显示bug"),
+                assistantLine("Patched the docked window teardown path."),
+            ],
+            to: transcriptURL
+        )
+
+        let info = await parse(transcriptURL)
+
+        XCTAssertEqual(info.summary, "双窗口重复显示bug")
+        XCTAssertEqual(info.firstUserMessage, "修复一下窗口重复显示的问题")
+    }
+
+    /// Claude Code rewrites the `custom-title` record on every turn, and the title
+    /// changes as the session moves on. The newest one has to win.
+    func testLatestCustomTitleWins() async throws {
+        let transcriptURL = temporaryTranscriptURL(named: "latest-title")
+        defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
+
+        try writeJSONLLines(
+            [
+                userLine("先看看标题为什么不对", at: "2026-08-30T10:00:00.000Z"),
+                customTitleLine("排查标题来源"),
+                assistantLine("Found the parser gap."),
+                userLine("好的，修复一下", at: "2026-08-30T10:05:00.000Z"),
+                customTitleLine("会话标题解析修复"),
+                assistantLine("Patched ConversationParser."),
+            ],
+            to: transcriptURL
+        )
+
+        let info = await parse(transcriptURL)
+
+        XCTAssertEqual(info.summary, "会话标题解析修复")
+    }
+
+    /// Older transcripts (and other Claude-compatible clients) still ship `summary`
+    /// records, so that path must keep working.
+    func testLegacySummaryRecordStillParses() async throws {
+        let transcriptURL = temporaryTranscriptURL(named: "legacy-summary")
+        defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
+
+        try writeJSONLLines(
+            [
+                ["type": "summary", "summary": "Ship stable completion handling"],
+                userLine("ship it", at: "2026-08-30T10:00:00.000Z"),
+                assistantLine("Released."),
+            ],
+            to: transcriptURL
+        )
+
+        let info = await parse(transcriptURL)
+
+        XCTAssertEqual(info.summary, "Ship stable completion handling")
+    }
+
+    func testTranscriptWithoutTitleFallsBackToFirstUserMessage() async throws {
+        let transcriptURL = temporaryTranscriptURL(named: "no-title")
+        defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
+
+        try writeJSONLLines(
+            [
+                userLine("just a quick question", at: "2026-08-30T10:00:00.000Z"),
+                assistantLine("Here is the answer."),
+            ],
+            to: transcriptURL
+        )
+
+        let info = await parse(transcriptURL)
+
+        XCTAssertNil(info.summary)
+        XCTAssertEqual(info.firstUserMessage, "just a quick question")
+    }
+
+    func testBlankCustomTitleIsIgnored() async throws {
+        let transcriptURL = temporaryTranscriptURL(named: "blank-title")
+        defer { try? FileManager.default.removeItem(at: transcriptURL.deletingLastPathComponent()) }
+
+        try writeJSONLLines(
+            [
+                userLine("blank title please", at: "2026-08-30T10:00:00.000Z"),
+                customTitleLine("   "),
+                assistantLine("Done."),
+            ],
+            to: transcriptURL
+        )
+
+        let info = await parse(transcriptURL)
+
+        XCTAssertNil(info.summary)
+        XCTAssertEqual(info.firstUserMessage, "blank title please")
+    }
+
+    private func parse(_ url: URL) async -> ConversationInfo {
+        let parser = ConversationParser()
+        return await parser.parse(
+            sessionId: url.deletingPathExtension().lastPathComponent,
+            cwd: url.deletingLastPathComponent().path,
+            explicitFilePath: url.path
+        )
+    }
+}
+
+private func userLine(_ text: String, at timestamp: String) -> [String: Any] {
+    [
+        "type": "user",
+        "timestamp": timestamp,
+        "message": ["role": "user", "content": [["type": "text", "text": text]]],
+    ]
+}
+
+private func assistantLine(_ text: String) -> [String: Any] {
+    [
+        "type": "assistant",
+        "message": ["role": "assistant", "content": [["type": "text", "text": text]]],
+    ]
+}
+
+private func customTitleLine(_ title: String) -> [String: Any] {
+    ["type": "custom-title", "customTitle": title]
+}
+
+private func temporaryTranscriptURL(named name: String) -> URL {
+    FileManager.default.temporaryDirectory
+        .appendingPathComponent("ping-island-\(name)-parser-\(UUID().uuidString)", isDirectory: true)
+        .appendingPathComponent("session.jsonl")
+}
+
+private func writeJSONLLines(_ objects: [[String: Any]], to url: URL) throws {
+    try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+    let lines = try objects.map { object -> String in
+        let data = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+        return String(decoding: data, as: UTF8.self)
+    }
+    try lines.joined(separator: "\n").appending("\n").write(to: url, atomically: true, encoding: .utf8)
+}


### PR DESCRIPTION
## 问题

Island 里的 Claude Code 会话，标题显示的是用户的**第一条 prompt**，而不是 Claude Code 自己为这个会话显示的标题。而且它永远不变 —— 一个以「标题为什么不对？」开头的会话，之后无论聊到哪里，行上挂的还是这句话。

`SessionState.displayTitle` 的优先级是 `sessionName → conversationInfo.summary → firstUserMessage → projectName`，而 `ConversationParser` 里 `summary` 只有一个来源：transcript 中 `{"type":"summary"}` 的记录。

Claude Code 2.x 已经不再写这种记录了。它把自己 UI 上显示的标题存成另一种记录，并且每轮对话都会重写一次：

```json
{"type":"custom-title","customTitle":"双窗口重复显示bug","sessionId":"faa1378d-…"}
```

在本地 `~/.claude/projects` 上做了统计（418 份 transcript，Claude Code 2.1.247）：含 `summary` 记录的 **0 份**，含 `custom-title` 的 88 份；最近两周内有改动的 118 份里 87 份带 `custom-title`。也就是说 `summary` 在实际使用中恒为 nil，当前所有 Claude Code 会话都会掉到 `firstUserMessage`，还被截断到 50 字符。

## 改动

在 `parseContent` 已有的倒序扫描里读取 `custom-title`，倒序第一个命中的就是最新标题，并优先于旧的 `summary`。

标题喂给已有的 `ConversationInfo.summary` 字段，而不是新增一个字段，所以所有现有消费方 —— `displayTitle`、副标题 badge、Codex 辅助会话判断 —— 不需要任何改动即可生效。

兼容性：

- 旧 transcript 以及其他仍然输出 `summary` 的 Claude 兼容客户端不受影响，该路径原样保留并作为 fallback。
- 两种记录都没有的 transcript（短会话、subagent sidechain）仍然回退到第一条用户消息，与现状完全一致。
- 空白标题会被忽略，不会把标题刷成一串空格。
- 提前退出的条件改成接受任一来源，所以两种记录都没有的 transcript 扫描成本与现在相同，不会因为这次改动变差。
- `parse()` 按文件 mtime 缓存，Claude Code 改写标题时会更新 mtime，标题能自动刷新，不需要额外的失效逻辑。

## 测试

新增 `PingIslandTests/ConversationParserTests.swift`（此前这个 parser 没有直接的测试覆盖）：custom-title 优先于第一条用户消息、存在多条时取最新的、旧的 `summary` 路径仍可解析、两者都没有时回退、空白标题被忽略。

CI 的两项检查在本分支上于本地均已通过：`swift test --package-path Prototype`（129 tests）与 `-only-testing:PingIslandTests`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
