### PR TITLE
perf: reduce detached working mascot cadence

### DIFF
--- a/PingIsland/UI/Components/MascotView.swift
+++ b/PingIsland/UI/Components/MascotView.swift
@@ -415,19 +415,22 @@ struct MascotView: View {
     var size: CGFloat = 40
     var animationTime: TimeInterval?
     var isDragging: Bool = false
+    var animationSurface: MascotAnimationSurface = .standard
 
     init(
         kind: MascotKind,
         status: MascotStatus,
         size: CGFloat = 40,
         animationTime: TimeInterval? = nil,
-        isDragging: Bool = false
+        isDragging: Bool = false,
+        animationSurface: MascotAnimationSurface = .standard
     ) {
         self.kind = kind
         self.status = status
         self.size = size
         self.animationTime = animationTime
         self.isDragging = isDragging
+        self.animationSurface = animationSurface
     }
 
     init(
@@ -435,14 +438,16 @@ struct MascotView: View {
         status: MascotStatus,
         size: CGFloat = 40,
         animationTime: TimeInterval? = nil,
-        isDragging: Bool = false
+        isDragging: Bool = false,
+        animationSurface: MascotAnimationSurface = .standard
     ) {
         self.init(
             kind: MascotKind(provider: provider),
             status: status,
             size: size,
             animationTime: animationTime,
-            isDragging: isDragging
+            isDragging: isDragging,
+            animationSurface: animationSurface
         )
     }
 
@@ -530,25 +535,11 @@ struct MascotView: View {
     /// Adaptive refresh rate based on animation complexity.
     /// Visible pets need enough cadence for the time-based motion to read as animation.
     private func adaptiveInterval(for mode: MascotRenderMode) -> TimeInterval {
-        let baseInterval = switch mode {
-        case .idle:
-            1.0 / 12.0
-        case .working:
-            1.0 / 24.0
-        case .warning:
-            1.0 / 24.0
-        case .dragging:
-            1.0 / 30.0
-        }
-
-        switch energyGovernor.policy.animationLevel {
-        case .full:
-            return baseInterval
-        case .reduced:
-            return baseInterval * 1.6
-        case .staticFrames:
-            return baseInterval
-        }
+        MascotAnimationCadence.frameInterval(
+            for: mode,
+            surface: animationSurface,
+            animationLevel: energyGovernor.policy.animationLevel
+        )
     }
 
     private func animatedCanvas(interval: TimeInterval, mode: MascotRenderMode) -> some View {
@@ -2116,11 +2107,53 @@ struct MascotView: View {
     }
 }
 
-private enum MascotRenderMode {
+enum MascotAnimationSurface {
+    case standard
+    case detachedPet
+}
+
+enum MascotRenderMode {
     case idle
     case working
     case warning
     case dragging
+}
+
+struct MascotAnimationCadence {
+    nonisolated static func frameInterval(
+        for mode: MascotRenderMode,
+        surface: MascotAnimationSurface,
+        animationLevel: EnergyAnimationLevel
+    ) -> TimeInterval {
+        let baseInterval = switch mode {
+        case .idle:
+            1.0 / 12.0
+        case .working:
+            1.0 / 24.0
+        case .warning:
+            1.0 / 24.0
+        case .dragging:
+            1.0 / 30.0
+        }
+
+        let surfaceMultiplier: Double = switch (surface, mode) {
+        case (.detachedPet, .working):
+            // A detached working pet can remain visible for hours. Match the
+            // existing idle cadence while keeping attention and drag states fast.
+            2.0
+        default:
+            1.0
+        }
+
+        let energyMultiplier: Double = switch animationLevel {
+        case .full, .staticFrames:
+            1.0
+        case .reduced:
+            1.6
+        }
+
+        return baseInterval * surfaceMultiplier * energyMultiplier
+    }
 }
 
 private struct MascotMotion {

--- a/PingIsland/UI/Views/DetachedIslandPanelView.swift
+++ b/PingIsland/UI/Views/DetachedIslandPanelView.swift
@@ -1163,7 +1163,8 @@ private struct DetachedFloatingMascotView: View {
             kind: kind,
             status: status,
             size: renderSize,
-            isDragging: isDragging
+            isDragging: isDragging,
+            animationSurface: .detachedPet
         )
         .frame(width: renderSize, height: renderSize)
         .scaleEffect(displayScale)

--- a/PingIslandTests/MascotAnimationCadenceTests.swift
+++ b/PingIslandTests/MascotAnimationCadenceTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+@testable import Ping_Island
+
+final class MascotAnimationCadenceTests: XCTestCase {
+    func testStandardSurfacePreservesExistingFullCadence() {
+        XCTAssertEqual(frameRate(for: .idle), 12, accuracy: 0.001)
+        XCTAssertEqual(frameRate(for: .working), 24, accuracy: 0.001)
+        XCTAssertEqual(frameRate(for: .warning), 24, accuracy: 0.001)
+        XCTAssertEqual(frameRate(for: .dragging), 30, accuracy: 0.001)
+    }
+
+    func testDetachedWorkingPetUsesTwelveFramesPerSecond() {
+        XCTAssertEqual(
+            frameRate(for: .working, surface: .detachedPet),
+            12,
+            accuracy: 0.001
+        )
+    }
+
+    func testDetachedAttentionAndDraggingKeepFullCadence() {
+        XCTAssertEqual(
+            frameRate(for: .warning, surface: .detachedPet),
+            24,
+            accuracy: 0.001
+        )
+        XCTAssertEqual(
+            frameRate(for: .dragging, surface: .detachedPet),
+            30,
+            accuracy: 0.001
+        )
+    }
+
+    func testReducedEnergyPolicyComposesWithDetachedWorkingCadence() {
+        XCTAssertEqual(
+            frameRate(
+                for: .working,
+                surface: .detachedPet,
+                animationLevel: .reduced
+            ),
+            7.5,
+            accuracy: 0.001
+        )
+    }
+
+    private func frameRate(
+        for mode: MascotRenderMode,
+        surface: MascotAnimationSurface = .standard,
+        animationLevel: EnergyAnimationLevel = .full
+    ) -> Double {
+        1.0 / MascotAnimationCadence.frameInterval(
+            for: mode,
+            surface: surface,
+            animationLevel: animationLevel
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- cap detached floating pets in the long-running `working` state at 12 FPS instead of 24 FPS
- preserve the existing cadence for the compact/notch mascot, warning states, and dragging
- compose the detached-pet budget with the existing reduced-energy policy
- add focused cadence regression tests

## Why

The floating pet can stay active for hours, and its user-configurable scale now reaches well beyond the original compact mascot size. Repainting the same time-based working animation at 24 FPS has a measurable background CPU cost, especially on lower-end Macs.

This change targets only that sustained detached-pet state. Warning remains at 24 FPS and dragging remains at 30 FPS so attention and direct manipulation stay responsive.

## Real-world benchmark

Measured on a MacBook Pro (`Mac17,9`, Apple M5 Pro, 15 cores, 48 GB), macOS 26.6.2, on AC power.

- baseline: signed release 0.29.0 (77), commit `a525f1f`
- candidate: CI-built ad hoc Release app, commit `f8ea751`
- setup: `surfaceMode=floatingPet`; a local synthetic Codex session held the mascot in `working`
- collection: `top -l 21 -s 1 -pid <pid>`; discarded the warm-up sample and retained 20 one-second samples per build/scale
- 2.5× was repeated three times (60 samples per build) because it is the normal daily-use setting
- 10× produced an actual 920×920 floating-pet window, to exercise an intentionally extreme size

| Pet scale | Samples/build | Baseline CPU avg / median / P95 | Candidate CPU avg / median / P95 | Average delta |
| --- | ---: | ---: | ---: | ---: |
| 1× | 20 | 7.48% / 7.00% / 10.70% | 5.30% / 5.30% / 6.00% | **-29.1%** |
| 2.5× | 60 | 7.52% / 6.85% / 11.20% | 6.67% / 6.40% / 10.10% | **-11.3%** |
| 5× | 20 | 8.00% / 7.75% / 9.40% | 6.55% / 6.10% / 9.50% | **-18.1%** |
| 10× | 20 | 7.79% / 7.70% / 9.30% | 6.97% / 6.25% / 10.50% | **-10.5%** |

Average CPU improved at every tested size, and median CPU also improved at every size. The 20-sample 5×/10× P95 values are noisy and slightly higher, so this PR does not claim a tail-latency improvement there. The data also did not support adding a size-dependent resolution cap; cadence was the useful low-risk lever.

## Validation

- fork PR Checks: Prototype tests and Xcode unit tests passed
- fork Local Ad Hoc Build: Prototype tests, Xcode unit tests, and Release app build passed
- exact candidate artifact revision and SHA-256 were verified before benchmarking
- `git diff --check`
- `swiftc -parse` for all changed Swift files

CI runs:

- https://github.com/F21HGG/ping-island/actions/runs/33847939086
- https://github.com/F21HGG/ping-island/actions/runs/33847936609
