### PR TITLE
feat(power): keep the Mac awake while agent sessions are working

### DIFF
--- a/PingIsland/App/AppDelegate.swift
+++ b/PingIsland/App/AppDelegate.swift
@@ -29,6 +29,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         if !launchConfiguration.isRunningTests {
             UpdateManager.shared.start()
             UserIdleAutoProtection.shared.start()
+            // Holds a system power assertion while agent sessions are working.
+            // Off by default; see KeepAwakeMode.
+            _ = KeepAwakeController.shared
             Task {
                 await SoundPackCatalog.shared.refreshInBackground()
             }

--- a/PingIsland/Core/KeepAwakeController.swift
+++ b/PingIsland/Core/KeepAwakeController.swift
@@ -1,0 +1,140 @@
+//
+//  KeepAwakeController.swift
+//  PingIsland
+//
+//  Wires session state and the user's KeepAwakeMode into a single power assertion.
+//  The decision itself lives in KeepAwakePolicy so it stays unit testable; this type
+//  only gathers inputs, drives the grace-window re-evaluation, and applies the result.
+//
+
+import Combine
+import Foundation
+import IOKit.ps
+
+@MainActor
+final class KeepAwakeController: ObservableObject {
+    static let shared = KeepAwakeController()
+
+    @Published private(set) var decision: KeepAwakeDecision = .release(.disabled)
+
+    private let assertion: SleepAssertion
+    private var cancellables = Set<AnyCancellable>()
+    private var lastWorkingAt: Date?
+    private var hasWorkingSession = false
+    private var graceTimer: Timer?
+
+    /// Re-evaluate this often while inside the grace window, so the assertion is
+    /// dropped promptly once the window expires rather than waiting for the next
+    /// session event, which may never come.
+    private static let graceTickInterval: TimeInterval = 15
+
+    init(
+        assertion: SleepAssertion = SleepAssertion(),
+        observeSessions: Bool = true
+    ) {
+        self.assertion = assertion
+
+        guard observeSessions else { return }
+
+        SessionStore.shared.sessionsPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] sessions in
+                self?.updateSessions(sessions)
+            }
+            .store(in: &cancellables)
+
+        AppSettingsStore.shared.$keepAwakeMode
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.reevaluate()
+            }
+            .store(in: &cancellables)
+    }
+
+    deinit {
+        graceTimer?.invalidate()
+    }
+
+    private func updateSessions(_ sessions: [SessionState]) {
+        // `phase.isActive` is .processing/.compacting only. Deliberately not
+        // `needsAttention`: a session waiting on the user will not resume by itself.
+        hasWorkingSession = sessions.contains { $0.phase.isActive }
+        if hasWorkingSession {
+            lastWorkingAt = Date()
+        }
+        reevaluate()
+    }
+
+    private func reevaluate() {
+        let power = Self.currentPowerState()
+        let hasWorking = hasWorkingSession
+
+        var inputs = KeepAwakeInputs.empty
+        inputs.mode = AppSettingsStore.shared.keepAwakeMode
+        inputs.hasWorkingSession = hasWorking
+        inputs.secondsSinceWorking = lastWorkingAt.map { Date().timeIntervalSince($0) }
+        inputs.isOnBattery = power.isOnBattery
+        inputs.batteryPercent = power.percent
+
+        let next = KeepAwakePolicy.decide(for: inputs)
+        if next != decision {
+            decision = next
+        }
+        assertion.apply(next)
+        updateGraceTimer(isHolding: next.isHolding, hasWorking: hasWorking)
+    }
+
+    /// Only tick while holding without an actively working session, i.e. inside the
+    /// grace window. Holding because work is in progress needs no timer, and releasing
+    /// needs none either.
+    private func updateGraceTimer(isHolding: Bool, hasWorking: Bool) {
+        let needsTimer = isHolding && !hasWorking
+        if needsTimer {
+            guard graceTimer == nil else { return }
+            graceTimer = Timer.scheduledTimer(
+                withTimeInterval: Self.graceTickInterval,
+                repeats: true
+            ) { [weak self] _ in
+                Task { @MainActor in self?.reevaluate() }
+            }
+        } else {
+            graceTimer?.invalidate()
+            graceTimer = nil
+        }
+    }
+
+    // MARK: - Power source
+
+    struct PowerState: Equatable {
+        var isOnBattery: Bool
+        var percent: Int?
+    }
+
+    nonisolated static func currentPowerState() -> PowerState {
+        guard let snapshot = IOPSCopyPowerSourcesInfo()?.takeRetainedValue(),
+              let sources = IOPSCopyPowerSourcesList(snapshot)?.takeRetainedValue() as? [CFTypeRef]
+        else {
+            return PowerState(isOnBattery: false, percent: nil)
+        }
+
+        for source in sources {
+            guard let description = IOPSGetPowerSourceDescription(snapshot, source)?
+                .takeUnretainedValue() as? [String: Any] else { continue }
+
+            let state = description[kIOPSPowerSourceStateKey] as? String
+            let isOnBattery = (state == kIOPSBatteryPowerValue)
+
+            var percent: Int?
+            if let current = description[kIOPSCurrentCapacityKey] as? Int,
+               let maximum = description[kIOPSMaxCapacityKey] as? Int,
+               maximum > 0 {
+                percent = Int((Double(current) / Double(maximum)) * 100.0)
+            }
+
+            return PowerState(isOnBattery: isOnBattery, percent: percent)
+        }
+
+        // Desktops report no power sources; treat that as wall power.
+        return PowerState(isOnBattery: false, percent: nil)
+    }
+}

