### PR TITLE
fix(hooks): keep the live socket path when a superseded instance stops

### DIFF
--- a/PingIsland/Services/Hooks/HookSocketServer.swift
+++ b/PingIsland/Services/Hooks/HookSocketServer.swift
@@ -1565,6 +1565,11 @@ class HookSocketServer {
     private var permissionFailureHandler: PermissionFailureHandler?
     private let queue = DispatchQueue(label: "com.wudanwu.pingisland.socket", qos: .userInitiated)
 
+    /// Identity of the socket file this instance bound. A relaunched instance claims the
+    /// shared path by unlinking whatever is already there, so a superseded instance must
+    /// never remove a path that the newer one owns by now.
+    private var boundSocketIdentity: SocketFileIdentity?
+
     private var pendingPermissions: [String: [PendingPermission]] = [:]
     private let permissionsLock = NSLock()
     private var recentInterventionResponses = RecentInterventionResponseStore()
@@ -1646,6 +1651,7 @@ class HookSocketServer {
 
         BridgeRuntimePaths.prepareRuntimeDirectory()
         unlink(Self.socketPath)
+        boundSocketIdentity = nil
 
         serverSocket = socket(AF_UNIX, SOCK_STREAM, 0)
         guard serverSocket >= 0 else {
@@ -1684,6 +1690,8 @@ class HookSocketServer {
             return
         }
 
+        boundSocketIdentity = SocketFileIdentity.current(path: socketPath)
+
         chmod(Self.socketPath, 0o777)
 
         guard listen(serverSocket, 10) == 0 else {
@@ -1711,7 +1719,9 @@ class HookSocketServer {
     func stop() {
         acceptSource?.cancel()
         acceptSource = nil
-        unlink(Self.socketPath)
+        queue.async { [weak self] in
+            self?.removeBoundSocketPath()
+        }
 
         permissionsLock.lock()
         for (_, pendings) in pendingPermissions {
@@ -1721,6 +1731,32 @@ class HookSocketServer {
         }
         pendingPermissions.removeAll()
         permissionsLock.unlock()
+    }
+
+    /// Remove the shared socket path only while it still resolves to the socket this
+    /// instance bound. When another instance has already claimed the path, deleting it
+    /// would leave that instance listening on an unlinked socket: every later bridge
+    /// delivery fails with `connection_failed` and the island silently stops updating.
+    private func removeBoundSocketPath() {
+        defer { boundSocketIdentity = nil }
+        guard let boundSocketIdentity,
+              SocketFileIdentity.current(path: Self.socketPath) == boundSocketIdentity else {
+            return
+        }
+
+        unlink(Self.socketPath)
+    }
+
+    /// Device + inode of a socket file, so ownership survives path reuse by another instance.
+    struct SocketFileIdentity: Equatable {
+        let device: dev_t
+        let inode: ino_t
+
+        static func current(path: String) -> SocketFileIdentity? {
+            var info = stat()
+            guard lstat(path, &info) == 0 else { return nil }
+            return SocketFileIdentity(device: info.st_dev, inode: info.st_ino)
+        }
     }
 
     func respondToPermission(toolUseId: String, decision: String, reason: String? = nil) {

--- a/Prototype/Sources/IslandApp/Core/SocketServer.swift
+++ b/Prototype/Sources/IslandApp/Core/SocketServer.swift
@@ -11,6 +11,11 @@ actor SocketServer {
     private var listenerFD: Int32 = -1
     private var acceptTask: Task<Void, Never>?
 
+    /// Identity of the socket file this server bound. A relaunched instance claims the
+    /// shared path by unlinking whatever is already there, so a superseded instance must
+    /// never remove a path that the newer one owns by now.
+    private var boundSocketIdentity: SocketFileIdentity?
+
     init(socketPath: String, sessionStore: SessionStore, approvalCoordinator: ApprovalCoordinator) {
         self.socketPath = socketPath
         self.sessionStore = sessionStore
@@ -21,6 +26,7 @@ actor SocketServer {
         await stop()
 
         unlink(socketPath)
+        boundSocketIdentity = nil
 
         listenerFD = socket(AF_UNIX, SOCK_STREAM, 0)
         guard listenerFD >= 0 else {
@@ -47,6 +53,8 @@ actor SocketServer {
         guard bindResult == 0 else {
             throw POSIXError(.EADDRINUSE)
         }
+
+        boundSocketIdentity = SocketFileIdentity.current(path: socketPath)
 
         guard listen(listenerFD, 16) == 0 else {
             throw POSIXError(.EIO)
@@ -92,7 +100,33 @@ actor SocketServer {
         if let task {
             await task.value
         }
+        removeBoundSocketPath()
+    }
+
+    /// Remove the shared socket path only while it still resolves to the socket this
+    /// server bound. When another instance has already claimed the path, deleting it
+    /// would leave that instance listening on an unlinked socket: every later bridge
+    /// delivery fails with `connection_failed` and the island silently stops updating.
+    private func removeBoundSocketPath() {
+        defer { boundSocketIdentity = nil }
+        guard let boundSocketIdentity,
+              SocketFileIdentity.current(path: socketPath) == boundSocketIdentity else {
+            return
+        }
+
         unlink(socketPath)
+    }
+
+    /// Device + inode of a socket file, so ownership survives path reuse by another instance.
+    private struct SocketFileIdentity: Equatable {
+        let device: dev_t
+        let inode: ino_t
+
+        static func current(path: String) -> SocketFileIdentity? {
+            var info = stat()
+            guard lstat(path, &info) == 0 else { return nil }
+            return SocketFileIdentity(device: info.st_dev, inode: info.st_ino)
+        }
     }
 
     private func handle(clientFD: Int32) async {

--- a/Prototype/Tests/IslandTests/SocketServerTests.swift
+++ b/Prototype/Tests/IslandTests/SocketServerTests.swift
@@ -43,6 +43,57 @@ func socketServerPersistsStateOnlyEnvelopes() async throws {
     }
 }
 
+/// Relaunch overlap: a newer instance claims the shared socket path by unlinking whatever
+/// is already there, and the previous instance then exits. Its `stop()` used to unlink that
+/// path unconditionally, which left the live instance listening on an unlinked socket, so
+/// every later bridge delivery failed with `connection_failed` until the app was relaunched.
+@Test
+func supersededSocketServerStopKeepsTheLiveSocketPath() async throws {
+    try await withTemporaryDirectory { directory in
+        let socketPath = directory.appending(path: "island.sock").path()
+        let store = SessionStore { _ in }
+        let coordinator = ApprovalCoordinator()
+
+        let superseded = SocketServer(
+            socketPath: socketPath,
+            sessionStore: store,
+            approvalCoordinator: coordinator
+        )
+        try await superseded.start()
+
+        let live = SocketServer(
+            socketPath: socketPath,
+            sessionStore: store,
+            approvalCoordinator: coordinator
+        )
+        try await live.start()
+
+        await superseded.stop()
+
+        #expect(FileManager.default.fileExists(atPath: socketPath))
+
+        let envelope = BridgeEnvelope(
+            id: UUID(),
+            provider: .claude,
+            eventType: "PostToolUse",
+            sessionKey: "claude:socket-ownership",
+            title: "Socket Ownership",
+            preview: "Superseded server stopped",
+            cwd: "/tmp/socket-ownership",
+            status: SessionStatus(kind: .active)
+        )
+
+        let response = try TestSocketClient.send(envelope: envelope, socketPath: socketPath)
+
+        #expect(response.requestID == envelope.id)
+        #expect(response.errorMessage == nil)
+
+        await live.stop()
+
+        #expect(!FileManager.default.fileExists(atPath: socketPath))
+    }
+}
+
 @Test
 func socketServerReturnsApprovalDecisionForInteractiveEnvelopes() async throws {
     try await withTemporaryDirectory { directory in


### PR DESCRIPTION
## 问题

`HookSocketServer.stop()` 无条件 `unlink` 共享 socket 路径，而 `startServer()` 抢占该路径的方式是先 `unlink` 再 `bind`。重装/自动更新导致两个实例短暂并存时，先启动的实例退出（`applicationWillTerminate` → `SessionMonitor.stopMonitoring()` → `HookSocketServer.shared.stop()`）会删掉**已接管该路径的新实例**的 socket 文件。

新实例此后仍持有已被 unlink 的监听 fd：`lsof` 里 fd 指向 `/tmp/island.sock`，但路径在文件系统上不存在，之后所有连接一律 `ENOENT`。bridge 每次投递都返回 `deliveryOutcome: connection_failed` 并静默退出 0，灵动岛从此冻结在最后注册过的会话上，新会话永远不出现（app 只监视已注册会话的 transcript，无法靠文件发现新会话）。

完整现场分析、时间线与复现步骤见 #313。

## 改动

- `PingIsland/Services/Hooks/HookSocketServer.swift`：`bind` 成功后记录 socket 文件的 `(st_dev, st_ino)`，`stop()` 只在路径仍然解析到该 socket 时才 `unlink`。身份的读写都保持在既有的 socket `queue` 上，没有引入新的线程假设；`startServer()` 抢占路径的行为保持不变（takeover 是有意的），只是被取代的实例退出时不再误删。
- `Prototype/Sources/IslandApp/Core/SocketServer.swift`：同一份逻辑加同样的守卫。
- `Prototype/Tests/IslandTests/SocketServerTests.swift`：新增 `supersededSocketServerStopKeepsTheLiveSocketPath` —— 构造「新实例接管路径 → 旧实例 stop()」的重叠场景，断言路径仍存在、live 实例仍能收到 envelope，并确认真正的 owner 在 stop() 时仍会清理路径。

## 验证

- `swift build --package-path Prototype`：通过（`IslandApp` 强制重新编译 `SocketServer.swift`，无警告）。
- 新增的回归测试**未能在本地运行**：这台机器只装了 CommandLineTools，工具链里没有 `Testing` 模块（`ApprovalCoordinatorTests.swift:4: error: no such module 'Testing'`，既有环境问题），整个 `IslandTests` target 本地编译不了，请以 CI 的 `swift test --package-path Prototype` 结果为准。如果需要，我可以把它挪到 CI 会跑的切分里。
- 本机 APFS 上用独立 harness 验证了修复依赖的三个前提：重新 `bind` 得到不同的 inode（6407305 → 6407306）；路径被 takeover 后不再解析到旧 socket；无条件 `unlink` 会让 live 实例彻底不可达（即报告中的故障形态）。
- 本机无 Xcode，`PingIsland` target 的编译同样只能由 CI 验证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
