### PR TITLE
接入 Kimi 桌面版：独立的 hook 目标与桌面版特有行为

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,7 @@ This file is a routing layer for coding agents working in this repo. Keep it sho
   - The remote bridge forwards recent Codex app-server thread activity from the SSH target's `~/.codex/state_*.sqlite` through the existing remote hook-event channel
 - Provider/client routing: bridge envelopes are normalized in `PingIsland/Services/Hooks/HookSocketServer.swift`, stored on `SessionState`, and launched via `PingIsland/Services/Window/SessionLauncher.swift`
 - Client profile registry: installable hook clients and runtime client branding / recognition are centralized in `PingIsland/Models/ClientProfile.swift`
+  - The Kimi desktop app is a separate target (`kimi-app-hooks`). It runs a vendored kimi-code kernel (`@moonshot-ai/agent-core`) out of `~/Library/Application Support/kimi-desktop/daimon-share/daimon/runtime/kimi-code/config.toml`, so chat and agent turns both speak the same hooks protocol as the CLI. That file is rewritten every time Kimi's daimon runner starts, which drops the managed block; `KimiAppHookGuard` polls it and reinstalls whenever the block goes missing. Sessions from this target carry `--client-kind kimi-app` so they resolve to the `kimi-app` runtime profile and badge as "Kimi App".
 - VS Code-compatible IDE focus extension install / URI launch: `PingIsland/Services/Window/IDEExtensionInstaller.swift`, `PingIsland/Services/Window/TerminalSessionFocuser.swift`
 - Session list UI: `PingIsland/UI/Views/SessionListView.swift`
 - Client mascot system: `PingIsland/UI/Components/MascotView.swift`, `PingIsland/UI/Views/MascotSettingsView.swift`

--- a/PingIsland/Models/ClientProfile.swift
+++ b/PingIsland/Models/ClientProfile.swift
@@ -1131,6 +1131,44 @@ enum ClientProfileRegistry {
                 HookInstallEventDescriptor(name: "SessionEnd", templates: [.plain]),
             ]
         ),