--- a/PingIsland/Core/KeepAwakePolicy.swift
+++ b/PingIsland/Core/KeepAwakePolicy.swift
@@ -1,0 +1,114 @@
+//
+//  KeepAwakePolicy.swift
+//  PingIsland
+//
+//  Decides whether the machine should be kept awake based on session state.
+//  Kept pure and synchronous so the decision can be unit tested without IOKit,
+//  timers, or a running app, in the same spirit as EnergyGovernor.resolvedMode.
+//
+
+import Foundation
+
+/// How aggressively PingIsland keeps the machine awake.
+enum KeepAwakeMode: String, CaseIterable, Codable, Sendable {
+    /// Never take a power assertion. Default; matches behaviour before this feature.
+    case off
+
+    /// Take an assertion only while a session is actually working.
+    case auto
+
+    /// Take an assertion for as long as the app runs, regardless of session state.
+    /// This is the `caffeinate` equivalent and is an explicit user choice, so it
+    /// deliberately ignores the battery floor.
+    case always
+}
+
+struct KeepAwakeInputs: Equatable, Sendable {
+    var mode: KeepAwakeMode = .off
+
+    /// True when some session is in `.processing` or `.compacting`.
+    ///
+    /// Deliberately NOT `EnergyMode.active`: `resolvedMode` returns `.active` for
+    /// `hasActiveSession || hasAttentionSession`, and the attention branch is exactly
+    /// the case that must release. A session sitting on `.waitingForInput` or
+    /// `.waitingForApproval` will not resume on its own, so holding the machine awake
+    /// for it burns battery until the user returns and wakes the machine anyway.
+    var hasWorkingSession: Bool = false
+
+    /// Seconds since a session was last observed working; nil when never observed.
+    var secondsSinceWorking: TimeInterval?
+
+    var isOnBattery: Bool = false
+
+    /// 0-100. Nil when unknown or the machine has no battery.
+    var batteryPercent: Int?
+
+    static let empty = KeepAwakeInputs()
+}
+
+enum KeepAwakeHoldReason: Equatable, Sendable {
+    case alwaysOn
+    case sessionWorking
+    case graceWindow
+}
+
+enum KeepAwakeReleaseReason: Equatable, Sendable {
+    case disabled
+    case nothingWorking
+    case batteryFloor(percent: Int)
+}
+
+enum KeepAwakeDecision: Equatable, Sendable {
+    case hold(KeepAwakeHoldReason)
+    case release(KeepAwakeReleaseReason)
+
+    var isHolding: Bool {
+        if case .hold = self { return true }
+        return false
+    }
+}
+
+enum KeepAwakePolicy {
+    /// Keep holding for this long after the last working observation.
+    ///
+    /// Without a grace window the assertion flaps once per model-generation gap: the
+    /// pause between one tool finishing and the next starting is indistinguishable
+    /// from idle. Measured on an equivalent Windows implementation, no grace window
+    /// produced 4 acquire/release cycles in 3 minutes.
+    static let defaultGraceSeconds: TimeInterval = 120
+
+    /// Below this charge, `.auto` stops holding. An unattended overnight run can
+    /// otherwise flatten the machine, losing the work the assertion was protecting.
+    static let defaultBatteryFloorPercent = 35
+
+    nonisolated static func decide(
+        for inputs: KeepAwakeInputs,
+        graceSeconds: TimeInterval = defaultGraceSeconds,
+        batteryFloorPercent: Int = defaultBatteryFloorPercent
+    ) -> KeepAwakeDecision {
+        switch inputs.mode {
+        case .off:
+            return .release(.disabled)
+        case .always:
+            return .hold(.alwaysOn)
+        case .auto:
+            break
+        }
+
+        if inputs.isOnBattery,
+           let percent = inputs.batteryPercent,
+           percent <= batteryFloorPercent {
+            return .release(.batteryFloor(percent: percent))
+        }
+
+        if inputs.hasWorkingSession {
+            return .hold(.sessionWorking)
+        }
+
+        if let elapsed = inputs.secondsSinceWorking, elapsed < graceSeconds {
+            return .hold(.graceWindow)
+        }
+
+        return .release(.nothingWorking)
+    }
+}

