### PR TITLE
test(completion): isolate registry test to MainActor

### DIFF
--- a/PingIslandTests/SessionCompletionStateEvaluatorTests.swift
+++ b/PingIslandTests/SessionCompletionStateEvaluatorTests.swift
@@ -31,6 +31,7 @@ final class SessionCompletionStateEvaluatorTests: XCTestCase {
         XCTAssertEqual(first.assistantItemId, "assistant-1")
     }
 
+    @MainActor
     func testCompletionNotificationRegistryUsesSharedCompletionKeyLogic() {
         let registry = SessionCompletionNotificationRegistry.shared
         var session = SessionState(


### PR DESCRIPTION
## Background

- `SessionCompletionNotificationRegistry` is isolated to `MainActor`.
- Its shared completion-key test accesses the registry from a synchronous nonisolated method.
- This prevents the `PingIslandTests` target from compiling before unit tests run.

## Changes

- Mark `testCompletionNotificationRegistryUsesSharedCompletionKeyLogic` as `@MainActor`.