### PR TITLE
fix(remote): prevent Codex snapshots from overriding live session phase

### DIFF
--- a/PingIsland/Services/State/SessionStore.swift
+++ b/PingIsland/Services/State/SessionStore.swift
@@ -557,9 +557,17 @@ actor SessionStore {
             for: event,
             session: session
         )
-        let newPhase: SessionPhase = shouldPreserveEndedStopForAnsweredQuestion || codeBuddyCLINotificationIntervention != nil
+        let inferredPhase: SessionPhase = shouldPreserveEndedStopForAnsweredQuestion || codeBuddyCLINotificationIntervention != nil
             ? .waitingForInput
             : event.determinePhase()
+        // A fresh snapshot session is already idle. After any actor reentrancy,
+        // keep the reloaded lifecycle state under real hook-event control.
+        let isRemoteCodexThreadSnapshot = event.provider == .codex
+            && event.ingress == .remoteBridge
+            && event.event == "RemoteCodexThreadUpdated"
+        let newPhase: SessionPhase = isRemoteCodexThreadSnapshot
+            ? session.phase
+            : inferredPhase
         if wasCompletedReady, newPhase == .processing {
             session.completionSequence &+= 1
         }

--- a/PingIslandTests/RemoteCodexSnapshotPhaseTests.swift
+++ b/PingIslandTests/RemoteCodexSnapshotPhaseTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import XCTest
+@testable import Ping_Island
+
+final class RemoteCodexSnapshotPhaseTests: XCTestCase {
+    func testSnapshotCreatesIdleSessionWhenFirstObserved() async {
+        let sessionId = "codex-remote-snapshot-new-\(UUID().uuidString)"
+        let store = SessionStore.shared
+
+        await store.process(.hookReceived(makeSnapshot(sessionId: sessionId)))
+
+        let session = await store.session(for: sessionId)
+        XCTAssertEqual(session?.phase, .idle)
+
+        await store.process(.sessionArchived(sessionId: sessionId))
+    }
+
+    func testSnapshotPreservesExistingLifecyclePhase() async {
+        let store = SessionStore.shared
+        let cases: [(name: String, phase: SessionPhase)] = [
+            ("waiting", .waitingForInput),
+            ("ended", .ended)
+        ]
+
+        for testCase in cases {
+            let sessionId = "codex-remote-snapshot-\(testCase.name)-\(UUID().uuidString)"
+            await store.upsertCodexSession(
+                sessionId: sessionId,
+                name: "Remote task",
+                preview: "Existing lifecycle state",
+                cwd: snapshotCwd(sessionId: sessionId),
+                phase: testCase.phase,
+                intervention: nil,
+                clientInfo: .codexCLI()
+            )
+            await store.process(.hookReceived(makeSnapshot(sessionId: sessionId)))
+
+            let session = await store.session(for: sessionId)
+            XCTAssertEqual(session?.phase, testCase.phase, testCase.name)
+            await store.process(.sessionArchived(sessionId: sessionId))
+        }
+    }
+
+    private func makeSnapshot(sessionId: String) -> HookEvent {
+        HookEvent(
+            sessionId: sessionId,
+            cwd: snapshotCwd(sessionId: sessionId),
+            event: "RemoteCodexThreadUpdated",
+            status: "processing",
+            provider: .codex,
+            clientInfo: .codexCLI(),
+            pid: nil,
+            tty: nil,
+            tool: nil,
+            toolInput: nil,
+            toolUseId: nil,
+            notificationType: nil,
+            message: "Remote task snapshot",
+            ingress: .remoteBridge
+        )
+    }
+
+    private func snapshotCwd(sessionId: String) -> String {
+        "/tmp/remote-project-\(sessionId)"
+    }
+}

--- a/Prototype/Sources/IslandBridge/main.swift
+++ b/Prototype/Sources/IslandBridge/main.swift
@@ -1897,7 +1897,9 @@ private enum RemoteBridgeMessageBuilder {
             sessionID: thread.id,
             cwd: thread.cwd,
             event: "RemoteCodexThreadUpdated",
-            status: "processing",
+            // SQLite exposes recent thread metadata, not live turn state. Real
+            // hooks remain authoritative for active and completed edges.
+            status: "idle",
             provider: AgentProvider.codex.rawValue,
             pid: nil,
             tty: nil,

--- a/Prototype/Tests/IslandTests/IslandBridgeE2ETests.swift
+++ b/Prototype/Tests/IslandTests/IslandBridgeE2ETests.swift
@@ -419,7 +419,7 @@ func remoteAgentForwardsCodexAppServerStateUpdates() async throws {
         #expect(event.type == "hook_event")
         #expect(event.payload.provider == "codex")
         #expect(event.payload.cwd == "/work/project")
-        #expect(event.payload.status == "processing")
+        #expect(event.payload.status == "idle")
         #expect(event.payload.message == "Remote Codex is editing files")
         #expect(event.payload.clientInfo.kind == "codexCLI")
         #expect(event.payload.clientInfo.transport == "ssh")


### PR DESCRIPTION
## Background

- Remote Codex thread updates come from SQLite metadata snapshots, not live turn-state events.
- Treating every snapshot as `processing` can make an inactive remote session appear active.
- A snapshot may resume after actor reentrancy and overwrite a newer phase established by a live hook.
- The app-side guard also protects against already-installed remote bridges that still emit the legacy `processing` status.

## Changes

- Emit remote Codex thread snapshots as `idle` instead of `processing`.
- Treat `RemoteCodexThreadUpdated` from the remote bridge as metadata-only for session phase.
- Preserve the latest reloaded phase so live hook events remain authoritative.
- Add regression coverage for new, waiting, and ended sessions.