### PR TITLE
fix(sound): check per-event sound enabled guard in playAuxiliarySound

### DIFF
--- a/PingIsland/Core/Settings.swift
+++ b/PingIsland/Core/Settings.swift
@@ -2070,6 +2070,9 @@ enum AppSettings {
         island8BitSound: Island8BitSound,
         soundPackFallback: NotificationEvent
     ) {
+        guard soundEnabled, isSoundEnabled(for: soundPackFallback) else { return }
+        guard !areReminderNotificationsSuppressed else { return }
+
         switch soundThemeMode {
         case .builtIn:
             playSound(named: systemSound.soundName)


### PR DESCRIPTION
## 问题

在 `playAuxiliarySound` 中，builtIn 和 island8Bit 模式下缺少 per-event 声音开关检查（`isSoundEnabled(for:)`），只有 soundPack 模式有检查。这导致三类模式的 behavior 不一致。

## 修复

在 `playAuxiliarySound` 开头添加统一的 guard：

```swift
guard soundEnabled, isSoundEnabled(for: soundPackFallback) else { return }
guard !areReminderNotificationsSuppressed else { return }
```

## 测试

- 编译通过
- 1005 个单元测试全部通过
- 含 SoundThemeConfigurationTests、SemanticSoundFeedbackTests 等

## 影响

对于走通知路径的 `processingStarted` 事件不受影响。此修复确保辅助路径事件在三种模式下都能正确响应 per-event 开关。