--- a/PingIsland/Core/Settings.swift
+++ b/PingIsland/Core/Settings.swift
@@ -392,6 +392,7 @@ final class AppSettingsStore: ObservableObject {
 
     private enum Keys {
         static let appLanguage = "appLanguage"
+        static let keepAwakeMode = "keepAwakeMode"
         static let notificationSound = "notificationSound"
         static let soundEnabled = "soundEnabled"
         static let soundVolume = "soundVolume"
@@ -465,6 +466,14 @@ final class AppSettingsStore: ObservableObject {
         didSet {
             guard !isBootstrapping else { return }
             defaults.set(appLanguage.rawValue, forKey: Keys.appLanguage)
+        }
+    }
+
+    /// Whether the machine should be kept awake while agent sessions are working.
+    @Published var keepAwakeMode: KeepAwakeMode {
+        didSet {
+            guard !isBootstrapping else { return }
+            defaults.set(keepAwakeMode.rawValue, forKey: Keys.keepAwakeMode)
         }
     }
 
@@ -1353,6 +1362,7 @@ final class AppSettingsStore: ObservableObject {
         self.subagentVisibilityModeStorage = .visible
         let persistedKeys = Set(defaults.dictionaryRepresentation().keys)
         let appLanguageRaw = defaults.string(forKey: Keys.appLanguage)
+        let keepAwakeModeRaw = defaults.string(forKey: Keys.keepAwakeMode)
         let legacyNotificationSound = NotificationSound(
             rawValue: defaults.string(forKey: Keys.notificationSound) ?? ""
         ) ?? .blow
@@ -1411,6 +1421,7 @@ final class AppSettingsStore: ObservableObject {
             : nil
 
         _appLanguage = Published(initialValue: AppLanguage(rawValue: appLanguageRaw ?? "") ?? .system)
+        _keepAwakeMode = Published(initialValue: KeepAwakeMode(rawValue: keepAwakeModeRaw ?? "") ?? .off)
         _notificationSound = Published(initialValue: legacyNotificationSound)
         _soundEnabled = Published(initialValue: Self.boolValue(
             from: defaults,

--- a/PingIsland/Core/SleepAssertion.swift
+++ b/PingIsland/Core/SleepAssertion.swift
@@ -1,0 +1,71 @@
+//
+//  SleepAssertion.swift
+//  PingIsland
+//
+//  Thin wrapper around a single IOKit power assertion.
+//
+//  System sleep only, never display sleep: an agent working in the background has
+//  nothing to show, and holding the display awake is the larger battery cost of the
+//  two. The assertion is named so it is identifiable in `pmset -g assertions`.
+//
+
+import Foundation
+import IOKit.pwr_mgt
+
+final class SleepAssertion {
+    private var assertionID = IOPMAssertionID(0)
+    private(set) var isHeld = false
+
+    private let name: String
+
+    init(name: String = "PingIsland: agent session working") {
+        self.name = name
+    }
+
+    /// Takes the assertion if not already held. Idempotent.
+    /// - Returns: true when an assertion is held on return.
+    @discardableResult
+    func hold() -> Bool {
+        guard !isHeld else { return true }
+
+        var identifier = IOPMAssertionID(0)
+        let result = IOPMAssertionCreateWithName(
+            kIOPMAssertPreventUserIdleSystemSleep as CFString,
+            IOPMAssertionLevel(kIOPMAssertionLevelOn),
+            name as CFString,
+            &identifier
+        )
+
+        guard result == kIOReturnSuccess else { return false }
+
+        assertionID = identifier
+        isHeld = true
+        return true
+    }
+
+    /// Releases the assertion if held. Idempotent.
+    /// - Returns: true when no assertion is held on return.
+    @discardableResult
+    func release() -> Bool {
+        guard isHeld else { return true }
+
+        let result = IOPMAssertionRelease(assertionID)
+        assertionID = IOPMAssertionID(0)
+        isHeld = false
+        return result == kIOReturnSuccess
+    }
+
+    func apply(_ decision: KeepAwakeDecision) {
+        if decision.isHolding {
+            hold()
+        } else {
+            release()
+        }
+    }
+
+    deinit {
+        if isHeld {
+            IOPMAssertionRelease(assertionID)
+        }
+    }
+}

--- a/PingIslandTests/KeepAwakePolicyTests.swift
+++ b/PingIslandTests/KeepAwakePolicyTests.swift
@@ -1,0 +1,159 @@
+import XCTest
+@testable import Ping_Island
+
+final class KeepAwakePolicyTests: XCTestCase {
+
+    // MARK: - Modes
+
+    func testOffNeverHolds() {
+        var inputs = KeepAwakeInputs.empty
+        inputs.mode = .off
+        inputs.hasWorkingSession = true
+        XCTAssertEqual(KeepAwakePolicy.decide(for: inputs), .release(.disabled))
+    }
+
+    func testAlwaysHoldsEvenWithNoSessions() {
+        var inputs = KeepAwakeInputs.empty
+        inputs.mode = .always
+        XCTAssertEqual(KeepAwakePolicy.decide(for: inputs), .hold(.alwaysOn))
+    }
+
+    func testAlwaysIgnoresBatteryFloorBecauseItIsAnExplicitChoice() {
+        var inputs = KeepAwakeInputs.empty
+        inputs.mode = .always
+        inputs.isOnBattery = true
+        inputs.batteryPercent = 5
+        XCTAssertEqual(KeepAwakePolicy.decide(for: inputs), .hold(.alwaysOn))
+    }
+
+    // MARK: - Auto
+
+    func testAutoHoldsWhileASessionIsWorking() {
+        var inputs = KeepAwakeInputs.empty
+        inputs.mode = .auto
+        inputs.hasWorkingSession = true
+        XCTAssertEqual(KeepAwakePolicy.decide(for: inputs), .hold(.sessionWorking))
+    }
+
+    func testAutoReleasesWhenNothingIsWorking() {
+        var inputs = KeepAwakeInputs.empty
+        inputs.mode = .auto
+        inputs.hasWorkingSession = false
+        XCTAssertEqual(KeepAwakePolicy.decide(for: inputs), .release(.nothingWorking))
+    }
+
+    /// A session waiting on the user is not working. It will not resume by itself, so
+    /// holding the machine awake for it only costs battery. `hasWorkingSession` is
+    /// driven by `phase.isActive` (.processing/.compacting) rather than by
+    /// `EnergyMode.active`, which also covers `hasAttentionSession`.
+    func testAutoReleasesForSessionsWaitingOnTheUser() {
+        var inputs = KeepAwakeInputs.empty
+        inputs.mode = .auto
+        inputs.hasWorkingSession = false
+        inputs.secondsSinceWorking = KeepAwakePolicy.defaultGraceSeconds + 1
+        XCTAssertEqual(KeepAwakePolicy.decide(for: inputs), .release(.nothingWorking))
+    }
+
+    // MARK: - Grace window
+
+    func testGraceWindowHoldsThroughShortGenerationGaps() {
+        var inputs = KeepAwakeInputs.empty
+        inputs.mode = .auto
+        inputs.hasWorkingSession = false
+        inputs.secondsSinceWorking = 30
+        XCTAssertEqual(KeepAwakePolicy.decide(for: inputs), .hold(.graceWindow))
+    }
+
+    func testGraceWindowExpires() {
+        var inputs = KeepAwakeInputs.empty
+        inputs.mode = .auto
+        inputs.hasWorkingSession = false
+        inputs.secondsSinceWorking = KeepAwakePolicy.defaultGraceSeconds
+        XCTAssertEqual(KeepAwakePolicy.decide(for: inputs), .release(.nothingWorking))
+    }
+
+    func testGraceWindowIsConfigurable() {
+        var inputs = KeepAwakeInputs.empty
+        inputs.mode = .auto
+        inputs.secondsSinceWorking = 30
+        XCTAssertEqual(
+            KeepAwakePolicy.decide(for: inputs, graceSeconds: 10),
+            .release(.nothingWorking)
+        )
+    }
+
+    func testNeverHavingWorkedDoesNotHold() {
+        var inputs = KeepAwakeInputs.empty
+        inputs.mode = .auto
+        inputs.secondsSinceWorking = nil
+        XCTAssertEqual(KeepAwakePolicy.decide(for: inputs), .release(.nothingWorking))
+    }
+
+    // MARK: - Battery floor
+
+    func testAutoReleasesAtOrBelowTheBatteryFloorEvenWhileWorking() {
+        var inputs = KeepAwakeInputs.empty
+        inputs.mode = .auto
+        inputs.hasWorkingSession = true
+        inputs.isOnBattery = true
+        inputs.batteryPercent = KeepAwakePolicy.defaultBatteryFloorPercent
+        XCTAssertEqual(
+            KeepAwakePolicy.decide(for: inputs),
+            .release(.batteryFloor(percent: KeepAwakePolicy.defaultBatteryFloorPercent))
+        )
+    }
+
+    func testAutoHoldsAboveTheBatteryFloor() {
+        var inputs = KeepAwakeInputs.empty
+        inputs.mode = .auto
+        inputs.hasWorkingSession = true
+        inputs.isOnBattery = true
+        inputs.batteryPercent = KeepAwakePolicy.defaultBatteryFloorPercent + 1
+        XCTAssertEqual(KeepAwakePolicy.decide(for: inputs), .hold(.sessionWorking))
+    }
+
+    func testBatteryFloorDoesNotApplyOnACPower() {
+        var inputs = KeepAwakeInputs.empty
+        inputs.mode = .auto
+        inputs.hasWorkingSession = true
+        inputs.isOnBattery = false
+        inputs.batteryPercent = 5
+        XCTAssertEqual(KeepAwakePolicy.decide(for: inputs), .hold(.sessionWorking))
+    }
+
+    func testUnknownBatteryPercentDoesNotBlockHolding() {
+        var inputs = KeepAwakeInputs.empty
+        inputs.mode = .auto
+        inputs.hasWorkingSession = true
+        inputs.isOnBattery = true
+        inputs.batteryPercent = nil
+        XCTAssertEqual(KeepAwakePolicy.decide(for: inputs), .hold(.sessionWorking))
+    }
+
+    // MARK: - Assertion wrapper
+
+    func testSleepAssertionHoldAndReleaseAreIdempotent() {
+        let assertion = SleepAssertion(name: "PingIsland unit test")
+        XCTAssertFalse(assertion.isHeld)
+
+        XCTAssertTrue(assertion.hold())
+        XCTAssertTrue(assertion.isHeld)
+        XCTAssertTrue(assertion.hold(), "holding twice should be a no-op")
+        XCTAssertTrue(assertion.isHeld)
+
+        XCTAssertTrue(assertion.release())
+        XCTAssertFalse(assertion.isHeld)
+        XCTAssertTrue(assertion.release(), "releasing twice should be a no-op")
+        XCTAssertFalse(assertion.isHeld)
+    }
+
+    func testSleepAssertionFollowsDecision() {
+        let assertion = SleepAssertion(name: "PingIsland unit test")
+
+        assertion.apply(.hold(.sessionWorking))
+        XCTAssertTrue(assertion.isHeld)
+
+        assertion.apply(.release(.nothingWorking))
+        XCTAssertFalse(assertion.isHeld)
+    }
+}


### PR DESCRIPTION
Closes #306.

Keeps the Mac awake while an agent session is actually working, and lets it sleep normally the moment nothing is. Off by default.

### Why not just a toggle

A manual button is `caffeinate` with a nicer surface, and it fails in the case you'd want it for: you start a long run, walk away, and either forgot to enable it or leave it on all night. The value is in it being automatic, and Ping Island already knows which sessions are working, so the missing piece is small.

Three modes, so the manual behaviour is still available:

- `.off` (default) - never assert, current behaviour
- `.auto` - assert while a session is working
- `.always` - assert unconditionally, the `caffeinate` equivalent

### Design notes

**Holds on `phase.isActive` (`.processing` / `.compacting`), not on `EnergyMode.active`.** `resolvedMode` resolves `.active` from `hasActiveSession || hasAttentionSession`, and the attention branch is exactly the case that must release: a session parked on `.waitingForInput` or `.waitingForApproval` won't resume on its own, so holding for it just costs battery until the user comes back and wakes the machine anyway.

**System assertion only, never display.** `kIOPMAssertPreventUserIdleSystemSleep`. A background agent has nothing to show, and the display assertion is the larger battery cost.

**Grace window (120s).** Without one the assertion flaps once per model-generation gap, because the pause between one tool finishing and the next starting is indistinguishable from idle. On an equivalent Windows implementation, no grace window produced 4 acquire/release cycles in 3 minutes.

**Battery floor (35%), `.auto` only.** An unattended overnight run can otherwise flatten the machine and lose the work the assertion was protecting. `.always` ignores the floor, since it's an explicit choice.

The decision itself is a pure function in `KeepAwakePolicy`, in the same spirit as `EnergyGovernor.resolvedMode`, so it's testable without IOKit, timers, or a running app. `KeepAwakeController` only gathers inputs and applies the result.

### Tests

15 cases in `PingIslandTests/KeepAwakePolicyTests.swift`: the three modes, the grace window boundary, the battery floor including the AC and unknown-percent paths, and idempotent hold/release on the assertion wrapper.

### What I have not verified

I'm on Windows, so I can't check the one thing that ultimately matters: that the machine actually refrains from sleeping. CI covers compilation and the policy tests on macOS 15, and the assertion should be visible by name in `pmset -g assertions` while held, but the end-to-end behaviour needs someone on real hardware with a real idle timer. A remote session won't do it either, since SSH and Screen Sharing hold their own assertions.

Worth confirming on hardware before merge:

1. `pmset -g assertions` lists `PreventUserIdleSystemSleep` from PingIsland while a session is processing
2. it disappears within ~120s of the last session going idle
3. the display still sleeps on its normal schedule while it's held

### Not included

No UI yet. You suggested a button next to the temporary mute control, which makes sense, but I'd rather not guess at the visual language for a tri-state control. Happy to add it here, or leave it to you, whichever you prefer. The setting is persisted and functional in the meantime.

Lid close is out of scope: no user-space assertion prevents it on any OS. Might be worth a line in the docs.