+        // Kimi's desktop app runs a vendored kimi-code kernel (@moonshot-ai/agent-core)
+        // out of its own home, so its chat and agent turns speak the same hooks protocol
+        // as the CLI - only the config file lives inside the app's support directory.
+        // The app rewrites that file every time its daimon runner starts, so
+        // KimiAppHookGuard repairs the managed block whenever it disappears.
+        ManagedHookClientProfile(
+            id: "kimi-app-hooks",
+            title: "Kimi App",
+            subtitle: "管理 Kimi 桌面版内置 kimi-code 内核的 config.toml，聊天与 Agent 会话一并接入 Island",
+            installationKind: .tomlHooks,
+            alwaysVisibleInSettings: false,
+            logoAssetName: "KimiLogo",
+            prefersBundledLogoOverAppIcon: true,
+            localAppBundleIdentifiers: ["com.moonshot.kimichat"],
+            iconSymbolName: "moon.stars.fill",
+            configurationRelativePaths: [
+                KimiAppHookPaths.kernelConfigurationRelativePath
+            ],
+            bridgeSource: "kimi",
+            bridgeExtraArguments: [
+                "--client-kind", "kimi-app",
+                "--client-name", "Kimi App",
+                "--client-origin", "desktop",
+                "--client-originator", "Kimi App",
+                "--thread-source", "kimi-app-hooks"
+            ],
+            defaultEnabled: false,
+            brand: .kimi,
+            events: [
+                HookInstallEventDescriptor(name: "UserPromptSubmit", templates: [.plain]),
+                HookInstallEventDescriptor(name: "PreToolUse", templates: [.matcher("*")]),
+                HookInstallEventDescriptor(name: "PostToolUse", templates: [.matcher("*")]),
+                HookInstallEventDescriptor(name: "Notification", templates: [.matcher("*")]),
+                HookInstallEventDescriptor(name: "Stop", templates: [.plain]),
+                HookInstallEventDescriptor(name: "SessionStart", templates: [.plain]),
+                HookInstallEventDescriptor(name: "SessionEnd", templates: [.plain]),
+            ]
+        ),
     ]
 
     nonisolated static let runtimeProfiles: [SessionClientProfile] = [
@@ -1448,6 +1486,21 @@ enum ClientProfileRegistry {
             exactAliases: ["kimi", "kimi-cli", "kimi cli"],
             keywordAliases: ["kimi", "kimi cli"],
             bundleIdentifiers: []
+        ),
+        SessionClientProfile(
+            id: "kimi-app",
+            provider: .kimi,
+            family: .claudeHooks,
+            kind: .custom,
+            displayName: "Kimi App",
+            assistantLabelMode: .badgeLabel,
+            brand: .kimi,
+            defaultBundleIdentifier: "com.moonshot.kimichat",
+            defaultOrigin: "desktop",
+            recognizedKinds: ["kimi-app", "kimi_app", "kimi app", "kimi-desktop", "kimi desktop"],
+            exactAliases: ["kimi-app", "kimi app", "kimi-app-hooks", "kimi desktop"],
+            keywordAliases: ["kimi app", "kimi desktop"],
+            bundleIdentifiers: ["com.moonshot.kimichat"]
         ),
         SessionClientProfile(
             id: "codex-app",

--- a/PingIsland/Models/SessionEvent.swift
+++ b/PingIsland/Models/SessionEvent.swift
@@ -633,6 +633,16 @@ extension HookEvent {
             return .idle
         }
 
+        // The Kimi desktop app replays SessionStart for every conversation it
+        // restores when its kernel starts, so the event means "this conversation
+        // exists again", not "the user is waiting". Reading it as
+        // `waitingForInput` marked each restored conversation as needing
+        // attention, which permanently exempted it from the idle auto-archive.
+        // A real turn still arrives as UserPromptSubmit -> Stop.
+        if clientInfo.isKimiAppClient, event == "SessionStart" {
+            return .idle
+        }
+
         switch status {
         case "waiting_for_approval":
             if shouldSuppressApprovalHandling {

--- a/PingIsland/Models/SessionProvider.swift
+++ b/PingIsland/Models/SessionProvider.swift
@@ -197,13 +197,46 @@ struct SessionClientInfo: Codable, Equatable, Sendable {
             || originator?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "qwen-code"
     }
 
+    /// Both the Kimi CLI and the Kimi desktop app run the same kimi-code kernel, so
+    /// they share the hook quirks this flag gates: hook payloads carry no message
+    /// content, and `Stop` marks turn end rather than session end.
     nonisolated var isKimiClient: Bool {
-        profileID == "kimi"
-            || threadSource?.lowercased() == "kimi-hooks"
-            || name?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "kimi cli"
-            || name?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "kimi-cli"
-            || originator?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "kimi cli"
-            || originator?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "kimi-cli"
+        let kimiProfileIDs: Set<String> = ["kimi", "kimi-app"]
+        let kimiThreadSources: Set<String> = ["kimi-hooks", "kimi-app-hooks"]
+        let kimiLabels: Set<String> = ["kimi cli", "kimi-cli", "kimi app", "kimi-app"]
+
+        func normalized(_ value: String?) -> String? {
+            value?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        }
+
+        if let profileID, kimiProfileIDs.contains(profileID) { return true }
+        if let threadSource = normalized(threadSource), kimiThreadSources.contains(threadSource) { return true }
+        if let name = normalized(name), kimiLabels.contains(name) { return true }
+        if let originator = normalized(originator), kimiLabels.contains(originator) { return true }
+        return false
+    }
+
+    /// The Kimi desktop app specifically, as opposed to the Kimi CLI.
+    ///
+    /// The two share a kernel but not a lifecycle: the CLI is one process per
+    /// conversation and dies with it, while the app keeps a long-lived kernel and
+    /// replays `SessionStart` for every conversation it restores at launch. Only
+    /// the app needs the carve-outs that stop those restored conversations from
+    /// being read as live work waiting on the user.
+    nonisolated var isKimiAppClient: Bool {
+        let appProfileIDs: Set<String> = ["kimi-app"]
+        let appThreadSources: Set<String> = ["kimi-app-hooks"]
+        let appLabels: Set<String> = ["kimi app", "kimi-app", "kimi desktop", "kimi-desktop"]
+
+        func normalized(_ value: String?) -> String? {
+            value?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        }
+
+        if let profileID, appProfileIDs.contains(profileID) { return true }
+        if let threadSource = normalized(threadSource), appThreadSources.contains(threadSource) { return true }
+        if let name = normalized(name), appLabels.contains(name) { return true }
+        if let originator = normalized(originator), appLabels.contains(originator) { return true }
+        return false
     }
 
     nonisolated var isCodeBuddyCLIClient: Bool {

--- a/PingIsland/Models/SessionState.swift
+++ b/PingIsland/Models/SessionState.swift
@@ -446,7 +446,7 @@ struct SessionState: Equatable, Identifiable, Sendable {
             return true
         }
 
-        if isLikelyEmptyClaudeHookSessionForUI {
+        if isLikelyEmptyRestoredHookSessionForUI {
             return true
         }
 
@@ -457,6 +457,17 @@ struct SessionState: Equatable, Identifiable, Sendable {
         return isLikelyEmptyCodexPlaceholderForUI
     }
 
+    /// A hook row that announces a session which has no conversation behind it yet.
+    ///
+    /// Two clients do this, for the same reason and with the same consequence: a
+    /// long-lived host replays `SessionStart` for something it restored rather than
+    /// for something the user just started. Such a row must not outrank a real
+    /// session from another provider in the same workspace - and for the Kimi app,
+    /// which never reports a session end, it would otherwise sit in the list forever.
+    nonisolated var isLikelyEmptyRestoredHookSessionForUI: Bool {
+        isLikelyEmptyClaudeHookSessionForUI || isLikelyEmptyKimiAppHookSessionForUI
+    }
+
     /// Claude Code extensions can emit SessionStart when an idle panel is restored even though
     /// no conversation or transcript exists. Do not let that provisional hook row outrank a
     /// real session from another provider in the same workspace.
@@ -464,6 +475,31 @@ struct SessionState: Equatable, Identifiable, Sendable {
         guard provider == .claude else { return false }
         guard ingress == .hookBridge else { return false }
         guard clientInfo.isPlainClaudeCodeRouting else { return false }
+        guard isQuiescentHookRowWithoutContentForUI else { return false }
+        return hasNoReadableTranscriptForUI
+    }
+
+    /// The Kimi desktop app replays SessionStart for every conversation its kernel
+    /// restores at launch, so opening the app resurrects every conversation the user
+    /// ever had as a separate row.
+    ///
+    /// `.idle` is what separates those from real work, and it is deliberately
+    /// stricter than the Claude rule's `idle || waitingForInput`. Restoring a
+    /// conversation only ever emits SessionStart, which lands as `.idle`; reaching
+    /// `.waitingForInput` takes a `Stop`, which means a turn actually ran. Leaning on
+    /// the phase rather than on the row's text matters here because Kimi ships no
+    /// transcript - if a `UserPromptSubmit` ever arrived without its prompt text, a
+    /// content-only test would hide a conversation the user had just used.
+    nonisolated var isLikelyEmptyKimiAppHookSessionForUI: Bool {
+        guard clientInfo.isKimiAppClient else { return false }
+        guard ingress == .hookBridge else { return false }
+        guard phase == .idle else { return false }
+        guard isQuiescentHookRowWithoutContentForUI else { return false }
+        return hasNoReadableTranscriptForUI
+    }
+
+    /// Idle or turn-ended, with nothing the user could read in the row.
+    private nonisolated var isQuiescentHookRowWithoutContentForUI: Bool {
         guard phase == .idle || phase == .waitingForInput else { return false }
         guard chatItems.isEmpty else { return false }
         guard case nil = intervention else { return false }
@@ -471,12 +507,14 @@ struct SessionState: Equatable, Identifiable, Sendable {
         guard previewText?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty != false else {
             return false
         }
-        guard conversationInfo.summary?.isEmpty != false,
-              conversationInfo.firstUserMessage?.isEmpty != false,
-              conversationInfo.lastMessage?.isEmpty != false else {
-            return false
-        }
+        return conversationInfo.summary?.isEmpty != false
+            && conversationInfo.firstUserMessage?.isEmpty != false
+            && conversationInfo.lastMessage?.isEmpty != false
+    }
 
+    /// True when no transcript backs this session - either none was reported, or the
+    /// reported one is gone from disk.
+    private nonisolated var hasNoReadableTranscriptForUI: Bool {
         guard let transcriptPath = clientInfo.sessionFilePath?
             .trimmingCharacters(in: .whitespacesAndNewlines),
               !transcriptPath.isEmpty else {

--- a/PingIsland/Services/Hooks/HookInstaller.swift
+++ b/PingIsland/Services/Hooks/HookInstaller.swift
@@ -872,6 +872,13 @@ struct HookInstaller {
         uninstall(profile, persistPreference: true)
     }
 
+    /// Whether the user has this target switched on, regardless of whether its
+    /// configuration file currently carries the managed block. Used by guards that
+    /// repair configuration files rewritten by the host app.
+    static func isPreferred(_ profile: ManagedHookClientProfile) -> Bool {
+        preferredTargets().contains(profile.id)
+    }
+
     /// Check if any managed hooks are currently installed.
     static func isInstalled() -> Bool {
         ClientProfileRegistry.managedHookProfiles.contains { isInstalled($0) }

--- a/PingIsland/Services/Hooks/HookSocketServer.swift
+++ b/PingIsland/Services/Hooks/HookSocketServer.swift
@@ -722,7 +722,8 @@ private extension BridgeEnvelope {
             message: HookSocketServer.resolvedBridgeMessage(
                 eventType: eventType,
                 metadata: metadata,
-                preview: preview
+                preview: preview,
+                provider: provider.sessionProvider
             ),
             bridgeIntervention: intervention?.sessionIntervention(
                 fallbackID: metadata["tool_use_id"],
@@ -1196,6 +1197,23 @@ private extension BridgeProvider {
     }
 }
 
+/// Kimi spawns a throwaway kernel session per conversation purely to generate that
+/// conversation's title, and it fires the same hook lifecycle as a real turn. The
+/// kernel names those sessions with a `ctitle-` prefix (real conversations use
+/// `conv-`), so the prefix is a deterministic discriminator - no prompt-text
+/// heuristics, and it survives prompt wording or localization changes.
+enum KimiAuxiliaryHookFilter {
+    private nonisolated static let titleGenerationSessionPrefix = "ctitle-"
+
+    nonisolated static func isTitleGenerationSession(
+        provider: SessionProvider,
+        sessionId: String
+    ) -> Bool {
+        guard provider == .kimi else { return false }
+        return sessionId.hasPrefix(titleGenerationSessionPrefix)
+    }
+}
+
 struct CodexAuxiliaryHookFilter {
     private nonisolated static let titleGenerationPromptPrefix =
         "you are a helpful assistant. you will be presented with a user prompt"
@@ -1494,7 +1512,8 @@ class HookSocketServer {
     static func resolvedBridgeMessage(
         eventType: String,
         metadata: [String: String],
-        preview: String?
+        preview: String?,
+        provider: SessionProvider = .claude
     ) -> String? {
         func firstNonEmpty(_ values: String?...) -> String? {
             values.compactMap { value -> String? in
@@ -1512,11 +1531,39 @@ class HookSocketServer {
             )
         }
 
+        // Kimi's hooks carry the submitted turn under `prompt` rather than `message`,
+        // so without this fallback a Kimi session never learns its first user message
+        // and falls back to showing its working directory as the title.
+        if provider == .kimi, eventType == "UserPromptSubmit" {
+            return firstNonEmpty(
+                metadata["message"],
+                Self.plainTextFromPromptPayload(metadata["prompt"]),
+                preview
+            )
+        }
+
         return firstNonEmpty(
             metadata["message"],
             metadata["last_assistant_message"],
             preview
         )
+    }
+
+    /// Kimi sends the prompt as a JSON array of content blocks
+    /// (`[{"type":"text","text":"..."}]`). Fall back to the raw string when it is not
+    /// that shape, so an unexpected payload degrades to something readable.
+    nonisolated static func plainTextFromPromptPayload(_ payload: String?) -> String? {
+        guard let payload, !payload.isEmpty else { return nil }
+        guard let data = payload.data(using: .utf8),
+              let blocks = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+            return payload
+        }
+
+        let text = blocks
+            .compactMap { $0["text"] as? String }
+            .joined(separator: "\n")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return text.isEmpty ? nil : text
     }
 
     func start(onEvent: @escaping HookEventHandler, onPermissionFailure: PermissionFailureHandler? = nil) {
@@ -1888,6 +1935,17 @@ class HookSocketServer {
         if event.shouldFilterBeforeApprovalHandling {
             logger.debug(
                 "Filtering QoderWork non-responsive hook event=\(envelope.eventType, privacy: .public) session=\(event.sessionId.prefix(8), privacy: .public)"
+            )
+            sendAcknowledgement(for: envelope.id, to: clientSocket)
+            return
+        }
+
+        if KimiAuxiliaryHookFilter.isTitleGenerationSession(
+            provider: event.provider,
+            sessionId: event.sessionId
+        ) {
+            logger.debug(
+                "Ignoring Kimi title-generation hook event=\(envelope.eventType, privacy: .public) session=\(envelope.resolvedSessionID.prefix(8), privacy: .public)"
             )
             sendAcknowledgement(for: envelope.id, to: clientSocket)
             return

--- a/PingIsland/Services/Hooks/KimiAppHookGuard.swift
+++ b/PingIsland/Services/Hooks/KimiAppHookGuard.swift
@@ -1,0 +1,134 @@
+//
+//  KimiAppHookGuard.swift
+//  PingIsland
+//
+//  Kimi's desktop app runs a vendored kimi-code kernel out of its own support
+//  directory, and its daimon runner rewrites that kernel's config.toml every
+//  time it starts - which silently drops the managed hook block Island wrote.
+//  This guard re-applies the block whenever it goes missing so the integration
+//  survives a Kimi restart without the user having to toggle the target again.
+//
+//  Polling (rather than a file descriptor watch) is deliberate: the file is
+//  replaced, not modified in place, and a modification-date probe on a single
+//  small file is cheap enough to run on the same adaptive cadence the other
+//  desktop watchers use.
+//
+
+import Foundation
+import os.log
+
+private let logger = Logger(subsystem: "com.wudanwu.pingisland", category: "KimiAppHooks")
+
+enum KimiAppHookPaths {
+    /// Home-relative path of the `config.toml` read by the kimi-code kernel that
+    /// Kimi.app bundles. The CLI's own `~/.kimi-code/config.toml` is a separate
+    /// target, managed by the `kimi-hooks` profile.
+    nonisolated static let kernelConfigurationRelativePath =
+        "Library/Application Support/kimi-desktop/daimon-share/daimon/runtime/kimi-code/config.toml"
+
+    nonisolated static let managedProfileID = "kimi-app-hooks"
+}
+
+actor KimiAppHookGuard {
+    static let shared = KimiAppHookGuard()
+
+    /// Cadence used while the managed block is present and the file is stable.
+    private static let idleInterval: Duration = .seconds(30)
+    /// Cadence used when the target is disabled or Kimi.app has never run.
+    private static let dormantInterval: Duration = .seconds(120)
+    /// Cadence used right after a repair, to confirm the write survived.
+    private static let verifyInterval: Duration = .seconds(5)
+
+    enum CheckOutcome: Equatable {
+        /// The target is off, or the kernel config does not exist yet.
+        case dormant
+        /// The managed block is present, or the file has not changed since the last probe.
+        case intact
+        /// The managed block was missing and has just been rewritten.
+        case repaired
+    }
+
+    private var loopTask: Task<Void, Never>?
+    private var lastSeenModification: Date?
+
+    private init() {}
+
+    // MARK: - Lifecycle
+
+    func start() {
+        guard loopTask == nil else { return }
+        logger.info("Starting Kimi app hook guard")
+        loopTask = Task { [weak self] in
+            await self?.runLoop()
+        }
+    }
+
+    func stop() {
+        loopTask?.cancel()
+        loopTask = nil
+        lastSeenModification = nil
+        logger.info("Stopped Kimi app hook guard")
+    }
+
+    // MARK: - Loop
+
+    private func runLoop() async {
+        while !Task.isCancelled {
+            let outcome = checkOnce()
+            do {
+                try await Task.sleep(for: Self.interval(for: outcome))
+            } catch {
+                break
+            }
+        }
+    }
+
+    nonisolated static func interval(for outcome: CheckOutcome) -> Duration {
+        switch outcome {
+        case .dormant:
+            return dormantInterval
+        case .intact:
+            return idleInterval
+        case .repaired:
+            return verifyInterval
+        }
+    }
+
+    // MARK: - Repair
+
+    @discardableResult
+    func checkOnce() -> CheckOutcome {
+        guard let profile = ClientProfileRegistry.managedHookProfile(id: KimiAppHookPaths.managedProfileID),
+              HookInstaller.isPreferred(profile) else {
+            lastSeenModification = nil
+            return .dormant
+        }
+
+        let url = profile.primaryConfigurationURL
+        guard let modified = try? FileManager.default.attributesOfItem(atPath: url.path)[.modificationDate] as? Date else {
+            // Kimi.app has not created its kernel config yet; nothing to guard.
+            lastSeenModification = nil
+            return .dormant
+        }
+
+        // The daimon runner replaces the whole file, so an unchanged timestamp
+        // means the managed block cannot have been dropped since the last probe.
+        if let lastSeenModification, lastSeenModification == modified {
+            return .intact
+        }
+        lastSeenModification = modified
+
+        guard !HookInstaller.isInstalled(profile) else {
+            return .intact
+        }
+
+        logger.notice("Kimi app rewrote its kernel config; reinstalling managed hooks")
+        HookInstaller.install(profile)
+
+        // Re-read the timestamp so our own write does not look like a Kimi rewrite
+        // on the next probe.
+        lastSeenModification = try? FileManager.default
+            .attributesOfItem(atPath: url.path)[.modificationDate] as? Date
+        return .repaired
+    }
+}

--- a/PingIsland/Utilities/SessionTextSanitizer.swift
+++ b/PingIsland/Utilities/SessionTextSanitizer.swift
@@ -27,6 +27,14 @@ enum SessionTextSanitizer {
             with: "",
             options: .regularExpression
         )
+        // Kimi's desktop app prefixes every submitted turn with an awareness tag
+        // (`<meta awareness="low" timestamp="..." />`), which would otherwise become
+        // the session's visible title.
+        cleaned = cleaned.replacingOccurrences(
+            of: #"(?is)^\s*<meta\b[^>]*/>\s*"#,
+            with: "",
+            options: .regularExpression
+        )
         cleaned = cleaned.replacingOccurrences(
             of: #"(?is)<system-reminder>.*?</system-reminder>"#,
             with: " ",

--- a/PingIslandTests/KimiIntegrationTests.swift
+++ b/PingIslandTests/KimiIntegrationTests.swift
@@ -63,4 +63,370 @@ final class KimiIntegrationTests: XCTestCase {
         XCTAssertEqual(info.origin, "cli")
         XCTAssertEqual(info.profileID, "kimi")
     }
+
+    // MARK: - Kimi desktop app
+
+    func testKimiAppManagedProfileTargetsBundledKernelConfig() {
+        let profile = ClientProfileRegistry.managedHookProfile(id: "kimi-app-hooks")
+
+        XCTAssertNotNil(profile)
+        XCTAssertEqual(profile?.title, "Kimi App")
+        XCTAssertEqual(profile?.brand, .kimi)
+        XCTAssertEqual(profile?.installationKind, .tomlHooks)
+        XCTAssertEqual(profile?.bridgeSource, "kimi")
+        XCTAssertEqual(
+            profile?.configurationRelativePaths,
+            [KimiAppHookPaths.kernelConfigurationRelativePath]
+        )
+        XCTAssertEqual(
+            profile?.primaryConfigurationURL.path,
+            NSHomeDirectory()
+                + "/Library/Application Support/kimi-desktop/daimon-share/daimon/runtime/kimi-code/config.toml"
+        )
+        // Gated on Kimi.app being installed rather than always listed, unlike the CLI target.
+        XCTAssertEqual(profile?.alwaysVisibleInSettings, false)
+        XCTAssertEqual(profile?.localAppBundleIdentifiers, ["com.moonshot.kimichat"])
+    }
+
+    func testKimiAppProfileCoversSameEventsAsCLIProfile() {
+        let cli = ClientProfileRegistry.managedHookProfile(id: "kimi-hooks")
+        let app = ClientProfileRegistry.managedHookProfile(id: "kimi-app-hooks")
+
+        XCTAssertEqual(
+            app?.events.map(\.name),
+            cli?.events.map(\.name)
+        )
+    }
+
+    func testKimiAppProfileUsesDistinctConfigurationFromCLIProfile() {
+        let cli = ClientProfileRegistry.managedHookProfile(id: "kimi-hooks")
+        let app = ClientProfileRegistry.managedHookProfile(id: "kimi-app-hooks")
+
+        XCTAssertNotEqual(cli?.primaryConfigurationURL, app?.primaryConfigurationURL)
+        XCTAssertNotEqual(cli?.bridgeExtraArguments, app?.bridgeExtraArguments)
+    }
+
+    func testKimiAppRuntimeProfileOutranksCLIProfile() {
+        let profile = ClientProfileRegistry.matchRuntimeProfile(
+            provider: .kimi,
+            explicitKind: "kimi-app",
+            explicitName: "Kimi App",
+            explicitBundleIdentifier: "com.moonshot.kimichat",
+            terminalBundleIdentifier: nil,
+            origin: "desktop",
+            originator: "Kimi App",
+            threadSource: "kimi-app-hooks",
+            processName: nil
+        )
+
+        XCTAssertEqual(profile?.id, "kimi-app")
+        XCTAssertEqual(profile?.brand, .kimi)
+        XCTAssertEqual(profile?.displayName, "Kimi App")
+    }
+
+    func testKimiCLIRuntimeProfileStillWinsForTerminalSessions() {
+        let profile = ClientProfileRegistry.matchRuntimeProfile(
+            provider: .kimi,
+            explicitKind: "kimi",
+            explicitName: "Kimi CLI",
+            explicitBundleIdentifier: nil,
+            terminalBundleIdentifier: nil,
+            origin: "cli",
+            originator: "Kimi CLI",
+            threadSource: "kimi-hooks",
+            processName: nil
+        )
+
+        XCTAssertEqual(profile?.id, "kimi")
+    }
+
+    func testKimiAppSessionRendersDesktopBadge() {
+        let clientInfo = SessionClientInfo(
+            kind: .custom,
+            profileID: "kimi-app",
+            name: "Kimi App",
+            origin: "desktop",
+            originator: "Kimi App",
+            threadSource: "kimi-app-hooks"
+        )
+
+        XCTAssertEqual(clientInfo.brand, .kimi)
+        XCTAssertTrue(clientInfo.isKimiClient)
+        XCTAssertEqual(clientInfo.badgeLabel(for: .kimi), "Kimi App")
+        XCTAssertEqual(MascotKind(clientInfo: clientInfo, provider: .kimi), .kimi)
+    }
+
+    func testKimiAppHookGuardBacksOffWhenDormantAndVerifiesAfterRepair() {
+        XCTAssertEqual(KimiAppHookGuard.interval(for: .dormant), .seconds(120))
+        XCTAssertEqual(KimiAppHookGuard.interval(for: .intact), .seconds(30))
+        XCTAssertEqual(KimiAppHookGuard.interval(for: .repaired), .seconds(5))
+    }
+
+    // MARK: - Kimi desktop app auxiliary sessions and titles
+
+    func testKimiTitleGenerationSessionsAreFilteredOut() {
+        // Kimi names the throwaway title-generation session `ctitle-`, real ones `conv-`.
+        XCTAssertTrue(
+            KimiAuxiliaryHookFilter.isTitleGenerationSession(
+                provider: .kimi,
+                sessionId: "ctitle-01a05576-66de-7905-a2ca-5041e733576d"
+            )
+        )
+        XCTAssertFalse(
+            KimiAuxiliaryHookFilter.isTitleGenerationSession(
+                provider: .kimi,
+                sessionId: "conv-f2f3305fde511e8fa7dcb4d8"
+            )
+        )
+        // The CLI's own session ids must stay visible.
+        XCTAssertFalse(
+            KimiAuxiliaryHookFilter.isTitleGenerationSession(
+                provider: .kimi,
+                sessionId: "session_d4880dfd-aeb8-453e-ab5c-877d3b5d2c92"
+            )
+        )
+    }
+
+    func testTitleGenerationFilterIsScopedToKimi() {
+        // Other providers must not be filtered by a Kimi-specific naming convention.
+        XCTAssertFalse(
+            KimiAuxiliaryHookFilter.isTitleGenerationSession(
+                provider: .claude,
+                sessionId: "ctitle-01a05576-66de-7905-a2ca-5041e733576d"
+            )
+        )
+        XCTAssertFalse(
+            KimiAuxiliaryHookFilter.isTitleGenerationSession(
+                provider: .codex,
+                sessionId: "ctitle-01a05576-66de-7905-a2ca-5041e733576d"
+            )
+        )
+    }
+
+    func testKimiPromptPayloadDecodesToPlainText() {
+        XCTAssertEqual(
+            HookSocketServer.plainTextFromPromptPayload(
+                #"[{"text":"这个项目里面有啥东西啊？","type":"text"}]"#
+            ),
+            "这个项目里面有啥东西啊？"
+        )
+        // Multiple blocks join rather than dropping everything after the first.
+        XCTAssertEqual(
+            HookSocketServer.plainTextFromPromptPayload(
+                #"[{"type":"text","text":"first"},{"type":"text","text":"second"}]"#
+            ),
+            "first\nsecond"
+        )
+        // An unexpected shape degrades to the raw string instead of vanishing.
+        XCTAssertEqual(HookSocketServer.plainTextFromPromptPayload("plain prompt"), "plain prompt")
+        XCTAssertNil(HookSocketServer.plainTextFromPromptPayload(nil))
+        XCTAssertNil(HookSocketServer.plainTextFromPromptPayload(""))
+    }
+
+    func testKimiUserPromptSubmitResolvesMessageFromPromptMetadata() {
+        let metadata = ["prompt": #"[{"text":"给我说说 open vibe island 是什么","type":"text"}]"#]
+
+        XCTAssertEqual(
+            HookSocketServer.resolvedBridgeMessage(
+                eventType: "UserPromptSubmit",
+                metadata: metadata,
+                preview: nil,
+                provider: .kimi
+            ),
+            "给我说说 open vibe island 是什么"
+        )
+
+        // Other providers keep their existing resolution order untouched.
+        XCTAssertNil(
+            HookSocketServer.resolvedBridgeMessage(
+                eventType: "UserPromptSubmit",
+                metadata: metadata,
+                preview: nil,
+                provider: .claude
+            )
+        )
+    }
+
+    // MARK: - Kimi desktop app session lifecycle
+
+    private func kimiAppClientInfo(sessionFilePath: String? = nil) -> SessionClientInfo {
+        SessionClientInfo(
+            kind: .custom,
+            profileID: "kimi-app",
+            name: "Kimi App",
+            origin: "desktop",
+            originator: "Kimi App",
+            threadSource: "kimi-app-hooks",
+            sessionFilePath: sessionFilePath
+        )
+    }
+
+    private func kimiCLIClientInfo() -> SessionClientInfo {
+        SessionClientInfo(
+            kind: .custom,
+            profileID: "kimi",
+            name: "Kimi CLI",
+            origin: "cli",
+            originator: "Kimi CLI",
+            threadSource: "kimi-hooks"
+        )
+    }
+
+    private func kimiHookEvent(
+        sessionId: String,
+        event: String,
+        status: String,
+        clientInfo: SessionClientInfo,
+        message: String? = nil
+    ) -> HookEvent {
+        HookEvent(
+            sessionId: sessionId,
+            cwd: "/Users/tester/Documents/kimi/tasks/2026-08-31/01-10-52-c34eee5f",
+            event: event,
+            status: status,
+            provider: .kimi,
+            clientInfo: clientInfo,
+            pid: nil,
+            tty: nil,
+            tool: nil,
+            toolInput: nil,
+            toolUseId: nil,
+            notificationType: nil,
+            message: message
+        )
+    }
+
+    func testKimiAppClientIsDistinguishedFromTheCLI() {
+        XCTAssertTrue(kimiAppClientInfo().isKimiAppClient)
+        XCTAssertFalse(kimiCLIClientInfo().isKimiAppClient)
+        // Both still share the kernel-level quirks flag.
+        XCTAssertTrue(kimiAppClientInfo().isKimiClient)
+        XCTAssertTrue(kimiCLIClientInfo().isKimiClient)
+    }
+
+    /// The app replays SessionStart for every conversation its kernel restores at
+    /// launch. Read as `waitingForInput`, each replay marked a conversation as
+    /// needing attention, which exempted it from the idle auto-archive forever.
+    func testKimiAppSessionStartIsIdleRatherThanWaitingForInput() {
+        let event = kimiHookEvent(
+            sessionId: "conv-8d6",
+            event: "SessionStart",
+            status: "waiting_for_input",
+            clientInfo: kimiAppClientInfo()
+        )
+
+        XCTAssertEqual(event.determinePhase(), .idle)
+        XCTAssertFalse(event.determinePhase().needsAttention)
+    }
+
+    func testKimiAppStopStillWaitsForInput() {
+        let event = kimiHookEvent(
+            sessionId: "conv-8d6",
+            event: "Stop",
+            status: "waiting_for_input",
+            clientInfo: kimiAppClientInfo()
+        )
+
+        XCTAssertEqual(event.determinePhase(), .waitingForInput)
+    }
+
+    func testKimiCLISessionStartKeepsWaitingForInput() {
+        let event = kimiHookEvent(
+            sessionId: "session_d4880dfd",
+            event: "SessionStart",
+            status: "waiting_for_input",
+            clientInfo: kimiCLIClientInfo()
+        )
+
+        XCTAssertEqual(event.determinePhase(), .waitingForInput)
+    }
+
+    func testRestoredKimiAppConversationHidesFromPrimaryUI() {
+        let session = SessionState(
+            sessionId: "conv-8d6",
+            cwd: "/Users/tester/Documents/kimi/tasks/2026-08-31/01-10-52-c34eee5f",
+            provider: .kimi,
+            clientInfo: kimiAppClientInfo(),
+            ingress: .hookBridge,
+            phase: .idle,
+            lastActivity: Date()
+        )
+
+        XCTAssertTrue(session.isLikelyEmptyKimiAppHookSessionForUI)
+        XCTAssertTrue(session.isLikelyEmptyRestoredHookSessionForUI)
+        XCTAssertTrue(session.shouldHideFromPrimaryUI)
+    }
+
+    /// Kimi ships no transcript, so `UserPromptSubmit` filling in `firstUserMessage`
+    /// is the only evidence a conversation was ever used. That has to be enough to
+    /// keep the row visible once the turn ends.
+    func testPromptedKimiAppConversationStaysVisibleAfterItsTurnEnds() {
+        let session = SessionState(
+            sessionId: "conv-f2f",
+            cwd: "/Users/tester/Documents/kimi/tasks/2026-08-31/01-36-57-ce394fd7",
+            provider: .kimi,
+            clientInfo: kimiAppClientInfo(),
+            ingress: .hookBridge,
+            phase: .waitingForInput,
+            conversationInfo: ConversationInfo(
+                summary: nil,
+                lastMessage: nil,
+                lastMessageRole: "assistant",
+                lastToolName: nil,
+                firstUserMessage: "给我说说 open vibe island 是什么",
+                lastUserMessageDate: Date()
+            ),
+            lastActivity: Date()
+        )
+
+        XCTAssertFalse(session.isLikelyEmptyKimiAppHookSessionForUI)
+        XCTAssertFalse(session.shouldHideFromPrimaryUI)
+    }
+
+    /// A `Stop` is proof a turn ran, whatever the row ended up holding. Kimi ships no
+    /// transcript, so the row can legitimately be textless - the phase, not the text,
+    /// is what says the conversation was used.
+    func testKimiAppConversationThatRanATurnStaysVisibleEvenWithoutRowText() {
+        let session = SessionState(
+            sessionId: "conv-9c0",
+            cwd: "/Users/tester/Documents/kimi/tasks/2026-08-31/01-36-57-ce394fd7",
+            provider: .kimi,
+            clientInfo: kimiAppClientInfo(),
+            ingress: .hookBridge,
+            phase: .waitingForInput,
+            lastActivity: Date()
+        )
+
+        XCTAssertFalse(session.isLikelyEmptyKimiAppHookSessionForUI)
+        XCTAssertFalse(session.shouldHideFromPrimaryUI)
+    }
+
+    func testKimiCLISessionIsNotTreatedAsARestoredAppRow() {
+        let session = SessionState(
+            sessionId: "session_d4880dfd",
+            cwd: "/Users/tester/Coding Project/demo",
+            provider: .kimi,
+            clientInfo: kimiCLIClientInfo(),
+            ingress: .hookBridge,
+            phase: .waitingForInput,
+            lastActivity: Date()
+        )
+
+        XCTAssertFalse(session.isLikelyEmptyKimiAppHookSessionForUI)
+        XCTAssertFalse(session.isLikelyEmptyRestoredHookSessionForUI)
+    }
+
+    func testKimiDesktopAwarenessTagIsStrippedFromDisplayText() {
+        let raw = "<meta awareness=\"low\" timestamp=\"2026-08-31 03:36\" />\n给我说说open vibe island是什么"
+
+        XCTAssertEqual(
+            SessionTextSanitizer.sanitizedDisplayText(raw),
+            "给我说说open vibe island是什么"
+        )
+        // A meta tag that is not a leading injected prefix stays put.
+        XCTAssertEqual(
+            SessionTextSanitizer.sanitizedDisplayText("compare <meta a=\"1\" /> tags"),
+            "compare <meta a=\"1\" /> tags"
+        )
+    }
 }

--- a/PingIslandTests/TOMLHookInstallerTests.swift
+++ b/PingIslandTests/TOMLHookInstallerTests.swift
@@ -168,4 +168,109 @@ final class TOMLHookInstallerTests: XCTestCase {
         XCTAssertTrue(rebuilt.contains("base_url"))
         XCTAssertFalse(rebuilt.contains("ping-island-bridge"))
     }
+
+    /// Kimi's desktop app keeps provider credentials and model definitions in the same
+    /// config.toml Island writes hooks into, so the merge must be strictly additive.
+    func testTOMLRebuildPreservesKimiAppKernelConfiguration() {
+        let existing = """
+        default_model = "k2d6-agent"
+        extra_skill_dirs = [ "/Users/test/Library/Application Support/kimi-desktop/daimon-share/daimon/skills" ]
+
+        [thinking]
+        enabled = true
+        effort = "max"
+
+        [loop_control]
+        max_steps_per_turn = 100
+
+        [providers.daimon-kimi-code]
+        type = "kimi"
+        api_key = "kernel-credential"
+        base_url = "https://agent-gw.kimi.com/coding/v1"
+
+        [models.k2d6-agent]
+        provider = "daimon-kimi-code"
+        model = "k2d6-agent"
+        max_context_size = 262144
+        capabilities = [ "thinking", "image_in", "video_in" ]
+        """
+
+        let managedHooks = [
+            TOMLHookConfigParser.TOMLHookEntry(
+                event: "Stop",
+                command: "/Users/test/.ping-island/bin/ping-island-bridge --source kimi --client-kind kimi-app",
+                matcher: "",
+                timeout: nil
+            )
+        ]
+
+        let rebuilt = TOMLHookConfigParser.rebuild(
+            segments: TOMLHookConfigParser.parse(existing),
+            newHooks: managedHooks
+        )
+
+        // Every kernel setting the app owns survives the merge.
+        XCTAssertTrue(rebuilt.contains("default_model = \"k2d6-agent\""))
+        XCTAssertTrue(rebuilt.contains("api_key = \"kernel-credential\""))
+        XCTAssertTrue(rebuilt.contains("base_url = \"https://agent-gw.kimi.com/coding/v1\""))
+        XCTAssertTrue(rebuilt.contains("[models.k2d6-agent]"))
+        XCTAssertTrue(rebuilt.contains("max_steps_per_turn = 100"))
+        XCTAssertTrue(rebuilt.contains("capabilities = [ \"thinking\", \"image_in\", \"video_in\" ]"))
+        XCTAssertTrue(TOMLHookConfigParser.containsManagedHooks(rebuilt))
+    }
+
+    /// The guard reinstalls after every Kimi rewrite, so repeated installs must not
+    /// stack duplicate managed blocks on top of each other.
+    func testTOMLRebuildIsIdempotentForRepeatedManagedInstalls() {
+        let managedHooks = [
+            TOMLHookConfigParser.TOMLHookEntry(
+                event: "Stop",
+                command: "/Users/test/.ping-island/bin/ping-island-bridge --source kimi --client-kind kimi-app",
+                matcher: "",
+                timeout: nil
+            ),
+            TOMLHookConfigParser.TOMLHookEntry(
+                event: "SessionStart",
+                command: "/Users/test/.ping-island/bin/ping-island-bridge --source kimi --client-kind kimi-app",
+                matcher: "",
+                timeout: nil
+            )
+        ]
+
+        var content = "default_model = \"k2d6-agent\"\n"
+        for _ in 0..<3 {
+            content = TOMLHookConfigParser.rebuild(
+                segments: TOMLHookConfigParser.parse(content),
+                newHooks: managedHooks
+            )
+        }
+
+        XCTAssertEqual(content.components(separatedBy: "[[hooks]]").count - 1, managedHooks.count)
+        XCTAssertTrue(content.contains("default_model = \"k2d6-agent\""))
+    }
+
+    /// A hook the user added by hand must outlive an Island install.
+    func testTOMLRebuildKeepsUserAuthoredHooks() {
+        let existing = """
+        [[hooks]]
+        event = "PreToolUse"
+        command = "/usr/local/bin/safety-check.sh"
+        matcher = "Shell"
+        """
+
+        let rebuilt = TOMLHookConfigParser.rebuild(
+            segments: TOMLHookConfigParser.parse(existing),
+            newHooks: [
+                TOMLHookConfigParser.TOMLHookEntry(
+                    event: "Stop",
+                    command: "/Users/test/.ping-island/bin/ping-island-bridge --source kimi",
+                    matcher: "",
+                    timeout: nil
+                )
+            ]
+        )
+
+        XCTAssertTrue(rebuilt.contains("/usr/local/bin/safety-check.sh"))
+        XCTAssertTrue(TOMLHookConfigParser.containsManagedHooks(rebuilt))
+    }
 }

--- a/Prototype/Sources/IslandShared/HookPayloadMapper.swift
+++ b/Prototype/Sources/IslandShared/HookPayloadMapper.swift
@@ -488,6 +488,15 @@ public enum HookPayloadMapper {
            terminalContext.terminalBundleID == nil {
             return SessionStatus(kind: .idle)
         }
+        // Kimi's desktop app keeps one long-lived kernel and replays SessionStart
+        // for every conversation it restores at launch, so the event announces a
+        // conversation, not a turn waiting on the user. The shared default maps
+        // SessionStart to `waiting_for_input`, which left every restored Kimi
+        // conversation permanently marked as needing attention. The CLI is
+        // unaffected: it is one process per conversation and ends with it.
+        if isKimiDesktopHookClient(clientKind), eventType == "SessionStart" {
+            return SessionStatus(kind: .idle)
+        }
         let lowered = eventType.lowercased()
         if lowered.contains("permission") || lowered.contains("approval") {
             return SessionStatus(kind: .waitingForApproval)
@@ -1671,6 +1680,18 @@ public enum HookPayloadMapper {
         switch clientKind {
         case "gemini", "gemini-cli", "gemini_cli", "gemini cli",
              "antigravity", "antigravity-cli", "antigravity_cli", "antigravity cli", "agy":
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// The Kimi desktop app, as opposed to the Kimi CLI. Mirrors the
+    /// `kimi-app` runtime profile's recognized kinds.
+    private static func isKimiDesktopHookClient(_ clientKind: String?) -> Bool {
+        guard let clientKind else { return false }
+        switch clientKind {
+        case "kimi-app", "kimi_app", "kimi app", "kimi-desktop", "kimi desktop":
             return true
         default:
             return false

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Ping Island focuses on the moments that actually interrupt coding flow, then kee
 | Pi Agent | Official extension under `~/.pi/agent/extensions/ping_island/` | Pi Agent terminal host | Extension event forwarding, client-aware session tracking, terminal-cloud mascot |
 | Qwen Code | Official hooks in `~/.qwen/settings.json` | Compatible terminal hosts and remote SSH sessions | Permission prompts, notification popups, stop/session-end handling, remote hook forwarding |
 | Kimi CLI | Official `[[hooks]]` entries in `~/.kimi/config.toml` | Compatible terminal hosts | Tool activity, notifications, turn completion, session-end handling |
+| Kimi App | Official `[[hooks]]` entries in the bundled kimi-code kernel config under `~/Library/Application Support/kimi-desktop/` | Kimi desktop app | Chat and agent turns from the desktop app, with automatic repair when Kimi rewrites its kernel config |
 | OpenClaw | Managed internal hooks plus local transcript refresh | OpenClaw terminal host | Fast hook status, transcript backfill, message/session state |
 | OpenCode | Generated plugin file under `~/.config/opencode/plugins/` | OpenCode app and terminal host | Plugin event forwarding into the shared Island UI |
 | Cursor | Claude-compatible hooks plus optional VS Code-compatible focus extension | Cursor project window and active terminal | IDE routing, terminal focus, Claude-family session tracking |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -166,6 +166,7 @@ Ping Island 关注的，是那些真正会打断编码节奏的时刻，并把�
 | Pi Agent | `~/.pi/agent/extensions/ping_island/` 下的官方 extension | Pi Agent 终端宿主 | Extension 事件转发、客户端识别、终端云团宠物 |
 | Qwen Code | `~/.qwen/settings.json` 中的官方 hooks | 兼容终端宿主、远程 SSH 会话 | 权限追问、通知弹窗、Stop / SessionEnd 处理、远程 hooks 转发 |
 | Kimi CLI | `~/.kimi/config.toml` 中的官方 `[[hooks]]` | 兼容终端宿主 | 工具活动、通知、回合完成、会话结束处理 |
+| Kimi App | `~/Library/Application Support/kimi-desktop/` 下内置 kimi-code 内核 config 中的官方 `[[hooks]]` | Kimi 桌面版 | 桌面版聊天与 Agent 回合，Kimi 重写内核配置后自动补装 |
 | OpenClaw | 托管 internal hooks + 本地 transcript 回填 | OpenClaw 终端宿主 | 快速 hook 状态、完整对话回填、消息 / 会话状态 |
 | OpenCode | `~/.config/opencode/plugins/` 下的托管插件文件 | OpenCode 应用、终端宿主 | 插件事件转发到同一套 Island UI |
 | Cursor | Claude 兼容 hooks + 可选 VS Code 兼容聚焦扩展 | Cursor 项目窗口、活跃终端 | IDE 路由、终端精准聚焦、Claude 家族会话跟踪 |


### PR DESCRIPTION
## 背景

Kimi.app 内置了一份 kimi-code 内核（`@moonshot-ai/agent-core`），跑在自己的支持目录里。它的聊天和 Agent 轮次说的是与 Kimi CLI 完全相同的 hooks 协议，所以只要能把 hook 装进去，桌面版的会话就能直接接入 Island。

两个障碍：它的 `config.toml` 不在 `~/.kimi-code/` 而在应用支持目录下；并且每次 daimon runner 启动都会重写那个文件，把 Island 写入的托管块抹掉。

## 改动

新增 `kimi-app-hooks` 目标，指向内置内核的 config：

```
~/Library/Application Support/kimi-desktop/daimon-share/daimon/runtime/kimi-code/config.toml
```

它与现有的 `kimi-hooks`（CLI，`~/.kimi-code/config.toml`）是两个独立目标，事件集合相同，可以分别开关。`KimiAppHookGuard` 在托管块消失时把它补回去，按其他桌面版 watcher 相同的自适应节奏轮询——这个文件是被整体替换而不是原地修改的，对单个小文件做一次修改时间探测足够便宜，不值得上 FSEvents。

接上之后，桌面版还有三处与 CLI 不同的行为，各自单独处理：

**一次性标题会话**：每开一个会话，内核会额外起一个专门用来生成标题的会话，走完整套 hook 生命周期，于是 Island 里每条真实会话旁边都会多出一条空壳。这类会话的 id 带 `ctitle-` 前缀（真实会话是 `conv-`），按前缀过滤即可——不依赖 prompt 文本启发式，也不会因为措辞或语言变化而失效。

**启动时重放 SessionStart**：内核是长期存活的，启动时会为每一个恢复的会话重放 `SessionStart`。该事件表示"这个会话又存在了"，而不是"用户在等你"。默认映射会把它读成 `waiting_for_input`，结果是打开 Kimi 就把历史上所有会话复活成待处理项。桌面版的 `SessionStart` 因此映射为 `idle`，真实轮次仍然走 `UserPromptSubmit` → `Stop`；恢复出来的空会话同时从主列表隐去，否则由于 Kimi 从不上报会话结束，它们会永远留在列表里。

**prompt 载荷格式**：prompt 以 JSON content-block 数组放在 `prompt` 字段（而非 `message`），并且前面带一个 `<meta awareness=... />` 标签。两者都做了解析与剥离，否则 Kimi 会话学不到自己的第一条用户消息，标题会退化成显示工作目录。

## 测试

- `PingIslandTests` 全量通过（含新增的 `KimiIntegrationTests`，覆盖目标配置、profile 优先级、标题会话过滤、prompt 解码、SessionStart 语义、guard 的退避与修复后校验）
- `TOMLHookInstallerTests` 新增用例：托管安装不破坏内核 config 的其余内容、重复安装幂等、保留用户自写的 hooks
- Prototype 套件 146 tests 通过
- 在装有 Kimi 桌面版的机器上实机验证过聊天与 Agent 两种会话